### PR TITLE
Add support for branches in the travis integration

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/InfoController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/InfoController.groovy
@@ -74,8 +74,7 @@ class InfoController {
             )
             return masterList
         } else {
-            List<Object> masterList = buildMasters.map.keySet().sort()
-            masterList //TODO: return raw?
+            return buildMasters.map.keySet().sort()
         }
     }
 
@@ -84,7 +83,6 @@ class InfoController {
         log.info('Getting list of jobs for master: {}', master)
 
         def jenkinsService = buildMasters.filteredMap(BuildServiceProvider.JENKINS)[master]
-        def otherService = buildMasters.map[master]
         if (jenkinsService) {
             def jobList = []
             def recursiveGetJobs
@@ -104,7 +102,7 @@ class InfoController {
             recursiveGetJobs(jenkinsService.jobs.list)
 
             return jobList
-        } else if (otherService) {
+        } else if (buildMasters.map.containsKey(master)) {
             return buildCache.getJobNames(master)
         } else {
             throw new MasterNotFoundException("Master '${master}' does not exist")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisCache.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisCache.groovy
@@ -23,6 +23,8 @@ import org.springframework.stereotype.Service
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
 
+import java.util.concurrent.TimeUnit
+
 
 /*
     This creates an internal queue for igor triggered travis jobs.
@@ -58,7 +60,7 @@ class TravisCache {
 
     int setQueuedJob(String master, String jobName, int buildNumber) {
         Jedis resource = jedisPool.getResource()
-        int queueId = (int) (long) new Date().getTime()
+        int queueId = (int) (long) TimeUnit.MILLISECONDS.toSeconds(new Date().getTime())
         resource.withCloseable {
             while (resource.exists(makeKey(master, queueId))) {
                 queueId++;

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Commit.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Commit.groovy
@@ -37,7 +37,24 @@ class Commit {
     @SerializedName("author_name")
     String authorName
 
+    @SerializedName("compare_url")
+    String compareUrl
+
     GenericGitRevision genericGitRevision() {
         return new GenericGitRevision(branch, branch, sha)
+    }
+
+    boolean isTag(){
+        if (!compareUrl) {
+            return false
+        }
+        return compareUrl.split("/compare/").last().matches(branch)
+    }
+
+    String branchNameWithTagHandling() {
+        if (isTag()) {
+            return "tags"
+        }
+        return branch
     }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -78,7 +78,7 @@ class InfoControllerSpec extends Specification {
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
-        2 * buildMasters.map >> [ 'master1' : [ 'jobs' : [ 'list': [
+        1 * buildMasters.map >> [ 'master1' : [ 'jobs' : [ 'list': [
             ['name': 'job1'],
             ['name': 'job2'],
             ['name': 'job3']
@@ -93,7 +93,7 @@ class InfoControllerSpec extends Specification {
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
-        2 * buildMasters.map >> [ 'master1' : [ 'jobs' : [ 'list': [
+        1 * buildMasters.map >> [ 'master1' : [ 'jobs' : [ 'list': [
             ['name': 'folder', 'list': [
                 ['name': 'job1'],
                 ['name': 'job2']
@@ -102,6 +102,19 @@ class InfoControllerSpec extends Specification {
         ] ] ] ]
         1 * buildMasters.filteredMap(BuildServiceProvider.JENKINS) >> buildMasters.map
         response.contentAsString == '["folder/job/job1","folder/job/job2","job3"]'
+    }
+
+    void 'is able to get jobs for a travis master'() {
+        when:
+        MockHttpServletResponse response = mockMvc.perform(get('/jobs/travis-master1')
+            .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+        then:
+        1 * buildMasters.filteredMap(BuildServiceProvider.JENKINS) >> ["travis-master1": []]
+        1 * buildMasters.map >> ["travis-master1": []]
+        1 * cache.getJobNames('travis-master1') >> ["some-job"]
+        response.contentAsString == '["some-job"]'
+
     }
 
     private void setResponse(String body) {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor.travis
+
+import com.netflix.spinnaker.igor.build.BuildCache
+import com.netflix.spinnaker.igor.build.model.GenericGitRevision
+import com.netflix.spinnaker.igor.history.EchoService
+import com.netflix.spinnaker.igor.service.BuildMasters
+import com.netflix.spinnaker.igor.travis.client.model.Commit
+import com.netflix.spinnaker.igor.travis.client.model.Repo
+import com.netflix.spinnaker.igor.travis.service.TravisService
+import spock.lang.Specification
+
+class TravisBuildMonitorSpec extends Specification {
+    BuildCache buildCache = Mock(BuildCache)
+    TravisService travisService = Mock(TravisService)
+    TravisBuildMonitor travisBuildMonitor
+
+    final String MASTER = "MASTER"
+
+    void setup() {
+        travisBuildMonitor = new TravisBuildMonitor(buildCache: buildCache, buildMasters: new BuildMasters(map: [MASTER : travisService]))
+    }
+
+    void 'flag a new build not found in the cache'() {
+        Repo repo = new Repo()
+        repo.slug = "test-org/test-repo"
+        repo.lastBuildNumber = 4
+        repo.lastBuildState = "passed"
+        List<Repo> repos = [repo]
+
+        given:
+        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo']
+
+        when:
+        List<Map> builds = travisBuildMonitor.changedBuilds(MASTER)
+
+        then:
+        1 * travisService.setAccessToken()
+        1 * travisService.getReposForAccounts() >> repos
+
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo') >> [lastBuildLabel: 3]
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false)
+        builds.size() == 1
+        builds[0].current.slug == 'test-org/test-repo'
+        builds[0].current.lastBuildNumber == 4
+        builds[0].previous.lastBuildLabel == 3
+    }
+
+
+    void 'send events for build both on branch and on repository'() {
+        travisBuildMonitor.echoService = Mock(EchoService)
+
+        Commit commit = Mock(Commit)
+        Repo repo = new Repo()
+        repo.slug = "test-org/test-repo"
+        repo.lastBuildNumber = 4
+        repo.lastBuildState = "passed"
+        List<Repo> repos = [repo]
+
+        given:
+        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo']
+
+        when:
+        List<Map> builds = travisBuildMonitor.changedBuilds(MASTER)
+
+        then:
+        1 * travisService.getAccounts()
+        1 * travisService.setAccessToken()
+        1 * travisService.getReposForAccounts() >> repos
+        1 * travisService.getCommit('test-org/test-repo', 4) >> commit
+        1 * commit.branchNameWithTagHandling() >> "my_branch"
+
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo') >> [lastBuildLabel: 3]
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false)
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/my_branch', 4, false)
+
+        1 * travisBuildMonitor.echoService.postEvent({
+            it.content.project.name == "test-org/test-repo"
+            it.content.project.lastBuild.number == 4
+        })
+        1 * travisBuildMonitor.echoService.postEvent({
+            it.content.project.name == "test-org/test-repo/my_branch"
+            it.content.project.lastBuild.number == 4
+        })
+
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -19,7 +19,10 @@ package com.netflix.spinnaker.igor.travis.service
 import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.Result
 import com.netflix.spinnaker.igor.travis.client.TravisClient
+import com.netflix.spinnaker.igor.travis.client.model.AccessToken
 import com.netflix.spinnaker.igor.travis.client.model.Build
+import com.netflix.spinnaker.igor.travis.client.model.Builds
+import com.netflix.spinnaker.igor.travis.client.model.Commit
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -54,5 +57,69 @@ class TravisServiceSpec extends Specification{
         1 * build.duration >> 32
         1 * build.finishedAt >> new Date()
         1 * build.timestamp() >> 1458051084000
+    }
+
+    def "cleanRepoSlug(repoSlug)"() {
+        when:
+        String repoSlug = service.cleanRepoSlug(inputRepoSlug)
+
+        then:
+        repoSlug == expectedRepoSlug
+
+        where:
+        inputRepoSlug                     | expectedRepoSlug
+        "my-org/repo"                     | "my-org/repo"
+        "my-org/repo/branch"              | "my-org/repo"
+        "my-org/repo/branch/with/slashes" | "my-org/repo"
+
+    }
+
+    def "branchFromRepoSlug(repoSlug)"() {
+        when:
+        String branch = service.branchFromRepoSlug(inputRepoSlug)
+
+        then:
+        branch == expectedBranch
+
+        where:
+        inputRepoSlug                     | expectedBranch
+        "my-org/repo"                     | ""
+        "my-org/repo/branch"              | "branch"
+        "my-org/repo/branch/with/slashes" | "branch/with/slashes"
+    }
+
+    def "getCommit(repoSlug, buildNumber)"() {
+        given:
+        Commit commit = new Commit()
+        commit.branch = "1.0"
+        commit.compareUrl = "https://github.domain/org/repo/compare/1.0"
+        Builds builds = Mock(Builds)
+        AccessToken accessToken = new AccessToken()
+        accessToken.accessToken = "someToken"
+
+        when:
+        Commit fetchedCommit = service.getCommit("org/repo", 38)
+
+        then:
+        fetchedCommit.isTag() == true
+        1 * client.accessToken("someToken") >> accessToken
+        1 * client.builds("token someToken", "org/repo", 38) >> builds
+        2 * builds.commits >> [commit]
+    }
+
+    def "getCommit(repoSlug, buildNumber) when no commit is found"() {
+        given:
+        Builds builds = Mock(Builds)
+        AccessToken accessToken = new AccessToken()
+        accessToken.accessToken = "someToken"
+
+        when:
+        service.getCommit("org/repo", 38)
+
+        then:
+        thrown NoSuchFieldException
+        1 * client.accessToken("someToken") >> accessToken
+        1 * client.builds("token someToken", "org/repo", 38) >> builds
+        1 * builds.commits >> []
     }
 }


### PR DESCRIPTION
You can choose to listen to org/repo for all builds of the project, or you can choose a specific branch like org/repo/branch.

I have checked how jenkins work with https://wiki.jenkins-ci.org/display/JENKINS/Multi-Branch+Project+Plugin and this gives almost the same experience.