### PR TITLE
Capture Jenkins job names correctly when the folder plugin is being used

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.igor.jenkins.client.model.ProjectsList
 import com.netflix.spinnaker.igor.jenkins.client.model.QueuedJob
 import com.netflix.spinnaker.igor.jenkins.client.model.ScmDetails
 import retrofit.client.Response
+import retrofit.http.EncodedPath
 import retrofit.http.GET
 import retrofit.http.POST
 import retrofit.http.Path
@@ -36,44 +37,48 @@ import retrofit.http.Streaming
  */
 @SuppressWarnings('LineLength')
 interface JenkinsClient {
+    /*
+     * Jobs created with the Jenkins Folders plugin are nested.
+     * Some queries look for jobs within folders with a depth of 10.
+     */
 
-    @GET('/api/xml?tree=jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url]]&exclude=/*/*/*/action[not(totalCount)]')
+    @GET('/api/xml?tree=jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url]]]]]]]]]]]&exclude=/*/*/*/action[not(totalCount)]')
     ProjectsList getProjects()
 
-    @GET('/api/xml?tree=jobs[name]')
+    @GET('/api/xml?tree=jobs[name,jobs[name,jobs[name,jobs[name,jobs[name,jobs[name,jobs[name,jobs[name,jobs[name,jobs[name]]]]]]]]]]')
     JobList getJobs()
 
     @GET('/job/{jobName}/api/xml?exclude=/*/build/action[not(totalCount)]&tree=builds[number,url,duration,timestamp,result,building,url,fullDisplayName,actions[failCount,skipCount,totalCount]]')
-    BuildsList getBuilds(@Path('jobName') String jobName)
+    BuildsList getBuilds(@EncodedPath('jobName') String jobName)
 
     @GET('/job/{jobName}/api/xml?tree=name,url,actions[processes[name]],downstreamProjects[name,url],upstreamProjects[name,url]')
-    BuildDependencies getDependencies(@Path('jobName') String jobName)
+    BuildDependencies getDependencies(@EncodedPath('jobName') String jobName)
 
     @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(totalCount)]&tree=actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url,fullDisplayName,artifacts[displayPath,fileName,relativePath]')
-    Build getBuild(@Path('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
+    Build getBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
 
     @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(lastBuiltRevision)]&tree=actions[remoteUrl,lastBuiltRevision[branch[name,SHA1]]]')
-    ScmDetails getGitDetails(@Path('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
+    ScmDetails getGitDetails(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
 
     @GET('/job/{jobName}/lastCompletedBuild/api/xml')
-    Build getLatestBuild(@Path('jobName') String jobName)
+    Build getLatestBuild(@EncodedPath('jobName') String jobName)
 
     @GET('/queue/item/{itemNumber}/api/xml')
     QueuedJob getQueuedItem(@Path('itemNumber') Integer item)
 
     @POST('/job/{jobName}/build')
-    Response build(@Path('jobName') String jobName)
+    Response build(@EncodedPath('jobName') String jobName)
 
     @POST('/job/{jobName}/buildWithParameters')
-    Response buildWithParameters(@Path('jobName') String jobName, @QueryMap Map<String, String> queryParams)
+    Response buildWithParameters(@EncodedPath('jobName') String jobName, @QueryMap Map<String, String> queryParams)
 
     @GET('/job/{jobName}/api/xml?exclude=/*/action&exclude=/*/build&exclude=/*/property[not(parameterDefinition)]')
-    JobConfig getJobConfig(@Path('jobName') String jobName)
+    JobConfig getJobConfig(@EncodedPath('jobName') String jobName)
 
     @Streaming
     @GET('/job/{jobName}/{buildNumber}/artifact/{fileName}')
     Response getPropertyFile(
-        @Path('jobName') String jobName,
+        @EncodedPath('jobName') String jobName,
         @Path('buildNumber') Integer buildNumber, @Path(value = 'fileName', encode = false) String fileName)
 
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/Project.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/Project.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.jenkins.client.model
 import groovy.transform.CompileStatic
 import org.simpleframework.xml.Attribute
 import org.simpleframework.xml.Element
+import org.simpleframework.xml.ElementList
 import org.simpleframework.xml.Root
 
 /**
@@ -27,6 +28,9 @@ import org.simpleframework.xml.Root
 @CompileStatic
 @Root(name='job')
 class Project {
+    @ElementList(inline = true, name = "job", required=false)
+    List<Project> list
+
     @Element String name
     @Element(required = false)
     Build lastBuild

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/JobList.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/JobList.groovy
@@ -34,6 +34,9 @@ class JobList {
 }
 
 class Job {
+    @ElementList(inline = true, name = "job", required=false)
+    List<Job> list
+
     @Element(required = false)
     String name
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/BuildControllerSpec.groovy
@@ -16,13 +16,30 @@
 
 package com.netflix.spinnaker.igor.jenkins
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.igor.jenkins.client.JenkinsClient
 import com.netflix.spinnaker.igor.jenkins.client.JenkinsMasters
+import com.netflix.spinnaker.igor.jenkins.client.model.Build
+import com.netflix.spinnaker.igor.jenkins.client.model.BuildArtifact
+import com.netflix.spinnaker.igor.jenkins.client.model.BuildsList
 import com.netflix.spinnaker.igor.jenkins.client.model.JobConfig
 import com.netflix.spinnaker.igor.jenkins.client.model.ParameterDefinition
+import com.netflix.spinnaker.igor.jenkins.client.model.ParameterDefinition
+import com.netflix.spinnaker.igor.jenkins.client.model.QueuedJob
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
+import com.squareup.okhttp.mockwebserver.MockResponse
+import com.squareup.okhttp.mockwebserver.MockWebServer
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.util.NestedServletException
 import retrofit.client.Header
 import retrofit.client.Response
+import spock.lang.Shared
 import spock.lang.Specification
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 
 import java.util.concurrent.Executors
 
@@ -32,56 +49,134 @@ import java.util.concurrent.Executors
 @SuppressWarnings(['DuplicateNumberLiteral', 'PropertyName'])
 class BuildControllerSpec extends Specification {
 
-    JenkinsCache cache = Mock(JenkinsCache)
-    JenkinsService jenkinsService = Mock(JenkinsService)
-    BuildController controller
+    MockMvc mockMvc
+    JenkinsMasters masters
+    JenkinsCache cache
+    JenkinsClient client
+
+    @Shared
+    MockWebServer server
 
     final MASTER = 'MASTER'
     final HTTP_201 = 201
     final BUILD_NUMBER = 123
     final QUEUED_JOB_NUMBER = 123456
-    final JOB_NAME = "job1"
+    final JOB_NAME = "job/name/can/have/slashes"
+    final FILE_NAME = "test.yml"
+
+    void cleanup() {
+        server.shutdown()
+    }
 
     void setup() {
-        controller = new BuildController(executor: Executors.newSingleThreadExecutor(), masters: new JenkinsMasters(map: [MASTER: jenkinsService]))
+        client = Mock(JenkinsClient)
+        cache = Mock(JenkinsCache)
+        masters = new JenkinsMasters(map: [MASTER: client])
+        server = new MockWebServer()
+        mockMvc = MockMvcBuilders.standaloneSetup(new BuildController(
+            executor: Executors.newSingleThreadExecutor(), masters: masters, objectMapper: new ObjectMapper())).build()
+    }
+
+    void 'get the status of a build'() {
+        given:
+        1 * client.getBuild(JOB_NAME, BUILD_NUMBER) >> new Build(number: BUILD_NUMBER)
+
+        when:
+        MockHttpServletResponse response = mockMvc.perform(get("/builds/status/${BUILD_NUMBER}/${MASTER}/${JOB_NAME}")
+            .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+        then:
+        response.contentAsString == "{\"building\":false,\"number\":${BUILD_NUMBER}}"
+    }
+
+    void 'get an item from the queue'() {
+        given:
+        1 * client.getQueuedItem(QUEUED_JOB_NUMBER) >> new QueuedJob(number: QUEUED_JOB_NUMBER)
+
+        when:
+        MockHttpServletResponse response = mockMvc.perform(get("/builds/queue/${MASTER}/${QUEUED_JOB_NUMBER}")
+            .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+        then:
+        response.contentAsString == "{\"number\":${QUEUED_JOB_NUMBER}}"
+    }
+
+    void 'get a list of builds for a job'() {
+        given:
+        1 * client.getBuilds(JOB_NAME) >> new BuildsList(list: [new Build(number: 111), new Build(number: 222)])
+
+        when:
+        MockHttpServletResponse response = mockMvc.perform(get("/builds/all/${MASTER}/${JOB_NAME}")
+            .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+        then:
+        response.contentAsString == "[{\"building\":false,\"number\":111},{\"building\":false,\"number\":222}]"
+    }
+
+    void 'get properties of a build with a bad filename'() {
+        given:
+        1 * client.getBuild(JOB_NAME, BUILD_NUMBER) >> new Build(
+             number: BUILD_NUMBER, artifacts: [new BuildArtifact(fileName: FILE_NAME, relativePath: FILE_NAME)])
+
+        when:
+        MockHttpServletResponse response = mockMvc.perform(
+            get("/builds/properties/${BUILD_NUMBER}/${FILE_NAME}/${MASTER}/${JOB_NAME}")
+            .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+        then:
+        response.contentAsString == "{}"
     }
 
     void 'trigger a build without parameters'() {
         given:
-        1 * jenkinsService.getJobConfig(JOB_NAME) >> new JobConfig()
-        1 * jenkinsService.build(JOB_NAME) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${QUEUED_JOB_NUMBER}")], null)
+        1 * client.getJobConfig(JOB_NAME) >> new JobConfig()
+        1 * client.build(JOB_NAME) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${BUILD_NUMBER}")], null)
 
-        expect:
-        controller.build(MASTER,JOB_NAME,null) == QUEUED_JOB_NUMBER.toString()
+        when:
+        MockHttpServletResponse response = mockMvc.perform(put("/masters/${MASTER}/jobs/${JOB_NAME}")
+          .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+        then:
+        response.contentAsString == BUILD_NUMBER.toString()
 
     }
 
     void 'trigger a build with parameters to a job with parameters'() {
         given:
-        1 * jenkinsService.getJobConfig(JOB_NAME) >> new JobConfig(parameterDefinitionList: [new ParameterDefinition(defaultName: "name", defaultValue: null, description: "description")])
-        1 * jenkinsService.buildWithParameters(JOB_NAME,[name:"myName"]) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${QUEUED_JOB_NUMBER}")], null)
+        1 * client.getJobConfig(JOB_NAME) >> new JobConfig(parameterDefinitionList: [new ParameterDefinition(defaultName: "name", defaultValue: null, description: "description")])
+        1 * client.buildWithParameters(JOB_NAME,[name:"myName"]) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${BUILD_NUMBER}")], null)
 
-        expect:
-        controller.build(MASTER,JOB_NAME, [name:"myName"]) == QUEUED_JOB_NUMBER.toString()
+        when:
+        MockHttpServletResponse response = mockMvc.perform(put("/masters/${MASTER}/jobs/${JOB_NAME}")
+          .contentType(MediaType.APPLICATION_JSON).param("name", "myName")).andReturn().response
+
+        then:
+        response.contentAsString == BUILD_NUMBER.toString()
     }
 
     void 'trigger a build without parameters to a job with parameters with default values'() {
         given:
-        1 * jenkinsService.getJobConfig(JOB_NAME) >> new JobConfig(parameterDefinitionList: [new ParameterDefinition(defaultName: "name", defaultValue: "value", description: "description")])
-        1 * jenkinsService.buildWithParameters(JOB_NAME, ['startedBy': "igor"]) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${QUEUED_JOB_NUMBER}")], null)
+        1 * client.getJobConfig(JOB_NAME) >> new JobConfig(parameterDefinitionList: [new ParameterDefinition(defaultName: "name", defaultValue: "value", description: "description")])
+        1 * client.buildWithParameters(JOB_NAME, ['startedBy' : "igor"]) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${BUILD_NUMBER}")], null)
 
-        expect:
-        controller.build(MASTER, JOB_NAME, null)  == QUEUED_JOB_NUMBER.toString()
+
+        when:
+        MockHttpServletResponse response = mockMvc.perform(put("/masters/${MASTER}/jobs/${JOB_NAME}")
+          .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+        then:
+        response.contentAsString == BUILD_NUMBER.toString()
     }
 
     void 'trigger a build with parameters to a job without parameters'() {
         given:
-        1 * jenkinsService.getJobConfig(JOB_NAME) >> new JobConfig()
+        1 * client.getJobConfig(JOB_NAME) >> new JobConfig()
 
         when:
-        controller.build(MASTER, JOB_NAME, [foo:"bar"])
+        MockHttpServletResponse response = mockMvc.perform(put("/masters/${MASTER}/jobs/${JOB_NAME}")
+          .contentType(MediaType.APPLICATION_JSON).param("foo", "bar")).andReturn().response
 
         then:
-        thrown(RuntimeException)
+        thrown(NestedServletException)
     }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClientSpec.groovy
@@ -57,7 +57,7 @@ class JenkinsClientSpec extends Specification {
 
         then:
         projects.size() == 3
-        projects*.name == ['uno', 'dos', 'tres']
+        projects*.name == ['job1', 'job2', 'folder1/job/folder2/job/job3']
     }
 
     void 'gets build details'() {
@@ -186,11 +186,11 @@ class JenkinsClientSpec extends Specification {
         jobConfig.url == "http://jenkins.builds.net/job/My-Build/"
 
     }
-    
+
     void 'trigger a build without parameters'() {
         given:
         setResponse("")
-        
+
         when:
         def response = client.build("My-Build")
 
@@ -198,7 +198,7 @@ class JenkinsClientSpec extends Specification {
         response
 
     }
-    
+
     void 'trigger a build with parameters'() {
         given:
         setResponse("")
@@ -270,7 +270,7 @@ class JenkinsClientSpec extends Specification {
     private String getBuildsWithArtifactsAndTests() {
         return '<hudson>' +
                 '<job>' +
-                '<name>uno</name>' +
+                '<name>job1</name>' +
                 '<lastBuild>' +
                 '<action><failCount>0</failCount><skipCount>1</skipCount><totalCount>111</totalCount><urlName>testReport</urlName></action>' +
                 '<action><failCount>0</failCount><skipCount>0</skipCount><totalCount>123</totalCount><urlName>testngreports</urlName></action>' +
@@ -282,11 +282,11 @@ class JenkinsClientSpec extends Specification {
                 '<number>1</number>' +
                 '<result>SUCCESS</result>' +
                 '<timestamp>1421717251402</timestamp>' +
-                '<url>http://my.jenkins.net/job/uno/1/</url>' +
+                '<url>http://my.jenkins.net/job/job1/1/</url>' +
                 '</lastBuild>' +
                 '</job>' +
                 '<job>' +
-                '<name>dos</name>' +
+                '<name>job2</name>' +
                 '<lastBuild>' +
                 '<action><failCount>0</failCount><skipCount>0</skipCount><totalCount>222</totalCount></action>' +
                 '<action><failCount>0</failCount><skipCount>0</skipCount><totalCount>222</totalCount></action>' +
@@ -298,16 +298,16 @@ class JenkinsClientSpec extends Specification {
                 '<number>2</number>' +
                 '<result>SUCCESS</result>' +
                 '<timestamp>1421717251402</timestamp>' +
-                '<url>http://my.jenkins.net/job/dos/2/</url>' +
+                '<url>http://my.jenkins.net/job/job2/2/</url>' +
                 '</lastBuild>' +
                 '</job>' +
                 '<job>' +
-                '<name>tres</name>' +
+                '<name>folder1/job/folder2/job/job3</name>' +
                 '<lastBuild>' +
                 '<building>true</building>' +
                 '<number>3</number>' +
                 '<timestamp>1421717251402</timestamp>' +
-                '<url>http://my.jenkins.net/job/tres/3/</url>' +
+                '<url>http://my.jenkins.net/job/folder1/job/folder2/job/job3/3/</url>' +
                 '</lastBuild>' +
                 '</job>' +
                 '</hudson>'

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.jenkins.service
+
+import com.netflix.spinnaker.igor.config.JenkinsConfig
+import com.netflix.spinnaker.igor.jenkins.client.JenkinsClient
+import com.netflix.spinnaker.igor.jenkins.client.model.Project
+import com.squareup.okhttp.mockwebserver.MockResponse
+import com.squareup.okhttp.mockwebserver.MockWebServer
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@SuppressWarnings(['LineLength', 'DuplicateNumberLiteral'])
+class JenkinsServiceSpec extends Specification {
+
+    final String JOB_UNENCODED = 'folder/job/name with spaces'
+    final String JOB_ENCODED = 'folder/job/name%20with%20spaces'
+
+    @Shared
+    JenkinsClient client
+
+    @Shared
+    JenkinsService service
+
+    @Shared
+    MockWebServer server
+
+    void setup() {
+        server = new MockWebServer()
+        server.enqueue(
+            new MockResponse()
+                .setBody(getProjects())
+                .setHeader('Content-Type', 'text/xml;charset=UTF-8')
+        )
+        server.play()
+        client = Mock(JenkinsClient)
+        service = new JenkinsService('http://my.jenkins.net', client)
+    }
+
+    void cleanup() {
+        server.shutdown()
+    }
+
+    @Unroll
+    void 'the "#method" method encodes the job name'() {
+        when:
+        if (extra_args) {
+            service."${method}"(JOB_UNENCODED, *extra_args)
+        } else {
+            service."${method}"(JOB_UNENCODED)
+        }
+
+        then:
+        if (extra_args) {
+            1 * client."${method}"(JOB_ENCODED, *extra_args)
+        } else {
+            1 * client."${method}"(JOB_ENCODED)
+        }
+
+        where:
+        method                | extra_args
+        'getBuilds'           | []
+        'getDependencies'     | []
+        'getBuild'            | [2]
+        'getGitDetails'       | [2]
+        'getLatestBuild'      | []
+        'build'               | []
+        'buildWithParameters' | [['key': 'value']]
+        'getJobConfig'        | []
+    }
+
+    void 'get a list of projects with the folders plugin'() {
+        given:
+        client = new JenkinsConfig().jenkinsClient(server.getUrl('/').toString(), 'username', 'password')
+        service = new JenkinsService('http://my.jenkins.net', client)
+
+        when:
+        List<Project> projects = service.projects.list
+
+        then:
+        projects.size() == 3
+        projects*.name == ['job1', 'job2', 'folder1/job/folder2/job/job3']
+    }
+
+    private String getProjects() {
+        return '<hudson>' +
+                '<job>' +
+                '<name>job1</name>' +
+                '<lastBuild>' +
+                '<action><failCount>0</failCount><skipCount>1</skipCount><totalCount>111</totalCount><urlName>testReport</urlName></action>' +
+                '<action><failCount>0</failCount><skipCount>0</skipCount><totalCount>123</totalCount><urlName>testngreports</urlName></action>' +
+                '<artifact><displayPath>libs/myProject-1.601.0-sources.jar</displayPath><fileName>myProject-1.601.0-sources.jar</fileName><relativePath>build/libs/myProject-1.601.0-sources.jar</relativePath></artifact>' +
+                '<artifact><displayPath>libs/myProject-1.601.0.jar</displayPath><fileName>myProject-1.601.0.jar</fileName><relativePath>build/libs/myProject-1.601.0.jar</relativePath></artifact>' +
+                '<artifact><displayPath>publishMavenNebulaPublicationToDistMavenRepository/org/myProject/myProject/1.601.0/myProject-1.601.0-sources.jar</displayPath><fileName>myProject-1.601.0-sources.jar</fileName><relativePath>build/tmp/publishMavenNebulaPublicationToDistMavenRepository/org/myProject/myProject/1.601.0/myProject-1.601.0-sources.jar</relativePath></artifact>' +
+                '<building>false</building>' +
+                '<duration>39238</duration>' +
+                '<number>1</number>' +
+                '<result>SUCCESS</result>' +
+                '<timestamp>1421717251402</timestamp>' +
+                '<url>http://my.jenkins.net/job/job1/1/</url>' +
+                '</lastBuild>' +
+                '</job>' +
+                '<job>' +
+                '<name>job2</name>' +
+                '<lastBuild>' +
+                '<action><failCount>0</failCount><skipCount>0</skipCount><totalCount>222</totalCount></action>' +
+                '<action><failCount>0</failCount><skipCount>0</skipCount><totalCount>222</totalCount></action>' +
+                '<artifact><displayPath>libs/myProject-1.601.0-sources.jar</displayPath><fileName>myProject-1.601.0-sources.jar</fileName><relativePath>build/libs/myProject-1.601.0-sources.jar</relativePath></artifact>' +
+                '<artifact><displayPath>libs/myProject-1.601.0.jar</displayPath><fileName>myProject-1.601.0.jar</fileName><relativePath>build/libs/myProject-1.601.0.jar</relativePath></artifact>' +
+                '<artifact><displayPath>publishMavenNebulaPublicationToDistMavenRepository/org/myProject/myProject/1.601.0/myProject-1.601.0-sources.jar</displayPath><fileName>myProject-1.601.0-sources.jar</fileName><relativePath>build/tmp/publishMavenNebulaPublicationToDistMavenRepository/org/myProject/myProject/1.601.0/myProject-1.601.0-sources.jar</relativePath></artifact>' +
+                '<building>false</building>' +
+                '<duration>39238</duration>' +
+                '<number>2</number>' +
+                '<result>SUCCESS</result>' +
+                '<timestamp>1421717251402</timestamp>' +
+                '<url>http://my.jenkins.net/job/job2/2/</url>' +
+                '</lastBuild>' +
+                '</job>' +
+                '<job>' +
+                '<name>folder1</name>' +
+                '<job>' +
+                '<name>folder2</name>' +
+                '<job>' +
+                '<name>job3</name>' +
+                '<lastBuild>' +
+                '<building>true</building>' +
+                '<number>3</number>' +
+                '<timestamp>1421717251402</timestamp>' +
+                '<url>http://my.jenkins.net/job/folder1/job/folder2/job/job3/3/</url>' +
+                '</lastBuild>' +
+                '</job>' +
+                '</job>' +
+                '</job>' +
+                '</hudson>'
+    }
+}


### PR DESCRIPTION
This is meant to address https://github.com/spinnaker/spinnaker/issues/605.
I'm able to hit `http://localhost:8080/jobs/<JenkinsName>/` and see a list of jobs with the expected names:

```json
[
  "Job1",
  "Folder1/job/Job2",
  "Folder1/job/Folder2/job/Job3"
]
```
Its also likely that a few endpoints will need to be updated since they currently have the job names in the middle of other parameters, such as "/jobs/{jobName}/builds" which could be troublesome.