### PR TITLE
provider/docker: Send proper event details to echo.

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/EchoService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/EchoService.groovy
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.igor.history
 
-import com.netflix.spinnaker.igor.history.model.BuildDetails
+import com.netflix.spinnaker.igor.history.model.Event
 import retrofit.http.Body
 import retrofit.http.POST
 
@@ -9,5 +9,5 @@ import retrofit.http.POST
  */
 interface EchoService {
     @POST('/')
-    String postBuild(@Body BuildDetails build)
+    String postEvent(@Body Event event)
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/BuildEvent.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/BuildEvent.groovy
@@ -3,7 +3,7 @@ package com.netflix.spinnaker.igor.history.model
 /**
  * A history entry that contains a build detail
  */
-class BuildDetails {
+class BuildEvent extends Event {
 
     BuildContent content
     Map details = [

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/DockerEvent.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/DockerEvent.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.history.model
+
+class DockerEvent extends Event {
+    Content content
+    Map details = [
+        type  : 'docker',
+        source: 'igor'
+    ]
+
+    static class Content {
+        String registry
+        String repository
+        String tag
+        String digest
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/Event.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/Event.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.history.model
+
+abstract class Event {
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/BuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/BuildMonitor.groovy
@@ -20,7 +20,7 @@ import com.netflix.appinfo.InstanceInfo
 import com.netflix.discovery.DiscoveryClient
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.history.model.BuildContent
-import com.netflix.spinnaker.igor.history.model.BuildDetails
+import com.netflix.spinnaker.igor.history.model.BuildEvent
 import com.netflix.spinnaker.igor.jenkins.client.JenkinsMasters
 import com.netflix.spinnaker.igor.jenkins.client.model.Project
 import com.netflix.spinnaker.igor.polling.PollingMonitor
@@ -185,8 +185,8 @@ class BuildMonitor implements PollingMonitor {
                                                 Project oldProject = new Project(name: project.name, lastBuild: build)
                                                 if( build.number != lastBuild
                                                     || ( build.number == lastBuild && cachedBuild.lastBuildBuilding != build.building )) {
-                                                   echoService.postBuild(
-                                                        new BuildDetails(content: new BuildContent(project: oldProject, master: master)))
+                                                   echoService.postEvent(
+                                                        new BuildEvent(content: new BuildContent(project: oldProject, master: master)))
                                                 }
                                             } catch (e) {
                                                 log.error("An error occurred fetching ${master}:${project.name}:${build.number}", e)
@@ -208,8 +208,8 @@ class BuildMonitor implements PollingMonitor {
                         log.debug "setting result to ${project.lastBuild.result}"
                         cache.setLastBuild(master, project.name, project.lastBuild.number, project.lastBuild.building)
                         if (echoService) {
-                            echoService.postBuild(
-                                new BuildDetails(content: new BuildContent(project: project, master: master))
+                            echoService.postEvent(
+                                new BuildEvent(content: new BuildContent(project: project, master: master))
                             )
                         }
                         results << [previous: cachedBuild, current: project]

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/BuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/BuildMonitorSpec.groovy
@@ -130,10 +130,10 @@ class BuildMonitorSpec extends Specification {
         then:
         1 * cache.getLastBuild(MASTER, 'job') >> [lastBuildLabel: 3, lastBuildRunning: true]
         1 * cache.setLastBuild(MASTER, 'job', 6, false)
-        1 * monitor.echoService.postBuild({it.content.project.lastBuild.number == 3})
-        1 * monitor.echoService.postBuild({it.content.project.lastBuild.number == 4})
-        1 * monitor.echoService.postBuild({it.content.project.lastBuild.number == 5})
-        1 * monitor.echoService.postBuild({it.content.project.lastBuild.number == 6})
+        1 * monitor.echoService.postEvent({it.content.project.lastBuild.number == 3})
+        1 * monitor.echoService.postEvent({it.content.project.lastBuild.number == 4})
+        1 * monitor.echoService.postEvent({it.content.project.lastBuild.number == 5})
+        1 * monitor.echoService.postEvent({it.content.project.lastBuild.number == 6})
     }
 
     void 'emits events only for builds in list'(){
@@ -158,8 +158,8 @@ class BuildMonitorSpec extends Specification {
         then:
         1 * cache.getLastBuild(MASTER, 'job') >> [lastBuildLabel: 3, lastBuildRunning: true]
         1 * cache.setLastBuild(MASTER, 'job', 6, false)
-        1 * monitor.echoService.postBuild({it.content.project.lastBuild.number == 3})
-        1 * monitor.echoService.postBuild({it.content.project.lastBuild.number == 6})
+        1 * monitor.echoService.postEvent({it.content.project.lastBuild.number == 3})
+        1 * monitor.echoService.postEvent({it.content.project.lastBuild.number == 6})
     }
 
     void 'does not send event for current unchanged build'(){
@@ -177,7 +177,7 @@ class BuildMonitorSpec extends Specification {
         then:
         1 * cache.getLastBuild(MASTER, 'job') >> [lastBuildLabel: 3, lastBuildBuilding: true]
         0 * jenkinsService.getBuilds('job')
-        0 * monitor.echoService.postBuild(_)
+        0 * monitor.echoService.postEvent(_)
     }
 
     void 'does not send event for past build with already sent event'(){
@@ -201,8 +201,8 @@ class BuildMonitorSpec extends Specification {
         then:
         1 * cache.getLastBuild(MASTER, 'job') >> [lastBuildLabel: 5, lastBuildBuilding: false]
         1 * cache.setLastBuild(MASTER, 'job', 6, true)
-        0 * monitor.echoService.postBuild({it.content.project.lastBuild.number == 5})
-        1 * monitor.echoService.postBuild({it.content.project.lastBuild.number == 6})
+        0 * monitor.echoService.postEvent({it.content.project.lastBuild.number == 5})
+        1 * monitor.echoService.postEvent({it.content.project.lastBuild.number == 6})
     }
 
     void 'does not send event for same build'(){
@@ -220,7 +220,7 @@ class BuildMonitorSpec extends Specification {
         then:
         1 * cache.getLastBuild(MASTER, 'job') >> [lastBuildLabel: 6, lastBuildBuilding: true]
         0 * jenkinsService.getBuilds('job')
-        0 * monitor.echoService.postBuild({_})
+        0 * monitor.echoService.postEvent({_})
     }
 
 
@@ -238,7 +238,7 @@ class BuildMonitorSpec extends Specification {
 
         then:
         1 * cache.getLastBuild(MASTER, 'job') >> [lastBuildLabel: 6, lastBuildBuilding: false]
-        1 * monitor.echoService.postBuild({it.content.project.lastBuild.number == 6})
+        1 * monitor.echoService.postEvent({it.content.project.lastBuild.number == 6})
     }
 
 }


### PR DESCRIPTION
I was incorrectly using the `details` field of the event data sent to Echo rather than `content`. 

I also switched formatting of `imageId` from `$registry/$repository:$tag` to the image key stored in redis, for simplicity.

@duftler 