### PR TITLE
Travis - make virtual branches for pull requests

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -208,16 +208,19 @@ class TravisBuildMonitor implements PollingMonitor{
         }
         Commit commit = travisService.getCommit(repo.slug, repo.lastBuildNumber)
         if (commit) {
-            String branchedSlug = "${repo.slug}/${commit.branchNameWithTagHandling()}"
-            buildCache.setLastBuild(master, branchedSlug, repo.lastBuildNumber, repo.lastBuildState == BUILD_IN_PROGRESS)
-            if (echoService) {
-                log.info "pushing event for ${master}:${branchedSlug}:${repo.lastBuildNumber}"
+            String branchedSlug = travisService.branchedRepoSlug(repo.slug, repo.lastBuildNumber, commit)
 
-                GenericProject project = new GenericProject(branchedSlug, TravisBuildConverter.genericBuild(repo, travisService.baseUrl))
-                echoService.postEvent(
-                    new GenericBuildEvent(content: new GenericBuildContent(project: project, master: master, type: 'travis'))
-                )
+            if (branchedSlug != repo.slug) {
+                buildCache.setLastBuild(master, branchedSlug, repo.lastBuildNumber, repo.lastBuildState == BUILD_IN_PROGRESS)
+                if (echoService) {
+                    log.info "pushing event for ${master}:${branchedSlug}:${repo.lastBuildNumber}"
 
+                    GenericProject project = new GenericProject(branchedSlug, TravisBuildConverter.genericBuild(repo, travisService.baseUrl))
+                    echoService.postEvent(
+                        new GenericBuildEvent(content: new GenericBuildContent(project: project, master: master, type: 'travis'))
+                    )
+
+                }
             }
         }
     }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Build.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Build.groovy
@@ -38,6 +38,8 @@ class Build {
     String state
     @SerializedName("finished_at")
     Date finishedAt
+    @SerializedName("pull_request")
+    Boolean pullRequest
     @JsonProperty(value = "job_ids")
     List <Integer> job_ids
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -266,6 +266,23 @@ class TravisService implements BuildService {
         ).execute()
     }
 
+    String branchedRepoSlug(String repoSlug, int buildNumber, Commit commit) {
+        new SimpleHystrixCommand<String>(
+            groupKey, buildCommandKey("branchedRepoSlug"),
+            {
+                Build build = getBuild(repoSlug, buildNumber)
+                String branchedRepoSlug = "${repoSlug}/"
+                if (build.pullRequest) {
+                    branchedRepoSlug = "${branchedRepoSlug}pull_request_"
+                }
+                return "${branchedRepoSlug}${commit.branchNameWithTagHandling()}"
+            },
+            {
+                return repoSlug
+            }
+        ).execute()
+    }
+
     void syncRepos() {
         try {
             travisClient.usersSync(getAccessToken())
@@ -280,7 +297,7 @@ class TravisService implements BuildService {
     }
 
     protected String branchFromRepoSlug(String inputRepoSlug) {
-        return inputRepoSlug.tokenize('/').drop(2).join('/')
+        return inputRepoSlug.tokenize('/').drop(2).join('/') - "pull_request_"
     }
 
     private void setAccessToken() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -79,7 +79,7 @@ class TravisBuildMonitorSpec extends Specification {
         then:
         1 * travisService.getReposForAccounts() >> repos
         1 * travisService.getCommit('test-org/test-repo', 4) >> commit
-        1 * commit.branchNameWithTagHandling() >> "my_branch"
+        1 * travisService.branchedRepoSlug('test-org/test-repo', 4, commit) >> "test-org/test-repo/my_branch"
 
         1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo') >> [lastBuildLabel: 3]
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false)


### PR DESCRIPTION
We discovered that pull request builds are registered as the branch you do the pull request against with `"pull_request":true` in the [response](https://docs.travis-ci.com/api#builds) from travis. This pull request makes igor identify these pull requests and creates virtual branches for the target branches. A pull request to master will be registered to spinnaker as the branch `pull_request_master`.

The idea behind this is that you can create pipelines in spinnaker that listens to pull requests and run more test on them than you do in travis. You can bake and deploy them to check them out.

The current code in igor will let pull requests trigger pipelines that listens on the target branch for the pull request.