### PR TITLE
Add support for triggering travis builds with igor

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/TravisConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/TravisConfig.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.igor.config
 
 import com.netflix.spinnaker.igor.service.BuildMasters
+import com.netflix.spinnaker.igor.travis.TravisCache
 import com.netflix.spinnaker.igor.travis.client.TravisClient
 import com.netflix.spinnaker.igor.travis.client.model.Build
 import com.netflix.spinnaker.igor.travis.service.TravisService
@@ -52,6 +53,9 @@ class TravisConfig {
     @Autowired(required = false)
     BuildMasters buildMasters
 
+    @Autowired
+    TravisCache travisCache
+
     @Bean
     Map<String, TravisService> travisMasters(@Valid TravisProperties travisProperties) {
         log.info "creating travisMasters"
@@ -59,14 +63,14 @@ class TravisConfig {
             String travisName = "travis-${host.name}"
             log.info "bootstrapping ${host.address} as ${travisName}"
 
-            [(travisName): travisService(travisName, host.baseUrl, host.githubToken, travisClient(host.address, clientTimeout))]
+            [(travisName): travisService(travisName, host.baseUrl, host.githubToken, travisClient(host.address, clientTimeout), travisCache)]
         })
         buildMasters.map.putAll travisMasters
         travisMasters
     }
 
-    static TravisService travisService(String travisHostId, String baseUrl, String githubToken, TravisClient travisClient) {
-        return new TravisService(travisHostId, baseUrl, githubToken, travisClient)
+    static TravisService travisService(String travisHostId, String baseUrl, String githubToken, TravisClient travisClient, TravisCache travisCache) {
+        return new TravisService(travisHostId, baseUrl, githubToken, travisClient, travisCache)
     }
 
     static TravisClient travisClient(String address, int timeout = 30000) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisCache.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisCache.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+
+
+/*
+    This creates an internal queue for igor triggered travis jobs.
+    The travis api does not return an id we can track in the queue.
+ */
+@Service
+@ConditionalOnProperty("travis.enabled")
+class TravisCache {
+    @Autowired
+    JedisPool jedisPool
+
+    @SuppressWarnings('GStringExpressionWithinString')
+    @Value('${spinnaker.jedis.prefix:igor}')
+    String prefix
+
+    String id = 'travis:builds:queue'
+
+    Map getQueuedJob(String master, int queueNumber) {
+        Jedis resource = jedisPool.getResource()
+
+        resource.withCloseable {
+            Map result = resource.hgetAll(makeKey(master, queueNumber))
+            if (!result) {
+                return [:]
+            }
+            Map convertedResult = [
+                buildNumber: Integer.parseInt(result.buildNumber),
+                jobName: result.jobName
+            ]
+            return convertedResult
+        }
+    }
+
+    int setQueuedJob(String master, String jobName, int buildNumber) {
+        Jedis resource = jedisPool.getResource()
+        int queueId = (int) (long) new Date().getTime()
+        resource.withCloseable {
+            while (resource.exists(makeKey(master, queueId))) {
+                queueId++;
+            }
+            resource.hset(makeKey(master, queueId), 'buildNumber', buildNumber as String)
+            resource.hset(makeKey(master, queueId), 'jobName', jobName)
+            return queueId
+        }
+    }
+
+    void remove(String master, int queueId) {
+        Jedis resource = jedisPool.getResource()
+        resource.withCloseable {
+            resource.del(makeKey(master, queueId))
+        }
+    }
+
+    private String makeKey(String master, int queueId) {
+        "${baseKey()}:${master}:${queueId}"
+    }
+
+    private String baseKey() {
+        return "${prefix}:${id}"
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -22,8 +22,13 @@ import com.netflix.spinnaker.igor.travis.client.model.Build
 import com.netflix.spinnaker.igor.travis.client.model.Builds
 import com.netflix.spinnaker.igor.travis.client.model.Jobs
 import com.netflix.spinnaker.igor.travis.client.model.Repo
+import com.netflix.spinnaker.igor.travis.client.model.RepoRequest
+import com.netflix.spinnaker.igor.travis.client.model.RepoWrapper
 import com.netflix.spinnaker.igor.travis.client.model.Repos
+import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse
 import retrofit.client.Response
+import retrofit.http.Body
+import retrofit.http.EncodedPath
 import retrofit.http.GET
 import retrofit.http.Header
 import retrofit.http.Headers
@@ -68,7 +73,11 @@ interface TravisClient {
     Repo repo(@Header("Authorization") String accessToken, @Path('repositoryId') int repositoryId)
 
     @GET('/repos/{repo_slug}')
-    Repo repo(@Header("Authorization") String accessToken, @Path('repo_slug') String repoSlug)
+    RepoWrapper repoWrapper(@Header("Authorization") String accessToken, @EncodedPath('repo_slug') String repoSlug)
+
+    @POST('/repo/{repoSlug}/requests')
+    @Headers("Travis-API-Version: 3")
+    TriggerResponse triggerBuild(@Header("Authorization") String accessToken, @Path('repoSlug') String repoSlug, @Body RepoRequest repoRequest)
 
     @GET('/jobs/{job_id}')
     Jobs jobs(@Header("Authorization") String accessToken , @Path('job_id') int jobId)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/RepoRequest.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/RepoRequest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonRootName
+
+/*
+  Body when posting to travis in order to trigger new builds
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonRootName("request")
+class RepoRequest {
+    String branch
+
+    String message = "Triggered from spinnaker"
+
+    RepoRequest(String branch) {
+        this.branch = branch
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/RepoWrapper.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/RepoWrapper.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import groovy.transform.CompileStatic
+import org.simpleframework.xml.Default
+import org.simpleframework.xml.Element
+import org.simpleframework.xml.Root
+
+/**
+ * Repos are represented in many ways in the travis api,
+ * this is a helper to get one of the representations.
+ */
+
+@Default
+@CompileStatic
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Root(strict = false)
+class RepoWrapper {
+        @Element(required = false, name = "repo")
+        Repo repo
+
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/TriggerResponse.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/TriggerResponse.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model
+
+import com.google.gson.annotations.SerializedName
+import groovy.transform.CompileStatic
+import org.simpleframework.xml.Default
+
+
+@Default
+@CompileStatic
+class TriggerResponse {
+    @SerializedName("remaining_requests")
+    int remainingRequests
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverter.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverter.groovy
@@ -25,6 +25,9 @@ import groovy.util.logging.Slf4j
 class TravisResultConverter {
     static Result getResultFromTravisState(String state) {
         switch (state) {
+            case "created":
+                return Result.NOT_BUILT
+                break
             case "started":
                 return Result.BUILDING
                 break
@@ -41,8 +44,8 @@ class TravisResultConverter {
                 return Result.FAILURE
                 break
             default:
-                log.info ("could not convert ${state} to result, setting FAILURE")
-                return Result.FAILURE
+                log.info ("could not convert ${state}")
+                throw new IllegalArgumentException("state: ${state} is not known to TravisResultConverter.")
                 break
         }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -33,7 +33,7 @@ class TravisServiceSpec extends Specification{
 
     void setup() {
         client = Mock(TravisClient)
-        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', client)
+        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', client, null)
     }
 
     def "getGenericBuild(build, repoSlug)" () {


### PR DESCRIPTION
* https://travis-ci.org confirmed working
* https://travis-ci.com (travis pro) @aioue will test it on travis-pro.
* Does not work on travis enterprise (travis enterprise is way behind the other versions)

The endpoint we are using is in beta. https://docs.travis-ci.com/user/triggering-builds

The builds in the screenshot are triggered from travis using 
`curl -s -X PUT http://localhost:8080/masters/travis-ci/jobs/repo/slug`

<img width="1437" alt="screen shot 2016-04-16 at 22 10 27" src="https://cloud.githubusercontent.com/assets/842541/14583361/1ed43ea4-0420-11e6-9dab-b6bac8f105c4.png">