### PR TITLE
Load properties straight into Spring Boot

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/Main.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/Main.groovy
@@ -16,14 +16,12 @@
 
 package com.netflix.spinnaker.igor
 
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.web.SpringBootServletInitializer
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-
 /**
  * Application entry point.
  */
@@ -41,22 +39,12 @@ class Main extends SpringBootServletInitializer {
         'spring.profiles.active': "${System.getProperty('netflix.environment', 'test')},local"
     ]
 
-    static {
-        applyDefaults()
-    }
-
-    static void applyDefaults() {
-        DEFAULT_PROPS.each { k, v ->
-            System.setProperty(k, System.getProperty(k, v))
-        }
-    }
-
     static void main(String... args) {
-        SpringApplication.run this, args
+        new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Main).run(args)
     }
 
     @Override
     SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-        application.sources Main
+        application.properties(DEFAULT_PROPS).sources(Main)
     }
 }


### PR DESCRIPTION
The current mechanism of writing default propeties straight into the environment breaks the Spring property lifecycle, making it impossible to override certain settings. This path does what's intended, load the default properties into the Spring Boot application builder while still allowing overrides.
