### PR TITLE
Travis - consider 'created' as a running state

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverter.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverter.groovy
@@ -48,6 +48,19 @@ class TravisResultConverter {
                 throw new IllegalArgumentException("state: ${state} is not known to TravisResultConverter.")
                 break
         }
+    }
 
+    static Boolean running(String state) {
+        switch (state) {
+            case "created":
+                return true
+                break
+            case "started":
+                return true
+                break
+            default:
+                return false
+                break
+        }
     }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverterTest.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverterTest.groovy
@@ -18,22 +18,32 @@ package com.netflix.spinnaker.igor.travis.service
 
 import com.netflix.spinnaker.igor.build.model.Result
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class TravisResultConverterTest extends Specification {
-    def "convert travis build states to Result object"() {
-        setup:
-        def state = travisBuildState
 
-        when:
-        Result result = TravisResultConverter.getResultFromTravisState(state)
-
-        then:
-        result == expectedResult
+    @Unroll
+    def "convert travis build states to Result object state='#travisBuildState' should give Result=#expectedResult"() {
+        expect:
+        TravisResultConverter.getResultFromTravisState(travisBuildState) == expectedResult
 
         where:
-        travisBuildState | expectedResult
-        "started"    | Result.BUILDING
-        "passed"     | Result.SUCCESS
-        "errored"    | Result.FAILURE
+        travisBuildState || expectedResult
+        "started"        || Result.BUILDING
+        "passed"         || Result.SUCCESS
+        "errored"        || Result.FAILURE
+    }
+
+    @Unroll
+    def "check if build is running state='#travisBuildState' should give running=#expectedResult"() {
+        expect:
+        TravisResultConverter.running(travisBuildState) == expectedResult
+
+        where:
+        travisBuildState || expectedResult
+        "started"        || true
+        "created"        || true
+        "passed"         || false
+        "errored"        || false
     }
 }


### PR DESCRIPTION
The TravisBuildMonitor only considers started as running as it is now. This PR makes igor aware of the `created` state and translates that into a running build as well.

This is an edge case that I have not seen in travis, but I'm sure we will see it some day.