### PR TITLE
Set TTL on BuildCache items for travis.

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildCache.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildCache.groovy
@@ -69,12 +69,31 @@ class BuildCache {
         convertedResult
     }
 
+    Long getTTL(String master, String job) {
+        Jedis resource = jedisPool.resource
+        Long ttl = resource.ttl(makeKey(master, job))
+        jedisPool.returnResource(resource)
+        return ttl
+    }
+
+    void setTTL(String master, String job, int ttl) {
+        Jedis resource = jedisPool.resource
+        resource.expire(makeKey(master, job), ttl)
+        jedisPool.returnResource(resource)
+    }
+
+
     void setLastBuild(String master, String job, int lastBuild, boolean building) {
         Jedis resource = jedisPool.resource
         String key = makeKey(master, job)
         resource.hset(key, 'lastBuildLabel', lastBuild as String)
         resource.hset(key, 'lastBuildBuilding', building as String)
         jedisPool.returnResource(resource)
+    }
+
+    void setLastBuild(String master, String job, int lastBuild, boolean building, int ttl) {
+        setLastBuild(master, job, lastBuild, building)
+        setTTL(master, job, ttl)
     }
 
     void remove(String master, String job) {


### PR DESCRIPTION
This PR makes all writes from TravisBuildMonitor to BuildCache
include a TTL. The TTL defaults to 60 days and can be overridden
by the property travis.cachedJobTTLDays.

setBuildCacheTTL() is called every time TravisBuildMonitor starts
(igor starts) that checks is all jobs in the BuildCache has ttl
set. If not, it will set it.