### PR TITLE
docker: Log changes to digests

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -101,11 +101,11 @@ class DockerMonitor implements PollingMonitor {
                     def digest = cache.getLastDigest(image.account, image.registry, image.repository, image.tag)
 
                     if (digest != image.digest) {
-                        log.info "Updated tagged image: ${image.account}: ${imageId}"
+                        log.info "Updated tagged image: ${image.account}: ${imageId}. Digest changed from [$digest] -> [$image.digest]."
                         updateCache = true
                     }
                 } else {
-                    log.info "New tagged image: ${image.account}: ${imageId}"
+                    log.info "New tagged image: ${image.account}: ${imageId}. Digest is now [$image.digest]."
                     updateCache = true
                 }
 


### PR DESCRIPTION
This will simplify tracking down the spurious trigger cause, and should be logged anyhow for traceabilty into what was deployed.

@duftler 