### PR TITLE
bump spinnaker dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
     apply plugin: 'groovy'
 
     spinnaker {
-        dependenciesVersion = "0.20.0"
+        dependenciesVersion = "0.37.0"
     }
     test {
       testLogging {

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -28,8 +28,8 @@ dependencies {
     compile spinnaker.dependency("okHttp")
 
     compile 'org.yaml:snakeyaml:1.15'
-    compile 'com.squareup.retrofit:converter-simplexml:1.5.1'
-    testCompile 'com.squareup.okhttp:mockwebserver:2.1.0'
+    compile 'com.squareup.retrofit:converter-simplexml:1.9.0'
+    testCompile 'com.squareup.okhttp:mockwebserver:2.7.0'
 }
 
 configurations.all {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -119,14 +119,14 @@ class BuildController {
         // Jobs that haven't been started yet won't have a buildNumber
         // (They're still in the queue). We use 0 to denote that case
         if (buildNumber != 0) {
-            jenkinsService.stopRunningBuild(jobName, buildNumber)
+            jenkinsService.stopRunningBuild(jobName, buildNumber, "")
         }
 
         // The jenkins api for removing a job from the queue (http://<Jenkins_URL>/queue/cancelItem?id=<queuedBuild>)
         // always returns a 404. This try catch block insures that the exception is eaten instead
         // of being handled by the handleOtherException handler and returning a 500 to orca
         try {
-            jenkinsService.stopQueuedBuild(queuedBuild)
+            jenkinsService.stopQueuedBuild(queuedBuild, "")
         } catch (RetrofitError e) {
             if (e.response?.status != HttpStatus.NOT_FOUND.value()) {
                 throw e
@@ -151,12 +151,12 @@ class BuildController {
                 validateJobParameters(jobConfig, requestParams)
             }
             if (requestParams && jobConfig.parameterDefinitionList?.size() > 0) {
-                response = jenkinsService.buildWithParameters(job, requestParams)
+                response = jenkinsService.buildWithParameters(job, requestParams, "")
             } else if (!requestParams && jobConfig.parameterDefinitionList?.size() > 0) {
                 // account for when you just want to fire a job with the default parameter values by adding a dummy param
-                response = jenkinsService.buildWithParameters(job, ['startedBy': "igor"])
+                response = jenkinsService.buildWithParameters(job, ['startedBy': "igor"], "")
             } else if (!requestParams && (!jobConfig.parameterDefinitionList || jobConfig.parameterDefinitionList.size() == 0)) {
-                response = jenkinsService.build(job)
+                response = jenkinsService.build(job, "")
             } else { // Jenkins will reject the build, so don't even try
                 // we should throw a BuildJobError, but I get a bytecode error : java.lang.VerifyError: Bad <init> method call from inside of a branch
                 throw new RuntimeException("job : ${job}, passing params to a job which doesn't need them")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.igor.jenkins.client.model.ProjectsList
 import com.netflix.spinnaker.igor.jenkins.client.model.QueuedJob
 import com.netflix.spinnaker.igor.jenkins.client.model.ScmDetails
 import retrofit.client.Response
+import retrofit.http.Body
 import retrofit.http.EncodedPath
 import retrofit.http.GET
 import retrofit.http.POST
@@ -68,16 +69,16 @@ interface JenkinsClient {
     QueuedJob getQueuedItem(@Path('itemNumber') Integer item)
 
     @POST('/job/{jobName}/build')
-    Response build(@EncodedPath('jobName') String jobName)
+    Response build(@EncodedPath('jobName') String jobName, @Body String emptyRequest)
 
     @POST('/job/{jobName}/buildWithParameters')
-    Response buildWithParameters(@EncodedPath('jobName') String jobName, @QueryMap Map<String, String> queryParams)
+    Response buildWithParameters(@EncodedPath('jobName') String jobName, @QueryMap Map<String, String> queryParams, @Body String EmptyRequest)
 
     @POST('/job/{jobName}/{buildNumber}/stop')
-    Response stopRunningBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
+    Response stopRunningBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber,  @Body String EmptyRequest)
 
     @POST('/queue/cancelItem')
-    Response stopQueuedBuild(@Query('id') String queuedBuild)
+    Response stopQueuedBuild(@Query('id') String queuedBuild, @Body String emptyRequest)
 
     @GET('/job/{jobName}/api/xml?exclude=/*/action&exclude=/*/build&exclude=/*/property[not(parameterDefinition)]')
     JobConfig getJobConfig(@EncodedPath('jobName') String jobName)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
@@ -122,11 +122,11 @@ class JenkinsService implements BuildService{
     }
 
     Response build(String jobName) {
-        return jenkinsClient.build(encode(jobName))
+        return jenkinsClient.build(encode(jobName), "")
     }
 
     Response buildWithParameters(String jobName, Map<String, String> queryParams) {
-        return jenkinsClient.buildWithParameters(encode(jobName), queryParams)
+        return jenkinsClient.buildWithParameters(encode(jobName), queryParams, "")
     }
 
     JobConfig getJobConfig(String jobName) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.igor.travis.client.model.RepoRequest
 import com.netflix.spinnaker.igor.travis.client.model.RepoWrapper
 import com.netflix.spinnaker.igor.travis.client.model.Repos
 import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse
+import com.squareup.okhttp.RequestBody
 import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.EncodedPath
@@ -40,7 +41,7 @@ import retrofit.http.Streaming
 interface TravisClient {
 
     @POST('/auth/github')
-    AccessToken accessToken(@Query('github_token') String githubToken)
+    AccessToken accessToken(@Query('github_token') String githubToken, @Body String emptyBody)
 
     @GET('/accounts')
     Accounts accounts(@Header("Authorization") String accessToken)
@@ -80,7 +81,7 @@ interface TravisClient {
     TriggerResponse triggerBuild(@Header("Authorization") String accessToken, @Path('repoSlug') String repoSlug, @Body RepoRequest repoRequest)
 
     @POST('/users/sync')
-    Response usersSync(@Header("Authorization") String accessToken)
+    Response usersSync(@Header("Authorization") String accessToken, @Body emptySting)
 
     @GET('/jobs/{job_id}')
     Jobs jobs(@Header("Authorization") String accessToken , @Path('job_id') int jobId)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -300,7 +300,7 @@ class TravisService implements BuildService {
 
     void syncRepos() {
         try {
-            travisClient.usersSync(getAccessToken())
+            travisClient.usersSync(getAccessToken(), "")
         } catch (RetrofitError e) {
             log.error "synchronizing travis repositories for ${groupKey} failed with error: ${e.message}"
         }
@@ -328,7 +328,7 @@ class TravisService implements BuildService {
     }
 
     private void setAccessToken() {
-        this.accessToken = travisClient.accessToken(githubToken)
+        this.accessToken = travisClient.accessToken(githubToken, "")
     }
 
     private String getAccessToken() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -44,6 +44,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 
 import java.util.concurrent.Executors
 
@@ -162,7 +163,7 @@ class BuildControllerSpec extends Specification {
     void 'trigger a build without parameters'() {
         given:
         1 * client.getJobConfig(JOB_NAME) >> new JobConfig()
-        1 * client.build(JOB_NAME) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${BUILD_NUMBER}")], null)
+        1 * client.build(JOB_NAME, "") >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${BUILD_NUMBER}")], null)
 
         when:
         MockHttpServletResponse response = mockMvc.perform(put("/masters/${MASTER}/jobs/${JOB_NAME}")
@@ -178,7 +179,7 @@ class BuildControllerSpec extends Specification {
     void 'trigger a build with parameters to a job with parameters'() {
         given:
         1 * client.getJobConfig(JOB_NAME) >> new JobConfig(parameterDefinitionList: [new ParameterDefinition(defaultName: "name", defaultValue: null, description: "description")])
-        1 * client.buildWithParameters(JOB_NAME,[name:"myName"]) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${BUILD_NUMBER}")], null)
+        1 * client.buildWithParameters(JOB_NAME,[name:"myName"], "") >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${BUILD_NUMBER}")], null)
 
         when:
         MockHttpServletResponse response = mockMvc.perform(put("/masters/${MASTER}/jobs/${JOB_NAME}")
@@ -193,11 +194,11 @@ class BuildControllerSpec extends Specification {
     void 'trigger a build without parameters to a job with parameters with default values'() {
         given:
         1 * client.getJobConfig(JOB_NAME) >> new JobConfig(parameterDefinitionList: [new ParameterDefinition(defaultName: "name", defaultValue: "value", description: "description")])
-        1 * client.buildWithParameters(JOB_NAME, ['startedBy' : "igor"]) >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${BUILD_NUMBER}")], null)
+        1 * client.buildWithParameters(JOB_NAME, ['startedBy' : "igor"], "") >> new Response("http://test.com", HTTP_201, "", [new Header("Location","foo/${BUILD_NUMBER}")], null)
 
 
         when:
-        MockHttpServletResponse response = mockMvc.perform(put("/masters/${MASTER}/jobs/${JOB_NAME}")
+        MockHttpServletResponse response = mockMvc.perform(put("/masters/${MASTER}/jobs/${JOB_NAME}", "")
           .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -123,7 +123,7 @@ class InfoControllerSpec extends Specification {
                 .setBody(body)
                 .setHeader('Content-Type', 'text/xml;charset=UTF-8')
         )
-        server.play()
+        server.start()
         service = new JenkinsConfig().jenkinsService("jenkins", new JenkinsConfig().jenkinsClient(server.getUrl('/').toString(), 'username', 'password'))
     }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClientSpec.groovy
@@ -191,7 +191,7 @@ class JenkinsClientSpec extends Specification {
         setResponse("")
 
         when:
-        def response = client.build("My-Build")
+        def response = client.build("My-Build", "")
 
         then:
         response
@@ -203,7 +203,7 @@ class JenkinsClientSpec extends Specification {
         setResponse("")
 
         when:
-        def response = client.buildWithParameters("My-Build", [foo:"bar", key:"value"])
+        def response = client.buildWithParameters("My-Build", [foo:"bar", key:"value"], "")
 
         then:
         response
@@ -215,7 +215,7 @@ class JenkinsClientSpec extends Specification {
                 .setBody(body)
                 .setHeader('Content-Type', 'text/xml;charset=UTF-8')
         )
-        server.play()
+        server.start()
         client = new JenkinsConfig().jenkinsClient(server.getUrl('/').toString(), 'username', 'password')
     }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
@@ -47,7 +47,7 @@ class JenkinsServiceSpec extends Specification {
                 .setBody(getProjects())
                 .setHeader('Content-Type', 'text/xml;charset=UTF-8')
         )
-        server.play()
+        server.start()
         client = Mock(JenkinsClient)
         service = new JenkinsService('http://my.jenkins.net', client)
     }
@@ -79,9 +79,29 @@ class JenkinsServiceSpec extends Specification {
         'getBuild'            | [2]
         'getGitDetails'       | [2]
         'getLatestBuild'      | []
+        'getJobConfig'        | []
+    }
+
+    @Unroll
+    void 'the "#method" method with empty post encodes the job name'() {
+        when:
+        if (extra_args) {
+            service."${method}"(JOB_UNENCODED, *extra_args)
+        } else {
+            service."${method}"(JOB_UNENCODED)
+        }
+
+        then:
+        if (extra_args) {
+            1 * client."${method}"(JOB_ENCODED, *extra_args, '')
+        } else {
+            1 * client."${method}"(JOB_ENCODED, '')
+        }
+
+        where:
+        method                | extra_args
         'build'               | []
         'buildWithParameters' | [['key': 'value']]
-        'getJobConfig'        | []
     }
 
     void 'get a list of projects with the folders plugin'() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/github/client/GitHubClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/github/client/GitHubClientSpec.groovy
@@ -48,7 +48,7 @@ class GitHubClientSpec extends Specification {
                 .setBody(body)
                 .setHeader('Content-Type', 'text/xml;charset=UTF-8')
         )
-        server.play()
+        server.start()
         client = new GitHubConfig().gitHubClient(server.getUrl('/').toString(), 'token')
     }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/client/StashClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/client/StashClientSpec.groovy
@@ -48,7 +48,7 @@ class StashClientSpec extends Specification {
                 .setBody(body)
                 .setHeader('Content-Type', 'text/xml;charset=UTF-8')
         )
-        server.play()
+        server.start()
         client = new StashConfig().stashClient(server.getUrl('/').toString(), 'username', 'password')
     }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
@@ -56,7 +56,7 @@ class TravisClientSpec extends Specification {
         setResponse '''{"access_token":"aCCeSSToKeN"}'''
 
         when:
-        AccessToken accessToken = client.accessToken("foo")
+        AccessToken accessToken = client.accessToken("foo", "")
 
         then:
         accessToken.accessToken == "aCCeSSToKeN"
@@ -381,7 +381,7 @@ class TravisClientSpec extends Specification {
                 .setBody(body)
                 .setHeader('Content-Type', 'application/json;charset=utf-8')
         )
-        server.play()
+        server.start()
         client = new TravisConfig().travisClient(server.getUrl('/').toString())
     }
 
@@ -391,7 +391,7 @@ class TravisClientSpec extends Specification {
                 .setBody(body)
                 .setHeader('Content-Type', 'text/plain;charset=utf-8')
         )
-        server.play()
+        server.start()
         client = new TravisConfig().travisClient(server.getUrl('/').toString())
 
     }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -131,7 +131,7 @@ class TravisServiceSpec extends Specification{
 
         then:
         fetchedCommit.isTag()
-        1 * client.accessToken("someToken") >> accessToken
+        1 * client.accessToken("someToken", "") >> accessToken
         1 * client.builds("token someToken", "org/repo", 38) >> builds
         2 * builds.commits >> [commit]
     }
@@ -147,7 +147,7 @@ class TravisServiceSpec extends Specification{
 
         then:
         thrown NoSuchFieldException
-        1 * client.accessToken("someToken") >> accessToken
+        1 * client.accessToken("someToken", "") >> accessToken
         1 * client.builds("token someToken", "org/repo", 38) >> builds
         1 * builds.commits >> []
     }
@@ -165,7 +165,7 @@ class TravisServiceSpec extends Specification{
 
         then:
         branchedRepoSlug == "my/slug/pull_request_master"
-        1 * client.accessToken("someToken") >> accessToken
+        1 * client.accessToken("someToken", "") >> accessToken
         1 * client.builds("token someToken", "my/slug", 21) >> builds
         2 * builds.builds >> [build]
         1 * build.pullRequest >> true


### PR DESCRIPTION
- okhttp requires posts to not have an empty body, so existing @POST methods were modified to accommodate this.
- okhttp mock server method changed from .play() to .start()
