### PR TITLE
Adding support for igor to stop and cancel jenkins jobs

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/BuildController.groovy
@@ -115,7 +115,7 @@ class BuildController {
         def jenkinsService = masters.map[master]
 
         // Jobs that haven't been started yet won't have a buildNumber
-        // (They're still in the queue. We use 0 to denote that case
+        // (They're still in the queue). We use 0 to denote that case
         if (buildNumber != 0) {
             jenkinsService.stopRunningBuild(jobName, buildNumber)
         }
@@ -125,7 +125,10 @@ class BuildController {
         // of being handled by the handleOtherException handler and returning a 500 to orca
         try {
             jenkinsService.stopQueuedBuild(queuedBuild)
-        } catch (RuntimeException e) {
+        } catch (RetrofitError e) {
+            if (e.response?.status != HttpStatus.NOT_FOUND.value()) {
+                throw e
+            }
         }
 
         "true"

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/BuildController.groovy
@@ -101,6 +101,36 @@ class BuildController {
         masters.map[master].getBuilds(job).list
     }
 
+    @RequestMapping(value = "/masters/{name}/jobs/{jobName}/stop/{queuedBuild}/{buildNumber}", method = RequestMethod.PUT)
+    String stop(
+        @PathVariable("name") String master,
+        @PathVariable String jobName,
+        @PathVariable String queuedBuild,
+        @PathVariable Integer buildNumber) {
+
+        if (!masters.map.containsKey(master)) {
+            throw new MasterNotFoundException("Master '${master}' not found")
+        }
+
+        def jenkinsService = masters.map[master]
+
+        // Jobs that haven't been started yet won't have a buildNumber
+        // (They're still in the queue. We use 0 to denote that case
+        if (buildNumber != 0) {
+            jenkinsService.stopRunningBuild(jobName, buildNumber)
+        }
+
+        // The jenkins api for removing a job from the queue (http://<Jenkins_URL>/queue/cancelItem?id=<queuedBuild>)
+        // always returns a 404. This try catch block insures that the exception is eaten instead
+        // of being handled by the handleOtherException handler and returning a 500 to orca
+        try {
+            jenkinsService.stopQueuedBuild(queuedBuild)
+        } catch (RuntimeException e) {
+        }
+
+        "true"
+    }
+
     @RequestMapping(value = '/masters/{name}/jobs/**', method = RequestMethod.PUT)
     String build(
         @PathVariable("name") String master,

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -29,6 +29,7 @@ import retrofit.http.EncodedPath
 import retrofit.http.GET
 import retrofit.http.POST
 import retrofit.http.Path
+import retrofit.http.Query
 import retrofit.http.QueryMap
 import retrofit.http.Streaming
 
@@ -71,6 +72,12 @@ interface JenkinsClient {
 
     @POST('/job/{jobName}/buildWithParameters')
     Response buildWithParameters(@EncodedPath('jobName') String jobName, @QueryMap Map<String, String> queryParams)
+
+    @POST('/job/{jobName}/{buildNumber}/stop')
+    Response stopRunningBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
+
+    @POST('/queue/cancelItem')
+    Response stopQueuedBuild(@Query('id') String queuedBuild)
 
     @GET('/job/{jobName}/api/xml?exclude=/*/action&exclude=/*/build&exclude=/*/property[not(parameterDefinition)]')
     JobConfig getJobConfig(@EncodedPath('jobName') String jobName)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
@@ -128,6 +128,14 @@ class JenkinsService {
         return jenkinsClient.getPropertyFile(encode(jobName), buildNumber, fileName)
     }
 
+    Response stopRunningBuild (String jobName, Integer buildNumber){
+        return jenkinsClient.stopRunningBuild(encode(jobName), buildNumber)
+    }
+
+    Response stopQueuedBuild (String queuedBuild) {
+        return jenkinsClient.stopQueuedBuild(queuedBuild)
+    }
+
   /**
    * A CommandKey should be unique per group (to ensure broken circuits do not span Jenkins masters)
    */


### PR DESCRIPTION
Hello @robfletcher @ajordens @tomaslin !

This PR is to add the ability for the jenkins stage to be cancellable. The change involves changes on both Orca and Igor.

- Orca: Jenkins stage now implements the `CancellableStage` interface and there is now a new task that hits a `stop` endpoint on Igor
- Igor: There are two different apis for canceling a jenkins job. The first is `/job/{jobName}/{buildNumber}/stop` which will stop a job that is currently running. The other one is `/queue/cancelItem` which will remove a queued job. There is also some weird jenkins api issues I ran into that I commented on inline.
- Deck: I thought about adding some sort of flag on the jenkins stage that would allow the user to opt into the cancellable aspect of the stage, but the more I thought about it the more it seemed like a bug that it didn't cancel in the first place. Let me know what you guys think about this. 

[Orca PR](https://github.com/spinnaker/orca/pull/764)

Thanks!