### PR TITLE
Filter build lists from travis

### DIFF
--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
@@ -329,7 +329,7 @@ class TravisClientSpec extends Specification {
         Builds builds = client.builds("someToken", "org/repo", 39)
 
         then:
-        builds.commits.first().isTag() == true
+        builds.commits.first().isTag()
 
     }
 


### PR DESCRIPTION
This makes the build list from travis only show builds relevant to your choosen branch
when you trigger pipelines from deck.

* If you have choosen to listen to a specific branch, only builds of that branch shows up.
* If you have choosen to listen to the virtual branch tags, only tag builds shows up.
* If you listen to PRs against a specific branch, only PR builds shows up.
* If you listen to all builds (org/repo), all the builds show up.