### PR TITLE
Ignore travis builds that are older than the travis cache TTL

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/TravisConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/TravisConfig.groovy
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.igor.config
 import com.netflix.spinnaker.igor.service.BuildMasters
 import com.netflix.spinnaker.igor.travis.TravisCache
 import com.netflix.spinnaker.igor.travis.client.TravisClient
-import com.netflix.spinnaker.igor.travis.client.model.Build
 import com.netflix.spinnaker.igor.travis.service.TravisService
 import com.squareup.okhttp.OkHttpClient
 import groovy.transform.CompileStatic

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -74,6 +74,8 @@ class TravisBuildMonitor implements PollingMonitor{
 
     static final int NEW_BUILD_EVENT_THRESHOLD = 1
 
+    static final long BUILD_STARTED_AT_THRESHOLD = TimeUnit.SECONDS.toMillis(30)
+
     @SuppressWarnings('GStringExpressionWithinString')
     @Value('${spinnaker.build.pollInterval:60}')
     int pollInterval
@@ -140,7 +142,7 @@ class TravisBuildMonitor implements PollingMonitor{
 
         lastPoll = System.currentTimeMillis()
         def startTime = System.currentTimeMillis()
-        List<Repo> repos = travisService.getReposForAccounts()
+        List<Repo> repos = filterOutOldBuilds(travisService.getReposForAccounts())
         log.info("Took ${System.currentTimeMillis() - startTime}ms to retrieve ${repos.size()} repositories (master: ${master})")
 
         Observable.from(repos).subscribe(
@@ -253,5 +255,18 @@ class TravisBuildMonitor implements PollingMonitor{
 
     private int buildCacheJobTTLSeconds() {
         return TimeUnit.DAYS.toSeconds(cachedJobTTLDays)
+    }
+
+    private List<Repo> filterOutOldBuilds(List<Repo> repos){
+        /*
+        BUILD_STARTED_AT_THRESHOLD is here because the builds can be picked up by igor before lastBuildStartedAt is
+        set. This means the TTL can be set in the BuildCache before lastBuildStartedAt, if that happens we need a
+        grace threshold so that we don't resend the event to echo. The value of the threshold assumes that travis
+        will set the lastBuildStartedAt within 30 seconds.
+         */
+        Long threshold = new Date().getTime() - TimeUnit.DAYS.toMillis(cachedJobTTLDays) + BUILD_STARTED_AT_THRESHOLD
+        return repos.findAll({ repo ->
+            repo.lastBuildStartedAt?.getTime() > threshold
+        })
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -160,12 +160,6 @@ class TravisService implements BuildService {
         return list
     }
 
-    List<Repo> getRepos() {
-        Repos repos = travisClient.repos(getAccessToken())
-        log.debug "fetched " + repos.repos.size() + " repos"
-        return repos.repos
-    }
-
     Commit getCommit(String repoSlug, int buildNumber) {
         Builds builds = getBuilds(repoSlug, buildNumber)
         if (builds?.commits) {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
@@ -115,7 +115,7 @@ class TravisClientSpec extends Specification {
         setResponse '''{"repos":[{"id":8059977,"slug":"gardalize/travistest","description":"testing travis stuff","last_build_id":118583435,"last_build_number":"5","last_build_state":"passed","last_build_duration":39,"last_build_language":null,"last_build_started_at":"2016-03-25T22:29:44Z","last_build_finished_at":"2016-03-25T22:30:23Z","active":true,"github_language":"Ruby"}]}'''
 
         when:
-        Repos repos = client.repos("someToken")
+        Repos repos = client.repos("someToken", "gardalize")
 
         then:
         repos.repos.first().id   == 8059977


### PR DESCRIPTION
If the travis api returns old builds when the travisBuildMonitor fetches builds, we need to filter them out so that we don't get another event pushed to echo after the TTL has ran out.