### PR TITLE
Travis integration fixes for dealing with new version of okhttp

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -20,13 +20,14 @@ import com.netflix.spinnaker.igor.travis.client.model.AccessToken
 import com.netflix.spinnaker.igor.travis.client.model.Accounts
 import com.netflix.spinnaker.igor.travis.client.model.Build
 import com.netflix.spinnaker.igor.travis.client.model.Builds
+import com.netflix.spinnaker.igor.travis.client.model.EmptyObject
+import com.netflix.spinnaker.igor.travis.client.model.GithubAuth
 import com.netflix.spinnaker.igor.travis.client.model.Jobs
 import com.netflix.spinnaker.igor.travis.client.model.Repo
 import com.netflix.spinnaker.igor.travis.client.model.RepoRequest
 import com.netflix.spinnaker.igor.travis.client.model.RepoWrapper
 import com.netflix.spinnaker.igor.travis.client.model.Repos
 import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse
-import com.squareup.okhttp.RequestBody
 import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.EncodedPath
@@ -41,7 +42,7 @@ import retrofit.http.Streaming
 interface TravisClient {
 
     @POST('/auth/github')
-    AccessToken accessToken(@Query('github_token') String githubToken, @Body String emptyBody)
+    AccessToken accessToken(@Body GithubAuth gitHubAuth)
 
     @GET('/accounts')
     Accounts accounts(@Header("Authorization") String accessToken)
@@ -81,7 +82,7 @@ interface TravisClient {
     TriggerResponse triggerBuild(@Header("Authorization") String accessToken, @Path('repoSlug') String repoSlug, @Body RepoRequest repoRequest)
 
     @POST('/users/sync')
-    Response usersSync(@Header("Authorization") String accessToken, @Body emptySting)
+    Response usersSync(@Header("Authorization") String accessToken, @Body EmptyObject emptyObject)
 
     @GET('/jobs/{job_id}')
     Jobs jobs(@Header("Authorization") String accessToken , @Path('job_id') int jobId)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/EmptyObject.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/EmptyObject.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model
+
+import groovy.transform.CompileStatic
+import org.simpleframework.xml.Default
+
+@Default
+@CompileStatic
+class EmptyObject {
+    /*
+      Because okhttp requires a Body when doing post requests, we need
+      this one to send an empty body to travis when syncing repositories.
+     */
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/GithubAuth.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/GithubAuth.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model
+
+import com.google.gson.annotations.SerializedName
+import org.simpleframework.xml.Default
+
+@Default
+class GithubAuth {
+
+    @SerializedName("github_token")
+    String githubToken
+
+    GithubAuth(String githubToken) {
+        this.githubToken = githubToken
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -31,6 +31,8 @@ import com.netflix.spinnaker.igor.travis.client.model.Accounts
 import com.netflix.spinnaker.igor.travis.client.model.Build
 import com.netflix.spinnaker.igor.travis.client.model.Builds
 import com.netflix.spinnaker.igor.travis.client.model.Commit
+import com.netflix.spinnaker.igor.travis.client.model.EmptyObject
+import com.netflix.spinnaker.igor.travis.client.model.GithubAuth
 import com.netflix.spinnaker.igor.travis.client.model.Job
 import com.netflix.spinnaker.igor.travis.client.model.Jobs
 import com.netflix.spinnaker.igor.travis.client.model.Repo
@@ -46,15 +48,15 @@ import retrofit.mime.TypedByteArray
 class TravisService implements BuildService {
     final String baseUrl
     final String groupKey
-    final String githubToken
+    final GithubAuth gitHubAuth
     final TravisClient travisClient
     final TravisCache travisCache
-    private AccessToken accessToken
+    protected AccessToken accessToken
     private Accounts accounts
 
     TravisService(String travisHostId, String baseUrl, String githubToken, TravisClient travisClient, TravisCache travisCache) {
         this.groupKey     = "${travisHostId}"
-        this.githubToken  = githubToken
+        this.gitHubAuth   = new GithubAuth(githubToken)
         this.travisClient = travisClient
         this.baseUrl      = baseUrl
         this.travisCache  = travisCache
@@ -300,7 +302,7 @@ class TravisService implements BuildService {
 
     void syncRepos() {
         try {
-            travisClient.usersSync(getAccessToken(), "")
+            travisClient.usersSync(getAccessToken(), new EmptyObject())
         } catch (RetrofitError e) {
             log.error "synchronizing travis repositories for ${groupKey} failed with error: ${e.message}"
         }
@@ -328,7 +330,7 @@ class TravisService implements BuildService {
     }
 
     private void setAccessToken() {
-        this.accessToken = travisClient.accessToken(githubToken, "")
+        this.accessToken = travisClient.accessToken(gitHubAuth)
     }
 
     private String getAccessToken() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.igor.travis.client.model.Account
 import com.netflix.spinnaker.igor.travis.client.model.Accounts
 import com.netflix.spinnaker.igor.travis.client.model.Build
 import com.netflix.spinnaker.igor.travis.client.model.Builds
+import com.netflix.spinnaker.igor.travis.client.model.GithubAuth
 import com.netflix.spinnaker.igor.travis.client.model.Job
 import com.netflix.spinnaker.igor.travis.client.model.Jobs
 import com.netflix.spinnaker.igor.travis.client.model.RepoRequest
@@ -56,7 +57,7 @@ class TravisClientSpec extends Specification {
         setResponse '''{"access_token":"aCCeSSToKeN"}'''
 
         when:
-        AccessToken accessToken = client.accessToken("foo", "")
+        AccessToken accessToken = client.accessToken(new GithubAuth("foo"))
 
         then:
         accessToken.accessToken == "aCCeSSToKeN"

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -38,6 +38,10 @@ class TravisServiceSpec extends Specification{
     void setup() {
         client = Mock(TravisClient)
         service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', client, null)
+
+        AccessToken accessToken = new AccessToken()
+        accessToken.accessToken = "someToken"
+        service.accessToken = accessToken
     }
 
     def "getGenericBuild(build, repoSlug)" () {
@@ -123,15 +127,12 @@ class TravisServiceSpec extends Specification{
         commit.branch = "1.0"
         commit.compareUrl = "https://github.domain/org/repo/compare/1.0"
         Builds builds = Mock(Builds)
-        AccessToken accessToken = new AccessToken()
-        accessToken.accessToken = "someToken"
 
         when:
         Commit fetchedCommit = service.getCommit("org/repo", 38)
 
         then:
         fetchedCommit.isTag()
-        1 * client.accessToken("someToken", "") >> accessToken
         1 * client.builds("token someToken", "org/repo", 38) >> builds
         2 * builds.commits >> [commit]
     }
@@ -139,15 +140,12 @@ class TravisServiceSpec extends Specification{
     def "getCommit(repoSlug, buildNumber) when no commit is found"() {
         given:
         Builds builds = Mock(Builds)
-        AccessToken accessToken = new AccessToken()
-        accessToken.accessToken = "someToken"
 
         when:
         service.getCommit("org/repo", 38)
 
         then:
         thrown NoSuchFieldException
-        1 * client.accessToken("someToken", "") >> accessToken
         1 * client.builds("token someToken", "org/repo", 38) >> builds
         1 * builds.commits >> []
     }
@@ -156,8 +154,6 @@ class TravisServiceSpec extends Specification{
         given:
         Builds builds = Mock(Builds)
         Build build = Mock(Build)
-        AccessToken accessToken = new AccessToken()
-        accessToken.accessToken = "someToken"
         Commit commit = Mock(Commit)
 
         when:
@@ -165,7 +161,6 @@ class TravisServiceSpec extends Specification{
 
         then:
         branchedRepoSlug == "my/slug/pull_request_master"
-        1 * client.accessToken("someToken", "") >> accessToken
         1 * client.builds("token someToken", "my/slug", 21) >> builds
         2 * builds.builds >> [build]
         1 * build.pullRequest >> true


### PR DESCRIPTION
The new version of okhttp does not allow empty bodies on POST requests.
These changes makes the travis integration work again.