### PR TITLE
Rewrite of travis build monitor to support concurrent builds.

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericBuild.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericBuild.groovy
@@ -35,24 +35,4 @@ class GenericBuild {
     @JsonProperty("scm")
     List<GenericGitRevision> genericGitRevisions
 
-    GenericBuild(boolean building, int number) {
-        this.building = building
-        this.number = number
-    }
-
-    GenericBuild(boolean building, int number, int duration, Result result, String name, String url) {
-        this(building, number)
-        this.duration = duration
-        this.name = name
-        this.result = result
-        this.fullDisplayName = "${name} #${number}"
-        this.url = url
-    }
-
-    GenericBuild(boolean building, int number, int duration, Result result, String name, String url, String timestamp, String fullDisplayName) {
-        this(building, number, duration, result, name, url)
-        this.timestamp = timestamp
-        this.fullDisplayName = fullDisplayName
-    }
-
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/Build.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/Build.groovy
@@ -60,7 +60,7 @@ class Build {
     List<TestResults> testResults
 
     GenericBuild genericBuild(String jobName) {
-        GenericBuild genericBuild = new GenericBuild(building, number.intValue(), duration.intValue(), result as Result, jobName, url, timestamp, fullDisplayName)
+        GenericBuild genericBuild = new GenericBuild(building: building, number: number.intValue(), duration: duration.intValue(), result: result as Result, name: jobName, url: url, timestamp: timestamp, fullDisplayName: fullDisplayName)
         if (artifacts) {
             genericBuild.artifacts = artifacts*.getGenericArtifact()
         }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.igor.travis
 import com.netflix.appinfo.InstanceInfo
 import com.netflix.discovery.DiscoveryClient
 import com.netflix.spinnaker.igor.build.BuildCache
-import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.GenericProject
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.history.model.GenericBuildContent
@@ -27,9 +26,8 @@ import com.netflix.spinnaker.igor.history.model.GenericBuildEvent
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.polling.PollingMonitor
 import com.netflix.spinnaker.igor.service.BuildMasters
-import com.netflix.spinnaker.igor.travis.client.model.Build
-import com.netflix.spinnaker.igor.travis.client.model.Commit
 import com.netflix.spinnaker.igor.travis.client.model.Repo
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
 import com.netflix.spinnaker.igor.travis.service.TravisBuildConverter
 import com.netflix.spinnaker.igor.travis.service.TravisResultConverter
 import com.netflix.spinnaker.igor.travis.service.TravisService
@@ -147,29 +145,33 @@ class TravisBuildMonitor implements PollingMonitor{
 
         Observable.from(repos).subscribe(
             { Repo repo ->
-                boolean addToCache = false
-                Map cachedBuild = null
 
-                if (cachedRepoSlugs.contains(repo.slug)) {
-                    cachedBuild = buildCache.getLastBuild(master, repo.slug)
-                    if ((TravisResultConverter.running(repo.lastBuildState) != cachedBuild.lastBuildBuilding) ||
-                        (repo.lastBuildNumber != Integer.valueOf(cachedBuild.lastBuildLabel))) {
-                        addToCache = true
-                        log.info "Build changed: ${master}: ${repo.slug} : ${repo.lastBuildNumber} : ${repo.lastBuildState}"
-                        if (echoService) {
-                            pushEventsForMissingBuilds(repo, cachedBuild, master, travisService)
+                List<V3Build> builds = travisService.getBuilds(repo, 5)
+                for(V3Build build : builds){
+                    boolean addToCache = false
+                    Map cachedBuild = null
+                    String branchedRepoSlug = build.branchedRepoSlug()
+                    if (cachedRepoSlugs.contains(branchedRepoSlug)) {
+                        cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug)
+                        if (build.number > Integer.valueOf(cachedBuild.lastBuildLabel)) {
+                            addToCache = true
+                            log.info "New build: ${master}: ${branchedRepoSlug} : ${build.number}"
                         }
+                        if (buildStateHasChanged(build, cachedBuild)) {
+                            addToCache = true
+                        }
+                    } else {
+                        addToCache = true
                     }
-                } else {
-                    addToCache = true
-                }
-                if (addToCache) {
-                    log.info("Build update [${repo.slug}:${repo.lastBuildNumber}] [status:${repo.lastBuildState}] [running:${TravisResultConverter.running(repo.lastBuildState)}]")
-                    buildCache.setLastBuild(master, repo.slug, repo.lastBuildNumber, TravisResultConverter.running(repo.lastBuildState), buildCacheJobTTLSeconds())
-                    sendEventForBuild(repo, master, travisService)
-
-
-                    results << [previous: cachedBuild, current: repo]
+                    if (addToCache) {
+                        log.info("Build update [${branchedRepoSlug}:${build.number}] [status:${build.state}] [running:${TravisResultConverter.running(build.state)}]")
+                        buildCache.setLastBuild(master, branchedRepoSlug, build.number, TravisResultConverter.running(build.state), buildCacheJobTTLSeconds())
+                        buildCache.setLastBuild(master, build.repository.slug, build.number, TravisResultConverter.running(build.state), buildCacheJobTTLSeconds())
+                        if(!build.spinnakerTriggered()) {
+                            sendEventForBuild(build, branchedRepoSlug, master, travisService)
+                        }
+                        results << [previous: cachedBuild, current: repo]
+                    }
                 }
             }, {
             log.error("Error: ${it.message} (${master})")
@@ -185,54 +187,25 @@ class TravisBuildMonitor implements PollingMonitor{
 
     }
 
-    private void sendEventForBuild(Repo repo, String master, TravisService travisService) {
-        if (echoService) {
-            log.info "pushing event for ${master}:${repo.slug}:${repo.lastBuildNumber}"
+    private boolean buildStateHasChanged(V3Build build, Map cachedBuild) {
+        (TravisResultConverter.running(build.state) != cachedBuild.lastBuildBuilding) &&
+            (build.number == Integer.valueOf(cachedBuild.lastBuildLabel))
+    }
 
-            GenericProject project = new GenericProject(repo.slug, TravisBuildConverter.genericBuild(repo, travisService.baseUrl))
+    private void sendEventForBuild(V3Build build, String branchedSlug, String master, TravisService travisService) {
+        if (echoService) {
+            log.info "pushing event for ${master}:${build.repository.slug}:${build.number}"
+            GenericProject project = new GenericProject(build.repository.slug, TravisBuildConverter.genericBuild(build, travisService.baseUrl))
             echoService.postEvent(
                 new GenericBuildEvent(content: new GenericBuildContent(project: project, master: master, type: 'travis'))
             )
-
+            log.info "pushing event for ${master}:${branchedSlug}:${build.number}"
+            project = new GenericProject(branchedSlug, TravisBuildConverter.genericBuild(build, travisService.baseUrl))
+            echoService.postEvent(
+                new GenericBuildEvent(content: new GenericBuildContent(project: project, master: master, type: 'travis'))
+            )
         }
-        Commit commit = travisService.getCommit(repo.slug, repo.lastBuildNumber)
-        if (commit) {
-            String branchedSlug = travisService.branchedRepoSlug(repo.slug, repo.lastBuildNumber, commit)
 
-            if (branchedSlug != repo.slug) {
-                buildCache.setLastBuild(master, branchedSlug, repo.lastBuildNumber, TravisResultConverter.running(repo.lastBuildState), buildCacheJobTTLSeconds())
-                if (echoService) {
-                    log.info "pushing event for ${master}:${branchedSlug}:${repo.lastBuildNumber}"
-
-                    GenericProject project = new GenericProject(branchedSlug, TravisBuildConverter.genericBuild(repo, travisService.baseUrl))
-                    echoService.postEvent(
-                        new GenericBuildEvent(content: new GenericBuildContent(project: project, master: master, type: 'travis'))
-                    )
-
-                }
-            }
-        }
-    }
-
-    private void pushEventsForMissingBuilds(Repo repo, Map cachedBuild, String master, TravisService travisService) {
-        int currentBuild = repo.lastBuildNumber
-        int lastBuild = Integer.valueOf(cachedBuild.lastBuildLabel)
-        int nextBuild = lastBuild + NEW_BUILD_EVENT_THRESHOLD
-
-        if (nextBuild < currentBuild) {
-            log.info "sending build events for builds between ${lastBuild} and ${currentBuild}"
-
-            for (int buildNumber = nextBuild; buildNumber < currentBuild; buildNumber++) {
-                Build build = travisService.getBuild(repo, buildNumber) //rewrite to afterNumber list thing
-                if (build?.state) {
-                    log.info "pushing event for ${master}:${repo.slug}:${build.number}"
-                    String url = "${travisService.baseUrl}/${repo.slug}/builds/${build.id}"
-                    GenericProject project = new GenericProject(repo.slug, new GenericBuild((TravisResultConverter.running(build.state)), build.number, build.duration, TravisResultConverter.getResultFromTravisState(build.state), repo.slug, url))
-                    echoService.postEvent(
-                        new GenericBuildEvent(content: new GenericBuildContent(project: project, master: master, type: 'travis')))
-                }
-            }
-        }
     }
 
     private void setBuildCacheTTL() {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -147,7 +147,7 @@ class TravisBuildMonitor implements PollingMonitor{
             { Repo repo ->
 
                 List<V3Build> builds = travisService.getBuilds(repo, 5)
-                for(V3Build build : builds){
+                for (V3Build build : builds) {
                     boolean addToCache = false
                     Map cachedBuild = null
                     String branchedRepoSlug = build.branchedRepoSlug()

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.travis
 import com.netflix.appinfo.InstanceInfo
 import com.netflix.discovery.DiscoveryClient
 import com.netflix.spinnaker.igor.build.BuildCache
+import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.GenericProject
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.history.model.GenericBuildContent

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.igor.travis.client.model.RepoRequest
 import com.netflix.spinnaker.igor.travis.client.model.RepoWrapper
 import com.netflix.spinnaker.igor.travis.client.model.Repos
 import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Builds
 import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.EncodedPath
@@ -92,5 +93,8 @@ interface TravisClient {
     @GET('/logs/{logId}')
     Response log(@Header("Authorization") String accessToken , @Path('logId') int logId)
 
+    @GET('/repo/{repository_id}/builds')
+    @Headers("Travis-API-Version: 3")
+    V3Builds builds(@Header("Authorization") String accessToken, @Path('repository_id') int repositoryId, @Query('limit') int limit)
 
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Build.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Build.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.travis.client.model
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.gson.annotations.SerializedName
+import com.netflix.spinnaker.igor.travis.client.model.v3.TravisBuildState
 import groovy.transform.CompileStatic
 import org.simpleframework.xml.Default
 import org.simpleframework.xml.Root
@@ -35,7 +36,7 @@ class Build {
     @SerializedName("repository_id")
     int repositoryId
     int number
-    String state
+    TravisBuildState state
     @SerializedName("finished_at")
     Date finishedAt
     @SerializedName("pull_request")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/TravisBuildState.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/TravisBuildState.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.igor.travis.client.model.v3
+
+
+enum TravisBuildState {
+    created,started,passed,canceled,failed,errored
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Branch.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Branch.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model.v3
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import groovy.transform.CompileStatic
+import org.simpleframework.xml.Default
+import org.simpleframework.xml.Root
+
+@Default
+@CompileStatic
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Root(name = 'branch')
+class V3Branch {
+    String name
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model.v3
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.google.gson.annotations.SerializedName
+import com.netflix.spinnaker.igor.build.model.GenericGitRevision
+import com.netflix.spinnaker.igor.travis.client.model.Config
+import groovy.transform.CompileStatic
+import org.simpleframework.xml.Default
+import org.simpleframework.xml.Root
+
+@Default
+@CompileStatic
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Root(name = 'builds')
+class V3Build {
+    V3Branch branch
+    @SerializedName("commit_id")
+    int commitId
+    V3Commit commit
+    int duration
+    @SerializedName("event_type")
+    String eventType
+    int id
+    V3Repository repository
+    @SerializedName("repository_id")
+    int repositoryId
+    int number
+    String state
+    @SerializedName("finished_at")
+    Date finishedAt
+    @JsonProperty(value = "job_ids")
+    List <Integer> job_ids
+    Config config
+
+    long timestamp() {
+        return finishedAt.getTime()
+    }
+
+    String branchedRepoSlug() {
+        if(commit?.isPullRequest()) {
+            return "${repository.slug}/pull_request_${branch.name}"
+        }
+
+        if(commit?.isTag()) {
+            return "${repository.slug}/tags"
+        }
+
+        return "${repository.slug}/${branch.name}"
+
+    }
+
+    GenericGitRevision genericGitRevision() {
+        return new GenericGitRevision(branch.name, branch.name, commit.sha)
+    }
+
+    boolean spinnakerTriggered(){
+        return (eventType == "api" && commit.message == "Triggered from spinnaker")
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.groovy
@@ -42,7 +42,7 @@ class V3Build {
     @SerializedName("repository_id")
     int repositoryId
     int number
-    String state
+    TravisBuildState state
     @SerializedName("finished_at")
     Date finishedAt
     @JsonProperty(value = "job_ids")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Builds.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Builds.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model.v3
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.netflix.spinnaker.igor.travis.client.model.Job
+import groovy.transform.CompileStatic
+import org.simpleframework.xml.Default
+import org.simpleframework.xml.ElementList
+import org.simpleframework.xml.Root
+
+@Default
+@CompileStatic
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Root(strict = false)
+class V3Builds {
+    @ElementList(required = false, name = "builds", inline = true)
+    List<V3Build> builds
+
+    @ElementList(required = false, name = "jobs", inline = true)
+    List<Job> jobs
+
+    @ElementList(required = false, name = "commits", inline = true)
+    List<V3Commit> commits
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Commit.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Commit.groovy
@@ -39,14 +39,14 @@ class V3Commit {
     String compareUrl
 
     boolean isTag(){
-        if(ref) {
+        if (ref) {
             return ref.split("/")[1] == "tags"
         }
         return false
     }
 
     boolean isPullRequest(){
-        if(ref) {
+        if (ref) {
             return ref.split("/")[1] == "pull"
         }
         return false

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Commit.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Commit.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model.v3
+
+import com.google.gson.annotations.SerializedName
+import com.netflix.spinnaker.igor.build.model.GenericGitRevision
+import groovy.transform.CompileStatic
+import org.simpleframework.xml.Default
+import org.simpleframework.xml.Root
+
+@Default
+@CompileStatic
+@Root(name = 'commits')
+class V3Commit {
+    int id
+
+    String sha
+
+    String ref
+
+    String message
+
+
+    @SerializedName("compare_url")
+    String compareUrl
+
+    boolean isTag(){
+        if(ref) {
+            return ref.split("/")[1] == "tags"
+        }
+        return false
+    }
+
+    boolean isPullRequest(){
+        if(ref) {
+            return ref.split("/")[1] == "pull"
+        }
+        return false
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Repository.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Repository.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model.v3
+
+import groovy.transform.CompileStatic
+import org.simpleframework.xml.Default
+import org.simpleframework.xml.Root
+
+@Default
+@CompileStatic
+@Root(name = 'repository')
+class V3Repository {
+    int id
+    String name
+    String slug
+
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Repository.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Repository.groovy
@@ -27,5 +27,4 @@ class V3Repository {
     int id
     String name
     String slug
-
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisBuildConverter.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisBuildConverter.groovy
@@ -25,23 +25,15 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class TravisBuildConverter {
     static GenericBuild genericBuild(Build build, String repoSlug, String baseUrl) {
-        GenericBuild genericBuild = new GenericBuild(build.state == 'started', build.number, build.duration, TravisResultConverter.getResultFromTravisState(build.state), repoSlug, url(repoSlug, baseUrl, build.id))
+        GenericBuild genericBuild = new GenericBuild(building: build.state == 'started', number: build.number, duration: build.duration, result: TravisResultConverter.getResultFromTravisState(build.state), name: repoSlug, url: url(repoSlug, baseUrl, build.id))
         if (build.finishedAt) {
             genericBuild.timestamp = build.timestamp()
         }
         return genericBuild
     }
 
-    static GenericBuild genericBuild(Repo repo, String baseUrl) {
-        GenericBuild genericBuild = new GenericBuild((repo.lastBuildState == 'started'), repo.lastBuildNumber, repo.lastBuildDuration, TravisResultConverter.getResultFromTravisState(repo.lastBuildState), repo.slug, url(repo.slug, baseUrl, repo.lastBuildId))
-        if (repo.lastBuildFinishedAt) {
-            genericBuild.timestamp = repo.timestamp()
-        }
-        return genericBuild
-    }
-
     static GenericBuild genericBuild(V3Build build, String baseUrl) {
-        GenericBuild genericBuild = new GenericBuild(build.state == 'started', build.number, build.duration,TravisResultConverter.getResultFromTravisState(build.state), build.repository.slug, url(build.repository.slug, baseUrl, build.id))
+        GenericBuild genericBuild = new GenericBuild(building: build.state == 'started', number: build.number, duration: build.duration,result: TravisResultConverter.getResultFromTravisState(build.state),name: build.repository.slug,url: url(build.repository.slug, baseUrl, build.id))
         if (build.finishedAt) {
             genericBuild.timestamp = build.timestamp()
         }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisBuildConverter.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisBuildConverter.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.travis.service
 import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.travis.client.model.Build
 import com.netflix.spinnaker.igor.travis.client.model.Repo
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
 import groovy.transform.CompileStatic
 
 @CompileStatic
@@ -35,6 +36,14 @@ class TravisBuildConverter {
         GenericBuild genericBuild = new GenericBuild((repo.lastBuildState == 'started'), repo.lastBuildNumber, repo.lastBuildDuration, TravisResultConverter.getResultFromTravisState(repo.lastBuildState), repo.slug, url(repo.slug, baseUrl, repo.lastBuildId))
         if (repo.lastBuildFinishedAt) {
             genericBuild.timestamp = repo.timestamp()
+        }
+        return genericBuild
+    }
+
+    static GenericBuild genericBuild(V3Build build, String baseUrl) {
+        GenericBuild genericBuild = new GenericBuild(build.state == 'started', build.number, build.duration,TravisResultConverter.getResultFromTravisState(build.state), build.repository.slug, url(build.repository.slug, baseUrl, build.id))
+        if (build.finishedAt) {
+            genericBuild.timestamp = build.timestamp()
         }
         return genericBuild
     }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverter.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverter.groovy
@@ -17,30 +17,31 @@
 package com.netflix.spinnaker.igor.travis.service
 
 import com.netflix.spinnaker.igor.build.model.Result
+import com.netflix.spinnaker.igor.travis.client.model.v3.TravisBuildState
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
 @CompileStatic
 @Slf4j
 class TravisResultConverter {
-    static Result getResultFromTravisState(String state) {
+    static Result getResultFromTravisState(TravisBuildState state) {
         switch (state) {
-            case "created":
+            case TravisBuildState.created:
                 return Result.NOT_BUILT
                 break
-            case "started":
+            case TravisBuildState.started:
                 return Result.BUILDING
                 break
-            case "passed":
+            case TravisBuildState.passed:
                 return Result.SUCCESS
                 break
-            case "canceled":
+            case TravisBuildState.canceled:
                 return Result.ABORTED
                 break
-            case "failed":
+            case TravisBuildState.failed:
                 return Result.FAILURE
                 break
-            case "errored":
+            case TravisBuildState.errored:
                 return Result.FAILURE
                 break
             default:
@@ -50,12 +51,12 @@ class TravisResultConverter {
         }
     }
 
-    static Boolean running(String state) {
+    static Boolean running(TravisBuildState state) {
         switch (state) {
-            case "created":
+            case TravisBuildState.created:
                 return true
                 break
-            case "started":
+            case TravisBuildState.started:
                 return true
                 break
             default:

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -154,7 +154,7 @@ class TravisService implements BuildService {
 
     List<V3Build> getBuilds(Repo repo, int limit) {
         V3Builds builds = travisClient.builds(getAccessToken(), repo.id, limit)
-        log.debug "fetched " + builds.builds.size() + " builds"
+        log.debug "fetched ${builds.builds.size()} builds"
         return builds.builds
     }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -40,6 +40,8 @@ import com.netflix.spinnaker.igor.travis.client.model.Repo
 import com.netflix.spinnaker.igor.travis.client.model.RepoRequest
 import com.netflix.spinnaker.igor.travis.client.model.Repos
 import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Builds
 import groovy.util.logging.Slf4j
 import retrofit.RetrofitError
 import retrofit.client.Response
@@ -146,6 +148,12 @@ class TravisService implements BuildService {
 
     List<Build> getBuilds(Repo repo) {
         Builds builds = travisClient.builds(getAccessToken(), repo.id)
+        log.debug "fetched " + builds.builds.size() + " builds"
+        return builds.builds
+    }
+
+    List<V3Build> getBuilds(Repo repo, int limit) {
+        V3Builds builds = travisClient.builds(getAccessToken(), repo.id, limit)
         log.debug "fetched " + builds.builds.size() + " builds"
         return builds.builds
     }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -86,7 +86,7 @@ class BuildControllerSpec extends Specification {
 
     void 'get the status of a build'() {
         given:
-        1 * service.getGenericBuild(JOB_NAME, BUILD_NUMBER) >> new GenericBuild(false, BUILD_NUMBER)
+        1 * service.getGenericBuild(JOB_NAME, BUILD_NUMBER) >> new GenericBuild(building: false, number: BUILD_NUMBER)
 
         when:
         MockHttpServletResponse response = mockMvc.perform(get("/builds/status/${BUILD_NUMBER}/${MASTER}/${JOB_NAME}")

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -20,6 +20,8 @@ import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.service.BuildMasters
 import com.netflix.spinnaker.igor.travis.client.model.Commit
 import com.netflix.spinnaker.igor.travis.client.model.Repo
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Repository
 import com.netflix.spinnaker.igor.travis.service.TravisService
 import spock.lang.Specification
 
@@ -46,22 +48,30 @@ class TravisBuildMonitorSpec extends Specification {
         repo.lastBuildState = "passed"
         repo.lastBuildStartedAt = new Date()
         List<Repo> repos = [repo]
+        V3Build build = Mock(V3Build)
+        V3Repository repository = Mock(V3Repository)
 
         given:
-        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo']
+        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo/master']
 
         when:
-        List<Map> builds = travisBuildMonitor.changedBuilds(MASTER)
+        List<Map> receivedBuilds = travisBuildMonitor.changedBuilds(MASTER)
 
         then:
         1 * travisService.getReposForAccounts() >> repos
-
-        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo') >> [lastBuildLabel: 3]
+        1 * travisService.getBuilds(repo, 5) >> [ build ]
+        build.branchedRepoSlug() >> "test-org/test-repo/master"
+        build.getNumber() >> 4
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/master') >> [lastBuildLabel: 3]
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/master', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
-        builds.size() == 1
-        builds[0].current.slug == 'test-org/test-repo'
-        builds[0].current.lastBuildNumber == 4
-        builds[0].previous.lastBuildLabel == 3
+
+        build.repository >> repository
+        repository.slug >> 'test-org/test-repo'
+        receivedBuilds.size() == 1
+        receivedBuilds[0].current.slug == 'test-org/test-repo'
+        receivedBuilds[0].current.lastBuildNumber == 4
+        receivedBuilds[0].previous.lastBuildLabel == 3
     }
 
     void 'ignore old build not found in the cache'() {
@@ -75,19 +85,32 @@ class TravisBuildMonitorSpec extends Specification {
         repo.lastBuildNumber = 4
         repo.lastBuildState = "passed"
         repo.lastBuildStartedAt = new Date(now.getTime() - TimeUnit.DAYS.toMillis(travisBuildMonitor.cachedJobTTLDays-1))
-        List<Repo> repos = [oldRepo,repo, noLastBuildStartedAtRepo]
+        List<Repo> repos = [oldRepo, repo, noLastBuildStartedAtRepo]
+        V3Build build = Mock(V3Build)
+        V3Repository repository = Mock(V3Repository)
+
 
         given:
-        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo']
+        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo/master']
 
         when:
         List<Map> builds = travisBuildMonitor.changedBuilds(MASTER)
 
         then:
         1 * travisService.getReposForAccounts() >> repos
+        1 * travisService.getBuilds(repo, 5) >> [ build ]
+        build.branchedRepoSlug() >> "test-org/test-repo/master"
+        build.getNumber() >> 4
 
-        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo') >> [lastBuildLabel: 3]
+
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/master') >> [lastBuildLabel: 3]
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/master', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
+
+        build.repository >> repository
+        repository.slug >> 'test-org/test-repo'
+
+        expect:
         builds.size() == 1
         builds[0].current.slug == 'test-org/test-repo'
         builds[0].current.lastBuildNumber == 4
@@ -97,28 +120,34 @@ class TravisBuildMonitorSpec extends Specification {
     void 'send events for build both on branch and on repository'() {
         travisBuildMonitor.echoService = Mock(EchoService)
 
-        Commit commit = Mock(Commit)
         Repo repo = new Repo()
         repo.slug = "test-org/test-repo"
         repo.lastBuildNumber = 4
         repo.lastBuildState = "passed"
         repo.lastBuildStartedAt = new Date()
         List<Repo> repos = [repo]
+        V3Build build = Mock(V3Build)
+        V3Repository repository = Mock(V3Repository)
 
         given:
-        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo']
+        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo/my_branch']
 
         when:
         travisBuildMonitor.changedBuilds(MASTER)
 
         then:
         1 * travisService.getReposForAccounts() >> repos
-        1 * travisService.getCommit('test-org/test-repo', 4) >> commit
-        1 * travisService.branchedRepoSlug('test-org/test-repo', 4, commit) >> "test-org/test-repo/my_branch"
+        1 * travisService.getBuilds(repo, 5) >> [ build ]
+        build.branchedRepoSlug() >> "test-org/test-repo/my_branch"
+        build.getNumber() >> 4
 
-        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo') >> [lastBuildLabel: 3]
-        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/my_branch') >> [lastBuildLabel: 3]
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/my_branch', 4, false, CACHED_JOB_TTL_SECONDS)
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
+
+        build.repository >> repository
+        repository.slug >> 'test-org/test-repo'
+        build.getState() >> "passed"
 
         1 * travisBuildMonitor.echoService.postEvent({
             it.content.project.name == "test-org/test-repo"
@@ -128,6 +157,66 @@ class TravisBuildMonitorSpec extends Specification {
             it.content.project.name == "test-org/test-repo/my_branch"
             it.content.project.lastBuild.number == 4
         })
+
+    }
+
+    void 'send events when two different branches build at the same time.'() {
+        travisBuildMonitor.echoService = Mock(EchoService)
+
+        Repo repo = new Repo()
+        repo.slug = "test-org/test-repo"
+        repo.lastBuildNumber = 4
+        repo.lastBuildState = "passed"
+        repo.lastBuildStartedAt = new Date()
+        List<Repo> repos = [repo]
+        V3Build build = Mock(V3Build)
+        V3Build buildDifferentBranch = Mock(V3Build)
+        V3Repository repository = Mock(V3Repository)
+
+
+        given:
+        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo/my_branch', 'test-org/test-repo/different_branch']
+
+        when:
+        travisBuildMonitor.changedBuilds(MASTER)
+
+        then:
+        1 * travisService.getReposForAccounts() >> repos
+        1 * travisService.getBuilds(repo, 5) >> [ build, buildDifferentBranch ]
+        build.branchedRepoSlug() >> "test-org/test-repo/my_branch"
+        build.getNumber() >> 4
+        buildDifferentBranch.branchedRepoSlug() >> "test-org/test-repo/different_branch"
+        buildDifferentBranch.getNumber() >> 3
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/my_branch') >> [lastBuildLabel: 2]
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/my_branch', 4, false, CACHED_JOB_TTL_SECONDS)
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 3, false, CACHED_JOB_TTL_SECONDS)
+
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/different_branch') >> [lastBuildLabel: 1]
+        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/different_branch', 3, false, CACHED_JOB_TTL_SECONDS)
+
+        build.repository >> repository
+        repository.slug >> 'test-org/test-repo'
+        build.getState() >> "passed"
+        buildDifferentBranch.repository >> repository
+        buildDifferentBranch.getState() >> "passed"
+
+
+        1 * travisBuildMonitor.echoService.postEvent({
+            it.content.project.name == "test-org/test-repo/my_branch" &&
+                it.content.project.lastBuild.number == 4
+        })
+        1 * travisBuildMonitor.echoService.postEvent({
+            it.content.project.name == "test-org/test-repo" &&
+                it.content.project.lastBuild.number == 4
+        })
+
+        1 * travisBuildMonitor.echoService.postEvent({
+            it.content.project.name == "test-org/test-repo/different_branch" &&
+                it.content.project.lastBuild.number == 3
+        })
+
+
 
     }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverterSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisResultConverterSpec.groovy
@@ -17,10 +17,11 @@
 package com.netflix.spinnaker.igor.travis.service
 
 import com.netflix.spinnaker.igor.build.model.Result
+import com.netflix.spinnaker.igor.travis.client.model.v3.TravisBuildState
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class TravisResultConverterTest extends Specification {
+class TravisResultConverterSpec extends Specification {
 
     @Unroll
     def "convert travis build states to Result object state='#travisBuildState' should give Result=#expectedResult"() {
@@ -29,9 +30,9 @@ class TravisResultConverterTest extends Specification {
 
         where:
         travisBuildState || expectedResult
-        "started"        || Result.BUILDING
-        "passed"         || Result.SUCCESS
-        "errored"        || Result.FAILURE
+        TravisBuildState.started  || Result.BUILDING
+        TravisBuildState.passed   || Result.SUCCESS
+        TravisBuildState.errored  || Result.FAILURE
     }
 
     @Unroll
@@ -41,9 +42,9 @@ class TravisResultConverterTest extends Specification {
 
         where:
         travisBuildState || expectedResult
-        "started"        || true
-        "created"        || true
-        "passed"         || false
-        "errored"        || false
+        TravisBuildState.started  || true
+        TravisBuildState.created  || true
+        TravisBuildState.passed   || false
+        TravisBuildState.errored  || false
     }
 }


### PR DESCRIPTION
With the old implementation we could miss build events when the same repository was built several times in parallel. This happens a lot in travis, ie you push to a branch and travis builds the branch and the PR at the same time.