### PR TITLE
Include travis master in log if repository synchronization fails

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -53,7 +53,7 @@ class TravisService implements BuildService {
     private Accounts accounts
 
     TravisService(String travisHostId, String baseUrl, String githubToken, TravisClient travisClient, TravisCache travisCache) {
-        this.groupKey     = "travis-${travisHostId}"
+        this.groupKey     = "${travisHostId}"
         this.githubToken  = githubToken
         this.travisClient = travisClient
         this.baseUrl      = baseUrl
@@ -270,7 +270,7 @@ class TravisService implements BuildService {
         try {
             travisClient.usersSync(getAccessToken())
         } catch (RetrofitError e) {
-            log.error "synchronizing travis repositories failed with error: ${e.message}"
+            log.error "synchronizing travis repositories for ${groupKey} failed with error: ${e.message}"
         }
     }
 


### PR DESCRIPTION
The groupKey does not need to prefix with `travis-`. It is already done here:
https://github.com/spinnaker/igor/blob/master/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/TravisConfig.groovy#L63