### PR TITLE
fix poller names in health check

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/health/PollingMonitorHealth.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/health/PollingMonitorHealth.groovy
@@ -40,17 +40,17 @@ public class PollingMonitorHealth implements HealthIndicator {
         pollers.forEach { poller ->
             if (poller.isInService()) {
                 if (poller.lastPoll == null) {
-                    healths << Health.unknown().withDetail('${poller.name}.status', 'not polling yet').build()
+                    healths << Health.unknown().withDetail("${poller.name}.status", 'not polling yet').build()
                 } else {
                     // Check if twice the polling interval has elapsed.
                     if (System.currentTimeMillis() - poller.lastPoll > (poller.pollInterval * 2 * DateTimeConstants.MILLIS_PER_SECOND)) {
-                        healths << Health.down().withDetail('${poller.name}.status', 'stopped').withDetail('${poller.name}.lastPoll', poller.lastPoll.toString()).build()
+                        healths << Health.down().withDetail("${poller.name}.status", 'stopped').withDetail("${poller.name}.lastPoll", poller.lastPoll.toString()).build()
                     } else {
-                        healths << Health.up().withDetail('${poller.name}.status', 'running').withDetail('${poller.name}.lastPoll', poller.lastPoll.toString()).build()
+                        healths << Health.up().withDetail("${poller.name}.status", 'running').withDetail("${poller.name}.lastPoll", poller.lastPoll.toString()).build()
                     }
                 }
             } else {
-                healths << Health.unknown().withDetail('${poller.name}.status', 'not in service').build()
+                healths << Health.unknown().withDetail("${poller.name}.status", 'not in service').build()
             }
 
         }


### PR DESCRIPTION
in groovy, ${ value } within single quotes don't get evaluated, this PR renders the names of the pollers correctly in the health check