### PR TITLE
changed the poller to cache the building boolean instead of the status, ...

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsCache.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsCache.groovy
@@ -62,17 +62,17 @@ class JenkinsCache {
         Map result = resource.hgetAll(makeKey(master, job))
         Map convertedResult = [
             lastBuildLabel: Integer.parseInt(result.lastBuildLabel),
-            lastBuildStatus: result.lastBuildStatus
+            lastBuildBuilding: Boolean.parseBoolean(result.lastBuildBuilding)
         ]
         jedisPool.returnResource(resource)
         convertedResult
     }
 
-    void setLastBuild(String master, String job, int lastBuild, String status) {
+    void setLastBuild(String master, String job, int lastBuild, boolean building) {
         Jedis resource = jedisPool.resource
         String key = makeKey(master, job)
         resource.hset(key, 'lastBuildLabel', lastBuild as String)
-        resource.hset(key, 'lastBuildStatus', status)
+        resource.hset(key, 'lastBuildBuilding', building as String)
         jedisPool.returnResource(resource)
     }
 

--- a/src/test/groovy/com/netflix/spinnaker/igor/jenkins/BuildMonitorSpec.groovy
+++ b/src/test/groovy/com/netflix/spinnaker/igor/jenkins/BuildMonitorSpec.groovy
@@ -49,7 +49,7 @@ class BuildMonitorSpec extends Specification {
 
         then:
         0 * cache.getLastBuild(MASTER, 'job1')
-        1 * cache.setLastBuild(MASTER, 'job2', 1, "")
+        1 * cache.setLastBuild(MASTER, 'job2', 1, false)
         builds.size() == 1
         builds[0].current.name == 'job2'
         builds[0].current.lastBuild.number == 1
@@ -66,7 +66,7 @@ class BuildMonitorSpec extends Specification {
 
         then:
         1 * cache.getLastBuild(MASTER, 'job2') >> [lastBuildLabel: 3]
-        1 * cache.setLastBuild(MASTER, 'job2', 5, "")
+        1 * cache.setLastBuild(MASTER, 'job2', 5, false)
         builds[0].current.lastBuild.number == 5
         builds[0].previous.lastBuildLabel == 3
     }
@@ -75,19 +75,19 @@ class BuildMonitorSpec extends Specification {
         given:
         1 * cache.getJobNames(MASTER) >> ['job3']
         1 * client.projects >> new ProjectsList(
-            list: [new Project(name: 'job3', lastBuild : new Build(number: 5, result: 'FAILED'))]
+            list: [new Project(name: 'job3', lastBuild : new Build(number: 5, building: false))]
         )
 
         when:
         List<Map> builds = monitor.changedBuilds(MASTER)
 
         then:
-        1 * cache.getLastBuild(MASTER, 'job3') >> [lastBuildLabel: 5, lastBuildStatus: 'RUNNING']
-        1 * cache.setLastBuild(MASTER, 'job3', 5, 'FAILED')
+        1 * cache.getLastBuild(MASTER, 'job3') >> [lastBuildLabel: 5, lastBuildRunning: true]
+        1 * cache.setLastBuild(MASTER, 'job3', 5, false)
         builds[0].current.lastBuild.number == 5
         builds[0].previous.lastBuildLabel == 5
-        builds[0].current.lastBuild.result == 'FAILED'
-        builds[0].previous.lastBuildStatus == 'RUNNING'
+        builds[0].current.lastBuild.building == false
+        builds[0].previous.lastBuildRunning == true
     }
 
     void 'stale builds are removed'() {

--- a/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsCacheSpec.groovy
+++ b/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsCacheSpec.groovy
@@ -58,13 +58,13 @@ class JenkinsCacheSpec extends Specification {
 
     void 'new build numbers get overridden'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, 'running')
+        cache.setLastBuild(master, 'job1', 78, true)
 
         then:
         cache.getLastBuild(master, 'job1').lastBuildLabel == 78
 
         when:
-        cache.setLastBuild(master, 'job1', 80, 'running')
+        cache.setLastBuild(master, 'job1', 80, false)
 
         then:
         cache.getLastBuild(master, 'job1').lastBuildLabel == 80
@@ -72,16 +72,16 @@ class JenkinsCacheSpec extends Specification {
 
     void 'statuses get overridden'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, 'running')
+        cache.setLastBuild(master, 'job1', 78, true)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildStatus == 'running'
+        cache.getLastBuild(master, 'job1').lastBuildBuilding == true
 
         when:
-        cache.setLastBuild(master, 'job1', 78, 'failed')
+        cache.setLastBuild(master, 'job1', 78, false)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildStatus == 'failed'
+        cache.getLastBuild(master, 'job1').lastBuildBuilding == false
 
     }
 
@@ -92,8 +92,8 @@ class JenkinsCacheSpec extends Specification {
 
     void 'can set builds for multiple masters'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, 'success')
-        cache.setLastBuild('example2', 'job1', 88, 'success')
+        cache.setLastBuild(master, 'job1', 78, true)
+        cache.setLastBuild('example2', 'job1', 88, true)
 
         then:
         cache.getLastBuild(master, 'job1').lastBuildLabel == 78
@@ -102,9 +102,9 @@ class JenkinsCacheSpec extends Specification {
 
     void 'correctly retrieves all jobsNames for a master'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, 'success')
-        cache.setLastBuild(master, 'job2', 11, 'fail')
-        cache.setLastBuild(master, 'blurb', 1, 'running')
+        cache.setLastBuild(master, 'job1', 78, true)
+        cache.setLastBuild(master, 'job2', 11, false)
+        cache.setLastBuild(master, 'blurb', 1, false)
 
         then:
         cache.getJobNames(master) == ['blurb', 'job1', 'job2']
@@ -112,7 +112,7 @@ class JenkinsCacheSpec extends Specification {
 
     void 'can remove details for a build'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, 'success')
+        cache.setLastBuild(master, 'job1', 78, true)
         cache.remove(master, 'job1')
 
         then:
@@ -122,10 +122,10 @@ class JenkinsCacheSpec extends Specification {
     @Unroll
     void 'retrieves all matching jobs for typeahead #query'() {
         when:
-        cache.setLastBuild(master, 'job1', 1, 'success')
-        cache.setLastBuild(test, 'job1', 1, 'fail')
-        cache.setLastBuild(master, 'job2', 1, 'fail')
-        cache.setLastBuild(test, 'job3', 1, 'fail')
+        cache.setLastBuild(master, 'job1', 1, true)
+        cache.setLastBuild(test, 'job1', 1, false)
+        cache.setLastBuild(master, 'job2', 1, false)
+        cache.setLastBuild(test, 'job3', 1, false)
 
         then:
         cache.getTypeaheadResults(query) == expected
@@ -144,7 +144,7 @@ class JenkinsCacheSpec extends Specification {
         when:
         JenkinsCache secondInstance = new JenkinsCache(jedisPool: jedisPool)
         secondInstance.prefix = 'newPrefix'
-        secondInstance.setLastBuild(master, 'job1', 1, 'success')
+        secondInstance.setLastBuild(master, 'job1', 1, false)
 
         then:
         secondInstance.getJobNames(master) == ['job1']


### PR DESCRIPTION
...which didnt work for all use cases

In Jenkins a build can have a status == "SUCCESS" and building == true.  This is the state where the build command is complete, but the post-build tasks are still running.  I took status out of the equation and now proper single running and completed events are posted from igor to echo.
