### PR TITLE
allow timeout for jenkins http client to be modified by a property

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -24,6 +24,7 @@ dependencies {
     compile spinnaker.dependency("retrofit")
     compile spinnaker.dependency("eurekaClient")
     compile spinnaker.dependency("korkHystrix")
+    compile spinnaker.dependency("okHttp")
 
     compile 'org.yaml:snakeyaml:1.15'
     compile 'com.squareup.retrofit:converter-simplexml:1.5.1'


### PR DESCRIPTION
you can now set a client.timeout value in your igor.yml file and it will override the default value of 30 seconds. 

Note: the time is in milliseconds so ```client.timeout: 60000``` 