### PR TITLE
Parse a full JSON line from travis logs based on a magic string

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -225,7 +225,11 @@ class BuildController {
             }
             map
         } else if (buildMasters.filteredMap(BuildServiceProvider.TRAVIS).containsKey(master)) {
-            buildMasters.map[master].getBuildProperties(job, buildNumber)
+            try {
+                buildMasters.map[master].getBuildProperties(job, buildNumber)
+            } catch (e) {
+                log.error("Unable to get properties `${job}`", e)
+            }
         } else {
             throw new MasterNotFoundException("Could not find master '${master}' to get properties")
 


### PR DESCRIPTION
This PR allows to extract multiple properties from the Travis log. The properties are printed in one line in the Travis log in JSON format and prepended by `SPINNAKER_CONFIG_JSON=`.
Something like this:
```
SPINNAKER_CONFIG_JSON={"key1": "value1", "key2": "value2", "key3": {"key3_1": "value3_1", "key3_2": "value3_2"} }
```

As a side note: I'm swallowing the exception in case the JSON is malformed - doing it in a similar fashion as the [Jenkins implementation](https://github.com/spinnaker/igor/blob/master/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy#L224). Possibily the exception should be handled differently, but that means changing Orca as well - shall be addressed in a different PR.