### PR TITLE
added a case for a building a parameterized job using only the default vals

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/igor/jenkins/BuildController.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/igor/jenkins/BuildController.groovy
@@ -110,10 +110,13 @@ class BuildController {
 
             if(requestParams && jobConfig.parameterDefinitionList?.size() > 0) {
                 response = client.buildWithParameters(job, requestParams)
+            } else if(!requestParams && jobConfig.parameterDefinitionList?.size() > 0) {
+                // account for when you just want to fire a job with the default parameter values by adding a dummy param
+                response = client.buildWithParameters(job, ['startedBy' : "igor"])
             } else if(!requestParams && (!jobConfig.parameterDefinitionList || jobConfig.parameterDefinitionList.size() == 0)){
-                response = client.build(job, requestParams)
+                response = client.build(job)
             } else { // Jenkins will reject the build, so don't even try
-                log.error("job : ${job}, either not passing params to a build job which needs them or passing params to a job which doesn't need them")
+                log.error("job : ${job}, passing params to a job which doesn't need them")
                 // we should throw a BuildJobError, but I get a bytecode error : java.lang.VerifyError: Bad <init> method call from inside of a branch
                 throw new RuntimeException()
             }

--- a/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -53,7 +53,7 @@ interface JenkinsClient {
     QueuedJob getQueuedItem(@Path('itemNumber') Integer item)
 
     @POST('/job/{jobName}/build')
-    Response build(@Path('jobName') String jobName, @QueryMap Map<String,String> queryParams)
+    Response build(@Path('jobName') String jobName)
 
     @POST('/job/{jobName}/buildWithParameters')
     Response buildWithParameters(@Path('jobName') String jobName, @QueryMap Map<String,String> queryParams)

--- a/src/test/groovy/com/netflix/spinnaker/igor/jenkins/BuildControllerSpec.groovy
+++ b/src/test/groovy/com/netflix/spinnaker/igor/jenkins/BuildControllerSpec.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.jenkins
+
+import com.netflix.spinnaker.igor.jenkins.client.JenkinsClient
+import com.netflix.spinnaker.igor.jenkins.client.JenkinsMasters
+import com.netflix.spinnaker.igor.jenkins.client.model.Build
+import com.netflix.spinnaker.igor.jenkins.client.model.JobConfig
+import com.netflix.spinnaker.igor.jenkins.client.model.ParameterDefinition
+import retrofit.client.Header
+import retrofit.client.Response
+import spock.lang.Specification
+
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+
+/**
+ * Tests for BuildController
+ */
+@SuppressWarnings(['DuplicateNumberLiteral', 'PropertyName'])
+class BuildControllerSpec extends Specification {
+
+    JenkinsCache cache = Mock(JenkinsCache)
+    JenkinsClient client = Mock(JenkinsClient)
+    BuildController controller
+
+    final MASTER = 'MASTER'
+    final HTTP_201 = 201
+    final BUILD_NUMBER = 123
+    final QUEUED_JOB_NUMBER = 123456
+    final JOB_NAME = "job1"
+
+    void setup() {
+        controller = new BuildController(executor: Executors.newSingleThreadExecutor(), masters: new JenkinsMasters(map: [MASTER: client]))
+    }
+
+    void 'trigger a build without parameters'() {
+        given:
+        1 * client.getJobConfig(JOB_NAME) >> new JobConfig()
+        1 * client.getBuild(JOB_NAME,BUILD_NUMBER) >> new Build(number: BUILD_NUMBER)
+        1 * client.getQueuedItem(QUEUED_JOB_NUMBER) >> [number : BUILD_NUMBER]
+        1 * client.build(JOB_NAME) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${QUEUED_JOB_NUMBER}")], null)
+
+        when:
+        Build build = controller.build(MASTER,JOB_NAME,null)
+
+        then:
+        build.number == BUILD_NUMBER
+    }
+
+    void 'trigger a build with parameters to a job with parameters'() {
+        given:
+        1 * client.getJobConfig(JOB_NAME) >> new JobConfig(parameterDefinitionList: [new ParameterDefinition(defaultName: "name", defaultValue: null, description: "description")])
+        1 * client.getBuild(JOB_NAME,BUILD_NUMBER) >> new Build(number: BUILD_NUMBER)
+        1 * client.getQueuedItem(QUEUED_JOB_NUMBER) >> [number : BUILD_NUMBER]
+        1 * client.buildWithParameters(JOB_NAME,[name:"myName"]) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${QUEUED_JOB_NUMBER}")], null)
+
+        when:
+        Build build = controller.build(MASTER, JOB_NAME, [name:"myName"])
+
+        then:
+        build.number == BUILD_NUMBER
+    }
+
+    void 'trigger a build without parameters to a job with parameters with default values'() {
+        given:
+        1 * client.getJobConfig(JOB_NAME) >> new JobConfig(parameterDefinitionList: [new ParameterDefinition(defaultName: "name", defaultValue: "value", description: "description")])
+        1 * client.getBuild(JOB_NAME,BUILD_NUMBER) >> new Build(number: BUILD_NUMBER)
+        1 * client.getQueuedItem(QUEUED_JOB_NUMBER) >> [number : BUILD_NUMBER]
+        1 * client.buildWithParameters(JOB_NAME, ['startedBy' : "igor"]) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${QUEUED_JOB_NUMBER}")], null)
+
+        when:
+        Build build = controller.build(MASTER, JOB_NAME, null)
+
+        then:
+        build.number == BUILD_NUMBER
+    }
+
+    void 'trigger a build with parameters to a job without parameters'() {
+        given:
+        1 * client.getJobConfig(JOB_NAME) >> new JobConfig()
+
+        when:
+        controller.build(MASTER, JOB_NAME, [foo:"bar"])
+
+        then:
+        thrown(ExecutionException)
+    }
+}

--- a/src/test/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClientSpec.groovy
+++ b/src/test/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClientSpec.groovy
@@ -192,7 +192,7 @@ class JenkinsClientSpec extends Specification {
         setResponse("")
         
         when:
-        def response = client.build("My-Build", null)
+        def response = client.build("My-Build")
 
         then:
         response
@@ -204,7 +204,7 @@ class JenkinsClientSpec extends Specification {
         setResponse("")
 
         when:
-        def response = client.build("My-Build", [foo:"bar", key:"value"])
+        def response = client.buildWithParameters("My-Build", [foo:"bar", key:"value"])
 
         then:
         response


### PR DESCRIPTION
also cleaned up the JenkinsClient.build method since it will never take a map of params
