### PR TITLE
Decorate artifacts in igor.

### DIFF
--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -8,6 +8,15 @@ spinnaker:
 
 endpoints.health.sensitive: false
 
+#artifact:
+#  This is a feature toggle for decoration of artifacts.
+#  decorator:
+#    enabled: true
+#    fileDecorators:
+#       - type: mavenUrl
+#         decoratorRegex: /[\/\:.]*\/([a-zA-Z-]+)\-([\d\.]+\-[\d\.]+)[a-z\-\d]+\.[jw]ar$/
+#         identifierRegex: /https?\:\/\/[\/\:.]*\/([a-zA-Z-]+)\-([\d\.]+\-[\d\.]+)[a-z\-\d]+\.[jw]ar$/
+
 #travis:
 #  enabled: true
 #  Repository sync makes a call to travis telling travis to sync repos against github.

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.jenkins.client.model.JobConfig
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
+import com.netflix.spinnaker.igor.service.ArtifactDecorator
 import com.netflix.spinnaker.igor.service.BuildMasters
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
@@ -52,6 +53,9 @@ class BuildController {
     @Autowired
     ObjectMapper objectMapper
 
+    @Autowired(required = false)
+    ArtifactDecorator artifactDecorator
+
     @RequestMapping(value = '/builds/status/{buildNumber}/{master:.+}/**')
     GenericBuild getJobStatus(@PathVariable String master, @PathVariable Integer buildNumber, HttpServletRequest request) {
         def job = (String) request.getAttribute(
@@ -63,6 +67,11 @@ class BuildController {
             } catch (Exception e) {
                 log.error("could not get scm results for $master / $job / $buildNumber")
             }
+
+            if (artifactDecorator) {
+                artifactDecorator.decorate(build)
+            }
+
             return build
         } else {
             throw new MasterNotFoundException("Master '${master}' not found")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/ArtifactDetailsDecorator.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/ArtifactDetailsDecorator.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.build.artifact.decorator
+
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+
+interface ArtifactDetailsDecorator {
+
+    GenericArtifact decorate(GenericArtifact genericArtifact)
+
+    boolean handles(GenericArtifact genericArtifact)
+
+    String decoratorName()
+
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/ConfigurableFileDecorator.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/ConfigurableFileDecorator.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.build.artifact.decorator
+
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+
+class ConfigurableFileDecorator implements ArtifactDetailsDecorator {
+
+    final String decoratorRegex
+    final String identifierRegex
+    final String type
+
+    ConfigurableFileDecorator(String type, String decoratorRegex, String identifierRegex) {
+        this.decoratorRegex = decoratorRegex
+        this.identifierRegex = identifierRegex
+        this.type = type
+    }
+
+    @Override
+    GenericArtifact decorate(GenericArtifact genericArtifact) {
+        def m
+
+        if ((m = genericArtifact.fileName =~ decoratorRegex)) {
+            genericArtifact.name = m.group(1)
+            genericArtifact.version = m.group(2)
+            genericArtifact.type = m.groupCount() > 2 ? m.group(3) : type
+            genericArtifact.reference = genericArtifact.fileName
+        }
+
+        return genericArtifact
+    }
+
+    @Override
+    boolean handles(GenericArtifact genericArtifact) {
+        return genericArtifact.fileName =~ identifierRegex
+    }
+
+    @Override
+    String decoratorName() {
+        return type
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/DebDetailsDecorator.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/DebDetailsDecorator.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.build.artifact.decorator
+
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty('artifact.decorator.enabled')
+class DebDetailsDecorator implements ArtifactDetailsDecorator {
+
+    String packageType = "deb"
+    String versionDelimiter = '_'
+
+    @Override
+    GenericArtifact decorate(GenericArtifact genericArtifact) {
+        genericArtifact.name = extractName(genericArtifact.fileName)
+        genericArtifact.version = extractVersion(genericArtifact.fileName)
+        genericArtifact.type = packageType
+        genericArtifact.reference = genericArtifact.fileName
+        return genericArtifact
+    }
+
+    @Override
+    boolean handles(GenericArtifact genericArtifact) {
+        if (!genericArtifact.fileName) {
+            return false
+        }
+        return genericArtifact.fileName.tokenize('.').last() == "deb"
+    }
+
+    @Override
+    String decoratorName() {
+        return packageType
+    }
+
+    String extractVersion(String file) {
+        List<String> parts = file.tokenize(versionDelimiter)
+        parts.pop()
+        return parts.pop()
+    }
+
+    String extractName(String file) {
+        List<String> parts = file.tokenize(versionDelimiter)
+        return parts.first()
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/RpmDetailsDecorator.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/RpmDetailsDecorator.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.build.artifact.decorator
+
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty('artifact.decorator.enabled')
+class RpmDetailsDecorator implements ArtifactDetailsDecorator {
+
+    String packageType = 'rpm'
+    String versionDelimiter = '-'
+
+    @Override
+    GenericArtifact decorate(GenericArtifact genericArtifact) {
+        genericArtifact.name = extractName(genericArtifact.fileName)
+        genericArtifact.version = extractVersion(genericArtifact.fileName)
+        genericArtifact.type = packageType
+        genericArtifact.reference = genericArtifact.fileName
+        return genericArtifact
+    }
+
+    @Override
+    boolean handles(GenericArtifact genericArtifact) {
+        if (!genericArtifact.fileName) {
+            return false
+        }
+        return genericArtifact.fileName.tokenize('.').last() == "rpm"
+    }
+
+    @Override
+    String decoratorName() {
+        return packageType
+    }
+
+    String extractVersion(String file) {
+        List<String> parts = file.tokenize(versionDelimiter)
+        parts.pop()
+        return parts.pop()
+    }
+
+    String extractName(String file) {
+        List<String> parts = file.tokenize(versionDelimiter)
+        parts.pop()
+        parts.pop()
+        return parts.join(versionDelimiter)
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericArtifact.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericArtifact.groovy
@@ -16,14 +16,24 @@
 
 package com.netflix.spinnaker.igor.build.model
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import groovy.transform.ToString
+
+@ToString(includeNames = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class GenericArtifact {
     String fileName
     String displayPath
     String relativePath
+    String reference
+    String name
+    String type
+    String version
 
     GenericArtifact(String fileName, String displayPath, String relativePath) {
         this.fileName = fileName
         this.displayPath = displayPath
         this.relativePath = relativePath
     }
+
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/ArtifactDecorationProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/ArtifactDecorationProperties.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config
+
+import groovy.transform.CompileStatic
+import org.hibernate.validator.constraints.NotEmpty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+import javax.validation.Valid
+
+@Configuration
+@CompileStatic
+@ConfigurationProperties(prefix = 'artifact.decorator')
+class ArtifactDecorationProperties {
+    boolean enabled = false
+
+    @Valid
+    List<FileDecorator> fileDecorators
+
+    static class FileDecorator {
+        @NotEmpty
+        String type
+
+        @NotEmpty
+        String decoratorRegex
+
+        @NotEmpty
+        String identifierRegex
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/IgorConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/IgorConfig.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.igor.config
 
 import com.netflix.hystrix.exception.HystrixRuntimeException
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.igor.service.ArtifactDecorator
 import com.netflix.spinnaker.igor.service.BuildMasters
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import groovy.transform.CompileStatic
@@ -46,6 +47,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 class IgorConfig extends WebMvcConfigurerAdapter {
     @Autowired
     Registry registry
+
+    @Autowired(required = false)
+    ArtifactDecorator artifactDecorator
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/ArtifactDecorator.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/ArtifactDecorator.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.service
+
+import com.netflix.spinnaker.igor.build.artifact.decorator.ArtifactDetailsDecorator
+import com.netflix.spinnaker.igor.build.artifact.decorator.ConfigurableFileDecorator
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+import com.netflix.spinnaker.igor.build.model.GenericBuild
+import com.netflix.spinnaker.igor.config.ArtifactDecorationProperties
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+import javax.validation.Valid
+
+@Slf4j
+@Component
+@ConditionalOnProperty('artifact.decorator.enabled')
+class ArtifactDecorator {
+
+    List<ArtifactDetailsDecorator> artifactDetailsDecorators;
+
+    @Autowired(required = false)
+    ArtifactDecorationProperties artifactDecorationProperties
+
+    @Autowired
+    ArtifactDecorator(List<ArtifactDetailsDecorator> artifactDetailsDecorators, @Valid ArtifactDecorationProperties artifactDecorationProperties) {
+        this.artifactDetailsDecorators = artifactDetailsDecorators
+        List<ArtifactDetailsDecorator> configuredArtifactDetailsDecorators = artifactDecorationProperties?.fileDecorators?.collect { ArtifactDecorationProperties.FileDecorator fileDecorator ->
+            log.info "Configuring custom artifact decorator of type : ${fileDecorator.type}"
+            (ArtifactDetailsDecorator) new ConfigurableFileDecorator(fileDecorator.type, fileDecorator.decoratorRegex, fileDecorator.identifierRegex)
+        }
+        if (configuredArtifactDetailsDecorators) {
+            this.artifactDetailsDecorators.addAll(0, configuredArtifactDetailsDecorators)
+        }
+    }
+
+    void decorate(GenericArtifact genericArtifact) {
+        ArtifactDetailsDecorator artifactDetailsDecorator = artifactDetailsDecorators.find { it.handles(genericArtifact) }
+
+        if (artifactDetailsDecorator) {
+            artifactDetailsDecorator.decorate(genericArtifact)
+            log.debug "Decorated artifact with decorator [${artifactDetailsDecorator.decoratorName()}]: ${genericArtifact.toString()}"
+        }
+    }
+
+    void decorate(GenericBuild genericBuild) {
+        genericBuild.artifacts?.each {
+            decorate(it)
+        }
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.igor.build
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.igor.build.model.GenericBuild
-import com.netflix.spinnaker.igor.jenkins.client.JenkinsClient
 import com.netflix.spinnaker.igor.jenkins.client.model.Build
 import com.netflix.spinnaker.igor.jenkins.client.model.BuildArtifact
 import com.netflix.spinnaker.igor.jenkins.client.model.BuildsList

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/ConfigurableFileDecoratorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/ConfigurableFileDecoratorSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.build.artifact.decorator
+
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ConfigurableFileDecoratorSpec extends Specification {
+    @Unroll
+    def "decorate artifacts using regex groups"() {
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(reference, reference, reference)
+        ConfigurableFileDecorator configurableFileDecorator = new ConfigurableFileDecorator(artifactType, decoratorRegex, decoratorRegex)
+        configurableFileDecorator.decorate(genericArtifact)
+
+        then:
+        genericArtifact.name      == name
+        genericArtifact.version   == version
+        genericArtifact.type      == type
+        genericArtifact.reference == reference
+
+        where:
+        artifactType    | decoratorRegex                                 | reference                || name            | version | type
+        "war-release"   | /([a-zA-Z-]+)\-([\d\.]+)\.war$/                | "test-artifact-2.13.war" || "test-artifact" | "2.13"  | "war-release"
+        "jar-release"   | /([a-zA-Z-]+)\-([\d\.]+)\.jar$/                | "test-artifact-2.13.jar" || "test-artifact" | "2.13"  | "jar-release"
+        "Auto resolved" | /([a-zA-Z-]+)\-([\d\.]+)\.([jw]ar)$/           | "test-artifact-2.13.war" || "test-artifact" | "2.13"  | "war"
+        "snapshot-java" |
+            /[\/\:.]*\/([a-zA-Z-]+)\-([\d\.]+\-[\d\.]+)[a-z\-\d]+\.jar$/ |
+            "http://m.a.v/e/n/r/e/p/o/test-artifact/1.3.37-SNAPSHOT/test-artifact-1.3.37-20170304.121217-1337-shaded.jar" ||
+            "test-artifact" |
+            "1.3.37-20170304.121217" |
+            "snapshot-java"
+    }
+
+    @Unroll
+    def "identify artifacts using regex"() {
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(reference, reference, reference)
+        ConfigurableFileDecorator configurableFileDecorator = new ConfigurableFileDecorator("dummy", identifier, identifier)
+        configurableFileDecorator.decorate(genericArtifact)
+
+        then:
+        configurableFileDecorator.handles(genericArtifact) == knownArtifact
+
+        where:
+        artifactType    | identifier                            | reference                || knownArtifact
+        "war-release"   | /([a-zA-Z-]+)\-([\d\.]+)\.war$/       | "test-artifact-2.13.war" || true
+        "jar-release"   | /([a-zA-Z-]+)\-([\d\.]+)\.jar$/       | "test-artifact-2.13.jar" || true
+        "jar-release"   | /([a-zA-Z-]+)\-([\d\.]+)\.jar$/       | "rosco_0.35.0-3_all.deb" || false
+        "Auto resolved" | /([a-zA-Z-]+)\-([\d\.]+)\.([jw]ar)$/  | "test-artifact-2.13.war" || true
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/DebDetailsDecoratorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/DebDetailsDecoratorSpec.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.build.artifact.decorator
+
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DebDetailsDecoratorSpec extends Specification {
+
+    @Unroll
+    def "identifies version from DEBs"() {
+        given:
+        DebDetailsDecorator debDetailsDecorator = new DebDetailsDecorator()
+
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(file, file, file)
+        debDetailsDecorator.decorate(genericArtifact)
+
+        then:
+        genericArtifact.version == version
+
+        where:
+        file                           || version
+        "api_1.1.1-h01.sha123_all.deb" || "1.1.1-h01.sha123"
+    }
+
+    @Unroll
+    def "identifies name from DEBs"() {
+        given:
+        DebDetailsDecorator debDetailsDecorator = new DebDetailsDecorator()
+
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(file, file, file)
+        debDetailsDecorator.decorate(genericArtifact)
+
+        then:
+        genericArtifact.name == name
+
+        where:
+        file                           || name
+        "api_1.1.1-h01.sha123_all.deb" || "api"
+    }
+
+    def "identifies reference from DEBs"() {
+        given:
+        DebDetailsDecorator debDetailsDecorator = new DebDetailsDecorator()
+        String file = "api_1.1.1-h01.sha123_all.deb"
+
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(file, file, file)
+        debDetailsDecorator.decorate(genericArtifact)
+
+        then:
+        genericArtifact.reference == file
+    }
+
+    @Unroll
+    def "identifies DEB packages by reference"() {
+        when:
+        DebDetailsDecorator debDetailsDecorator = new DebDetailsDecorator()
+        GenericArtifact genericArtifact = new GenericArtifact(reference, reference, reference)
+
+        then:
+        debDetailsDecorator.handles(genericArtifact) == knownArtifact
+
+        where:
+        reference                || knownArtifact
+        "test-artifact-2.13.war" || false
+        "no-extension"           || false
+        "rosco_0.35.0-3_all.deb" || true
+        "test-2.13.deb.true.fal" || false
+        null                     || false
+        ""                       || false
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/RpmDetailsDecoratorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/RpmDetailsDecoratorSpec.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.build.artifact.decorator
+
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+import spock.lang.Specification
+import spock.lang.Unroll
+
+
+class RpmDetailsDecoratorSpec extends Specification {
+
+    @Unroll
+    def "set version on RPMs"() {
+        given:
+        RpmDetailsDecorator rpmDetailsExtractor = new RpmDetailsDecorator()
+
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(file, file, file)
+        rpmDetailsExtractor.decorate(genericArtifact)
+
+        then:
+        genericArtifact.version == version
+
+        where:
+        file                                        || version
+        "api-4.11.4h-1.x86_64.rpm"                  || "4.11.4h"
+        "alsa-lib-1.0.17-1.el5.i386.rpm"            || "1.0.17"
+        "openmotif22-libs-2.2.4-192.1.3.x86_64.rpm" || "2.2.4"
+    }
+
+    @Unroll
+    def "set name on RPMs"() {
+        given:
+        RpmDetailsDecorator rpmDetailsExtractor = new RpmDetailsDecorator()
+
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(file, file, file)
+        rpmDetailsExtractor.decorate(genericArtifact)
+
+        then:
+        genericArtifact.name == name
+
+        where:
+        file                                        || name
+        "api-4.11.4h-1.x86_64.rpm"                  || "api"
+        "alsa-lib-1.0.17-1.el5.i386.rpm"            || "alsa-lib"
+        "openmotif22-libs-2.2.4-192.1.3.x86_64.rpm" || "openmotif22-libs"
+    }
+
+    def "set reference on RPMs"() {
+        given:
+        RpmDetailsDecorator rpmDetailsExtractor = new RpmDetailsDecorator()
+        String file = "api-4.11.4h-1.x86_64.rpm"
+
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(file, file, file)
+        rpmDetailsExtractor.decorate(genericArtifact)
+
+        then:
+        genericArtifact.reference == file
+    }
+
+    @Unroll
+    def "identifies RPM packages by reference"() {
+        when:
+        RpmDetailsDecorator rpmDetailsDecorator = new RpmDetailsDecorator()
+        GenericArtifact genericArtifact = new GenericArtifact(reference, reference, reference)
+
+        then:
+        rpmDetailsDecorator.handles(genericArtifact) == knownArtifact
+
+        where:
+        reference                || knownArtifact
+        "test-artifact-2.13.war" || false
+        "no-extension"           || false
+        "rosco_0.35.0-3_all.deb" || false
+        "test-2.13.deb.true.fal" || false
+        null                     || false
+        ""                       || false
+        "api-411.4-1.x86_64.rpm" || true
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/service/ArtifactDecoratorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/service/ArtifactDecoratorSpec.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.service
+
+import com.netflix.spinnaker.igor.build.artifact.decorator.ArtifactDetailsDecorator
+import com.netflix.spinnaker.igor.build.artifact.decorator.DebDetailsDecorator
+import com.netflix.spinnaker.igor.build.artifact.decorator.RpmDetailsDecorator
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+import com.netflix.spinnaker.igor.config.ArtifactDecorationProperties
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ArtifactDecoratorSpec extends Specification {
+
+    @Unroll
+    def "Decorate"() {
+        given:
+        List<ArtifactDetailsDecorator> artifactDetailsDecorators = new ArrayList<>()
+        artifactDetailsDecorators.add (new DebDetailsDecorator())
+        artifactDetailsDecorators.add (new RpmDetailsDecorator())
+        def regex = /([a-zA-Z-]+)\-([\d\.]+)\.([jw]ar)$/
+        ArtifactDecorationProperties.FileDecorator fileDecorator = new ArtifactDecorationProperties.FileDecorator()
+        fileDecorator.type = "java-magic"
+        fileDecorator.identifierRegex = regex
+        fileDecorator.decoratorRegex = regex
+        ArtifactDecorationProperties artifactDecorationProperties = new ArtifactDecorationProperties()
+        artifactDecorationProperties.fileDecorators = [fileDecorator]
+        ArtifactDecorator artifactDecorator = new ArtifactDecorator(artifactDetailsDecorators, artifactDecorationProperties)
+
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(reference, reference, reference)
+        artifactDecorator.decorate(genericArtifact)
+
+        then:
+        genericArtifact.name    == name
+        genericArtifact.version == version
+        genericArtifact.type    == type
+
+        where:
+        reference                                   || name               | version            | type
+        "openmotif22-libs-2.2.4-192.1.3.x86_64.rpm" || "openmotif22-libs" | "2.2.4"            | "rpm"
+        "api_1.1.1-h01.sha123_all.deb"              || "api"              | "1.1.1-h01.sha123" | "deb"
+        "test-2.13.jar"                             || "test"             | "2.13"             | "jar"
+        "wara-2.13.war"                             || "wara"             | "2.13"             | "war"
+        "unknown-3.2.1.apk"                         || null               | null               | null
+        null                                        || null               | null               | null
+    }
+
+    @Unroll
+    def "Override the included parser with a parser defined in configuration"() {
+
+        given:
+        List<ArtifactDetailsDecorator> artifactDetailsDecorators = new ArrayList<>()
+        artifactDetailsDecorators.add (new DebDetailsDecorator())
+        artifactDetailsDecorators.add (new RpmDetailsDecorator())
+        def regex = /([a-zA-Z-]+)\_([\d\.]+)\.deb$/
+        ArtifactDecorationProperties.FileDecorator fileDecorator = new ArtifactDecorationProperties.FileDecorator()
+        fileDecorator.type = "deb-override"
+        fileDecorator.identifierRegex = regex
+        fileDecorator.decoratorRegex = regex
+        ArtifactDecorationProperties artifactDecorationProperties = new ArtifactDecorationProperties()
+        artifactDecorationProperties.fileDecorators = [fileDecorator]
+        ArtifactDecorator artifactDecorator = new ArtifactDecorator(artifactDetailsDecorators, artifactDecorationProperties)
+
+        when:
+        GenericArtifact genericArtifact = new GenericArtifact(reference, reference, reference)
+        artifactDecorator.decorate(genericArtifact)
+
+        then:
+        genericArtifact.name    == name
+        genericArtifact.version == version
+        genericArtifact.type    == type
+
+        where:
+        reference                      || name   | version            | type
+        "api_1.1.1-h01.sha123_all.deb" || "api"  | "1.1.1-h01.sha123" | "deb"
+        "api_1.1.1.deb"                || "api"  | "1.1.1"            | "deb-override"
+
+    }
+}


### PR DESCRIPTION
This PR moves the knowledge of rpm and deb packages out of orca and into igor.
Artifact decoration can be feature toggled on and off at will.

The code here is not done yet, but the skeleton and most of the logic is present.

Currently this code only decorates rpm and deb packages. The design should make
it easy to add support for more package types/formats. Also I plan to add a parser
that can be configured through igor.yml. This would make it possible to add support
for new types of artifacts without touching the codebase in igor.

Please provide feedback on this both on the implementation and if this fits better
in orca.

There has been some concerns about property file handling. I think this PR keeps all
current functionality in igor intact.

spinnaker/spinnaker#1348