### PR TITLE
Travis include artifacts in trigger event.

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -145,7 +145,7 @@ class TravisService implements BuildService {
         String repoSlug = cleanRepoSlug(inputRepoSlug)
 
         Build build = getBuild(repoSlug, buildNumber)
-        return PropertyParser.extractPropertiesFromLog(getLog(build))
+        return PropertyParser.extractPropertiesFromLog(getLog(build.job_ids))
     }
 
     List<Build> getBuilds(Repo repo) {
@@ -227,9 +227,9 @@ class TravisService implements BuildService {
         return jobs.job
     }
 
-    String getLog(Build build) {
+    String getLog(List<Integer> jobIds) {
         String buildLog = ""
-        build.job_ids.each {
+        jobIds.each {
             Job job = getJob(it.intValue())
             buildLog += getLog(job.logId)
         }
@@ -253,7 +253,7 @@ class TravisService implements BuildService {
 
     GenericBuild getGenericBuild(Build build, String repoSlug) {
         GenericBuild genericBuild = TravisBuildConverter.genericBuild(build, repoSlug, baseUrl)
-        genericBuild.artifacts = ArtifactParser.getArtifactsFromLog(getLog(build))
+        genericBuild.artifacts = ArtifactParser.getArtifactsFromLog(getLog(build.job_ids))
         return genericBuild
     }
 


### PR DESCRIPTION
We want to implement support for multi-repo incremental builds in spinnaker.
Given a project that creates two or more services and that is building incrementally,
we want to be able to filter in the trigger stage on which artifacts that have been uploaded.

This will let us have many pipelines listening to the same build, but only trigger them
when the artifact we will use in the bake is present.
