### PR TITLE
Update logrotate file permissions

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -111,6 +111,7 @@ ospackage {
     into('/etc/logrotate.d')
     user = 'root'
     permissionGroup = 'root'
+    fileMode = 0644
     fileType = CONFIG | NOREPLACE
   }
 }


### PR DESCRIPTION
This change will fix problems where logrotate ignores
/etc/logrotate.d/igor due to 'bad file mode.'

For Spinnaker issue [#904](https://github.com/spinnaker/spinnaker/issues/904)