### PR TITLE
Travis: synchronize repositories and validate the build cache

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -153,7 +153,7 @@ class TravisBuildMonitor implements PollingMonitor{
         startTime = System.currentTimeMillis()
         Observable.from(cachedRepoSlugs).subscribe(
             { String repoSlug ->
-                if(!buildMasters.map[master].getRepo(repoSlug)) {
+                if(!buildMasters.map[master].hasRepo(repoSlug)) {
                     log.info "repositorySync: Removing ${master}:${repoSlug} from buildCache because it is not on ${master} anymore."
                         buildCache.remove(master, repoSlug)
                 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -56,6 +56,8 @@ class TravisBuildMonitor implements PollingMonitor{
 
     Scheduler.Worker worker = Schedulers.io().createWorker()
 
+    Scheduler.Worker repositorySyncWorker = Schedulers.io().createWorker()
+
     @Autowired
     BuildCache buildCache
 
@@ -70,11 +72,17 @@ class TravisBuildMonitor implements PollingMonitor{
 
     Long lastPoll
 
+    Long lastRepositorySync
+
     static final String BUILD_IN_PROGRESS = 'started'
 
     @SuppressWarnings('GStringExpressionWithinString')
     @Value('${spinnaker.build.pollInterval:60}')
     int pollInterval
+
+    @SuppressWarnings('GStringExpressionWithinString')
+    @Value('${spinnaker.build.travis.repositorySyncInterval:300}')
+    int repositorySyncInterval
 
     @Override
     void onApplicationEvent(ContextRefreshedEvent event) {
@@ -91,6 +99,19 @@ class TravisBuildMonitor implements PollingMonitor{
                     lastPoll = null
                 }
             } as Action0, 0, pollInterval, TimeUnit.SECONDS
+        )
+
+        worker.schedulePeriodically(
+            {
+                if (isInService()) {
+                    buildMasters.filteredMap(BuildServiceProvider.TRAVIS).keySet().each { master ->
+                        repositorySync(master)
+                    }
+                } else {
+                    log.info("not in service (lastRepositorySync: ${lastRepositorySync ?: 'n/a'})")
+                    lastRepositorySync = null
+                }
+            } as Action0, 0, repositorySyncInterval, TimeUnit.SECONDS
         )
     }
 
@@ -121,29 +142,41 @@ class TravisBuildMonitor implements PollingMonitor{
         return pollInterval
     }
 
+    def repositorySync(String master) {
+        log.info('repositorySync: Syncing repositories for ' + master)
+        lastRepositorySync = System.currentTimeMillis()
+        List<String> cachedRepoSlugs = buildCache.getJobNames(master)
+        buildMasters.map[master].setAccessToken()
+        def startTime = System.currentTimeMillis()
+        buildMasters.map[master].syncRepos()
+        log.info("repositorySync: Took ${System.currentTimeMillis() - startTime}ms to sync repositories for ${master}")
+        startTime = System.currentTimeMillis()
+        Observable.from(cachedRepoSlugs).subscribe(
+            { String repoSlug ->
+                if(!buildMasters.map[master].getRepo(repoSlug)) {
+                    log.info "repositorySync: Removing ${master}:${repoSlug} from buildCache because it is not on ${master} anymore."
+                        buildCache.remove(master, repoSlug)
+                }
+            }, {
+            log.error("repositorySync: Error: ${it.message}")
+        }, {} as Action0
+        )
+        log.info("repositorySync: Took ${System.currentTimeMillis() - startTime}ms validate build cache for ${master}")
+        log.info("repositorySync: Last repositorySync took ${System.currentTimeMillis() - lastRepositorySync}ms (master: ${master})")
+
+    }
+
     List<Map> changedBuilds(String master) {
         log.info('Checking for new builds for ' + master)
         List<String> cachedRepoSlugs = buildCache.getJobNames(master)
         List<Map> results = []
         buildMasters.map[master].setAccessToken()
         lastPoll = System.currentTimeMillis()
-        buildMasters.map[master].getAccounts()
+        buildMasters.map[master].setAccounts()
         def startTime = System.currentTimeMillis()
         List<Repo> repos = buildMasters.map[master].getReposForAccounts()
         log.info("Took ${System.currentTimeMillis() - startTime}ms to retrieve ${repos.size()} repositories (master: ${master})")
-        List<String> repoSlugs = repos*.slug
-        Observable.from(cachedRepoSlugs).filter { String name ->
-            !(name in repoSlugs)
-        }.subscribe(
-            { String repoSlug ->
-                if (!buildMasters.map[master].getRepo(repoSlug)) {
-                    log.info "Removing ${master}:${repoSlug}"
-                    buildCache.remove(master, repoSlug)
-                }
-            }, {
-            log.error("Error: ${it.message}")
-        }, {} as Action0
-        )
+
         Observable.from(repos).subscribe(
             { Repo repo ->
                 boolean addToCache = false

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -37,6 +37,9 @@ interface TravisClient {
     @POST('/auth/github')
     AccessToken accessToken(@Query('github_token') String githubToken)
 
+    @POST('/users/sync')
+    Response usersSync(@Header("Authorization") String accessToken)
+
     @GET('/accounts')
     Accounts accounts(@Header("Authorization") String accessToken)
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -70,6 +70,17 @@ class TravisService implements BuildService {
         return accounts
     }
 
+    void setAccounts() {
+        this.accounts = getAccounts()
+    }
+
+    void syncRepos() {
+        Response response = travisClient.usersSync(getAccessToken())
+        if (response.status != 200) {
+            log.warn "synchronizing travis repositories failed with status: ${response.status}"
+        }
+    }
+
     List<Build> getBuilds() {
         Builds builds = travisClient.builds(getAccessToken())
         log.debug "fetched " + builds.builds.size() + " builds"

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.igor.travis.client.model.Jobs
 import com.netflix.spinnaker.igor.travis.client.model.Repo
 import com.netflix.spinnaker.igor.travis.client.model.Repos
 import groovy.util.logging.Slf4j
+import retrofit.RetrofitError
 import retrofit.client.Response
 import retrofit.mime.TypedByteArray
 
@@ -76,7 +77,7 @@ class TravisService implements BuildService {
 
     void syncRepos() {
         Response response = travisClient.usersSync(getAccessToken())
-        if (response.status != 200) {
+        if (response.status >= 400) {
             log.warn "synchronizing travis repositories failed with status: ${response.status}"
         }
     }
@@ -183,6 +184,22 @@ class TravisService implements BuildService {
 
     Repo getRepo(String repoSlug) {
         return travisClient.repo(getAccessToken(), repoSlug)
+    }
+
+    boolean hasRepo(String repoSlug) {
+        try {
+            getRepo(repoSlug)
+        } catch (RetrofitError error) {
+            if (error.getResponse()) {
+                if (error.getResponse().status == 404) {
+                    log.debug "repo not found ${repoSlug}"
+                    return false
+                }
+            }
+            log.info "Error requesting repo ${repoSlug}: ${error.message}"
+            return true
+        }
+        return true
     }
 
     GenericBuild getGenericBuild(Build build, String repoSlug) {


### PR DESCRIPTION
* Spawn separate worker thread for consistency work
* Make a travis call to sync travis against git
* Validate and delete jobs that are in the build cache and not in travis

The workflow we are implementing for using travis with spinnaker at schibsted is as follows.
1. We have a spinnaker system user in github
2. To get your builds into spinnaker, you grant the spinnaker system user access to the repository

Now igor syncs travis and github for us and makes new builds appear at in average 2 minutes and 30 seconds. The sync interval can be changed by the spinnaker.build.travis.repositorySyncInterval property.

The reason this is done in a separate thread is that the build cache validation can be quite expensive in large installations.