### PR TITLE
Sync repositories in travis for the spinnaker github user

### DIFF
--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -5,11 +5,14 @@ netflix:
 spinnaker:
   build:
     pollInterval: 30
-    
+
 endpoints.health.sensitive: false
 
 #travis:
 #  enabled: true
+#  Repository sync makes a call to travis telling travis to sync repos against github.
+#  This makes new repos with builds in travis the github user has access to tracked by spinnaker.
+#  repositorySyncEnabled: true
 #  Travis names are prefixed with travis- inside igor.
 #  masters:
 #    - name: ci # This will show as travis-ci inside spinnaker.

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -80,6 +80,10 @@ class TravisBuildMonitor implements PollingMonitor{
     @Value('${spinnaker.build.pollInterval:60}')
     int pollInterval
 
+    @SuppressWarnings('GStringExpressionWithinString')
+    @Value('${travis.repositorySyncEnabled:false}')
+    Boolean repositorySyncEnabled
+
     @Override
     void onApplicationEvent(ContextRefreshedEvent event) {
         log.info('Started')
@@ -217,8 +221,12 @@ class TravisBuildMonitor implements PollingMonitor{
         }, {
         } as Action0
         )
-
         log.info("Last poll took ${System.currentTimeMillis() - lastPoll}ms (master: ${master})")
+        if (repositorySyncEnabled) {
+            startTime = System.currentTimeMillis()
+            travisService.syncRepos()
+            log.info("repositorySync: Took ${System.currentTimeMillis() - startTime}ms to sync repositories for ${master}")
+        }
         results
 
     }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -79,6 +79,9 @@ interface TravisClient {
     @Headers("Travis-API-Version: 3")
     TriggerResponse triggerBuild(@Header("Authorization") String accessToken, @Path('repoSlug') String repoSlug, @Body RepoRequest repoRequest)
 
+    @POST('/users/sync')
+    Response usersSync(@Header("Authorization") String accessToken)
+
     @GET('/jobs/{job_id}')
     Jobs jobs(@Header("Authorization") String accessToken , @Path('job_id') int jobId)
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -253,6 +253,14 @@ class TravisService implements BuildService {
         return true
     }
 
+    void syncRepos() {
+        try {
+            travisClient.usersSync(getAccessToken())
+        } catch (RetrofitError e) {
+            log.error "synchronizing travis repositories failed with error: ${e.message}"
+        }
+    }
+
     @Override
     BuildServiceProvider buildServiceProvider() {
         return BuildServiceProvider.TRAVIS


### PR DESCRIPTION
The workflow we are implementing for using travis with spinnaker at schibsted is as follows.
1. We have a spinnaker system user in github
2. To get your builds into spinnaker, you grant the spinnaker system user access to the repository

Now igor syncs travis and github for us and makes new builds appear.