### PR TITLE
Rename BuildMonitor to JenkinsBuildMonitor

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit
 @Service
 @SuppressWarnings('CatchException')
 @ConditionalOnProperty('jenkins.enabled')
-class BuildMonitor implements PollingMonitor {
+class JenkinsBuildMonitor implements PollingMonitor {
 
     @Autowired
     Environment environment

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
@@ -30,11 +30,11 @@ import java.util.concurrent.TimeUnit
  * Ensures that build monitor runs periodically
  */
 @SuppressWarnings(['PropertyName'])
-class BuildMonitorSchedulingSpec extends Specification {
+class JenkinsBuildMonitorSchedulingSpec extends Specification {
 
     JenkinsCache cache = Mock(JenkinsCache)
     JenkinsService jenkinsService = Mock(JenkinsService)
-    BuildMonitor monitor
+    JenkinsBuildMonitor monitor
 
     final MASTER = 'MASTER'
     final PROJECTS = new ProjectsList(list: [])
@@ -44,7 +44,7 @@ class BuildMonitorSchedulingSpec extends Specification {
         given:
         cache.getJobNames(MASTER) >> []
         BuildMasters buildMasters = Mock(BuildMasters)
-        monitor = new BuildMonitor(cache: cache, buildMasters: buildMasters)
+        monitor = new JenkinsBuildMonitor(cache: cache, buildMasters: buildMasters)
         monitor.worker = scheduler.createWorker()
         monitor.pollInterval = 1
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSpec.groovy
@@ -26,19 +26,19 @@ import com.netflix.spinnaker.igor.service.BuildMasters
 import spock.lang.Specification
 
 /**
- * Tests for BuildMonitor
+ * Tests for JenkinsBuildMonitor
  */
 @SuppressWarnings(['DuplicateNumberLiteral', 'PropertyName'])
-class BuildMonitorSpec extends Specification {
+class JenkinsBuildMonitorSpec extends Specification {
 
     JenkinsCache cache = Mock(JenkinsCache)
     JenkinsService jenkinsService = Mock(JenkinsService)
-    BuildMonitor monitor
+    JenkinsBuildMonitor monitor
 
     final MASTER = 'MASTER'
 
     void setup() {
-        monitor = new BuildMonitor(cache: cache, buildMasters: new BuildMasters(map: [MASTER: jenkinsService]))
+        monitor = new JenkinsBuildMonitor(cache: cache, buildMasters: new BuildMasters(map: [MASTER: jenkinsService]))
     }
 
     void 'flag a new build not found in the cache'() {


### PR DESCRIPTION
Renaming the jenkins build monitor to JenkinsBuildMonitor.