### PR TITLE
Travis - make igor able to override multiple properties in build

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -98,7 +98,10 @@ class TravisService implements BuildService {
         Repo repo = getRepo(repoSlug)
         String branch = branchFromRepoSlug(inputRepoSlug)
         RepoRequest repoRequest = new RepoRequest(branch.empty? "master" : branch)
+        Build build = getBuilds(repo).first()
+
         repoRequest.config = new Config(queryParameters)
+        repoRequest.config.globalEnv = repoRequest.config.globalEnv.plus(build.config.secrets)
 
         TriggerResponse triggerResponse = travisClient.triggerBuild(getAccessToken(), repoSlug, repoRequest)
         if (triggerResponse.remainingRequests) {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
@@ -297,7 +297,7 @@ class TravisClientSpec extends Specification {
                 "pull_request_number": null,
                 "config": {
                     "language": "python",
-                    "env": ["TARGET_ENV=test.environment"],
+                    "global_env": ["TARGET_ENV=test.environment"],
                     "script": "./travis.sh",
                     ".result": "configured",
                     "group": "stable",
@@ -330,8 +330,8 @@ class TravisClientSpec extends Specification {
         then:
         Build build = builds.builds.first()
         build.number == 3
-        build.config.env.size() == 1
-        build.config.env.first() == "TARGET_ENV=test.environment"
+        build.config.globalEnv.size() == 1
+        build.config.globalEnv.first() == "TARGET_ENV=test.environment"
     }
 
     def "getBuilds(accessToken, repoSlug, buildNumber) with no build found"() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/model/ConfigSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/model/ConfigSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.igor.travis.client.model
 
 import com.netflix.spinnaker.igor.build.model.GenericParameterDefinition
 import spock.lang.Specification
+import spock.lang.Unroll
 
 
 class ConfigSpec extends Specification {
@@ -25,7 +26,7 @@ class ConfigSpec extends Specification {
     def "getGenericParameterDefinitionList extracts travis environment variables"() {
         given:
         Config config = new Config([:])
-        config.env = [ "FOO=bar", "BAR=foo"]
+        config.globalEnv = [ "FOO=bar", "BAR=foo" ]
 
         when:
         List<GenericParameterDefinition> genericParameterDefinitionList = config.getParameterDefinitionList()
@@ -39,7 +40,7 @@ class ConfigSpec extends Specification {
     def "getGenericParameterDefinitionList handles null"() {
         given:
         Config config = new Config([:])
-        config.env = null
+        config.globalEnv = null
 
         when:
         List<GenericParameterDefinition> genericParameterDefinitionList = config.getParameterDefinitionList()
@@ -63,7 +64,7 @@ class ConfigSpec extends Specification {
     def "getGenericParameterDefinitionList handles = in value"() {
         given:
         Config config = new Config([:])
-        config.env = [ 'FOO="foo=bar"']
+        config.globalEnv = ['FOO="foo=bar"']
 
         when:
         List<GenericParameterDefinition> genericParameterDefinitionList = config.getParameterDefinitionList()
@@ -71,6 +72,23 @@ class ConfigSpec extends Specification {
         then:
         genericParameterDefinitionList.size() == 1
         genericParameterDefinitionList.first().defaultValue == '"foo=bar"'
+    }
+
+    @Unroll
+    def "getSecrets returns secrets"(){
+        given:
+        Config config = new Config([:])
+        config.globalEnv = globalEnv
+
+        expect:
+        config.getSecrets() == secrets
+
+        where:
+        globalEnv                          || secrets
+        [ 'FOO=bar' ]                      || []
+        [ 'FOO=bar', ["secure":"xyz"] ]    || [ [secure:"xyz"] ]
+        [ [secure:"xyz"], [secure:"abc"] ] || [ [secure:"xyz"], [secure:"abc"] ]
+
     }
 
 }


### PR DESCRIPTION
The travis api acts strange when we trigger builds. We need to inject one property in `env` to be able to override `global_env`. We have to override `global_env` to override multiple properties in one job, if we do that in `env` it will trigger a job in travis for every property as a build matrix. The data inside `config.global_env` can both include strings and secrets `"MYPROPERTY=foo"` and secrets in a map like `{"secure":"xyz"}`. The code in this PR gathers the secrets from the last build and injects them into the payload when we trigger builds with igor against travis.