### PR TITLE
Travis - Add support for packagecloud uploads

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/logparser/ArtifactParser.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/logparser/ArtifactParser.groovy
@@ -23,14 +23,20 @@ import groovy.util.logging.Slf4j
 @CompileStatic
 @Slf4j
 class ArtifactParser {
+
+    static def REGEXES = [ /Uploading artifact: https?:\/\/.+\/(.+\.(deb|rpm)).*/,
+                          /Successfully pushed (.+\.(deb|rpm)) to .*/ ]
+
     static List<GenericArtifact> getArtifactsFromLog(String buildLog) {
         List<GenericArtifact> artifacts = new ArrayList<GenericArtifact>()
         buildLog.split('\n').each { line ->
             def m
-            if ((m = line =~ /Uploading artifact: https?:\/\/.+\/(.+\.(deb|rpm)).*/)) {
-                def match = m.group(1)
-                log.debug "Found artifact: ${match}"
-                artifacts.add new GenericArtifact(match,match,match)
+            for (def regex : REGEXES) {
+                if ((m = line =~ regex)) {
+                    def match = m.group(1)
+                    log.debug "Found artifact: ${match}"
+                    artifacts.add new GenericArtifact(match,match,match)
+                }
             }
         }
         artifacts


### PR DESCRIPTION
This adds support for [packagecloud uploads](https://docs.travis-ci.com/user/deployment/packagecloud).