### PR TITLE
Add BitBucket Cloud support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Igor
 [![Build Status](https://api.travis-ci.org/spinnaker/igor.svg?branch=master)](https://travis-ci.org/spinnaker/igor)
 
-Igor provides a single point of integration with Jenkins, Travis and Git repositories ( Stash and Github ) within Spinnaker.
+Igor provides a single point of integration with Jenkins, Travis and Git repositories ( BitBucket, Stash, and Github ) within Spinnaker.
 
 Igor keeps track of the credentials for multiple Jenkins and/or Travis hosts and sends events to [echo](http://www.github.com/spinnaker/echo) whenever build information has changed. 
 
@@ -61,6 +61,12 @@ stash:
   baseUrl: "<stash url>"
   username: '<stash username>'
   password: '<stash password>'
+
+bitbucket:
+  baseUrl: "https://api.bitbucket.org"
+  username: '<bitbucket username>'
+  password: '<bitbucket password>'
+  commitDisplayLength: 7
 ```
 
 Currently git credentials are used in Spinnaker pipelines to retrieve commit changes across different build versions. 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/BitBucketConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/BitBucketConfig.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config
+
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketClient
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketMaster
+import com.squareup.okhttp.Credentials
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import retrofit.Endpoints
+import retrofit.RequestInterceptor
+import retrofit.RestAdapter
+import retrofit.client.OkClient
+import retrofit.converter.JacksonConverter
+import javax.validation.Valid
+
+/**
+ * Converts the list of BitBucket Configuration properties a collection of clients to access the BitBucket hosts
+ */
+@Configuration
+@ConditionalOnProperty('bitbucket.baseUrl')
+@Slf4j
+@CompileStatic
+@EnableConfigurationProperties(BitBucketProperties)
+class BitBucketConfig {
+
+  @Bean
+  BitBucketMaster bitBucketMaster(@Valid BitBucketProperties bitBucketProperties) {
+    log.info "bootstrapping ${bitBucketProperties.baseUrl} as bitbucket"
+    new BitBucketMaster(
+      bitBucketClient: bitBucketClient(bitBucketProperties.baseUrl, bitBucketProperties.username, bitBucketProperties.password),
+      baseUrl: bitBucketProperties.baseUrl)
+  }
+
+  BitBucketClient bitBucketClient(String address, String username, String password) {
+    new RestAdapter.Builder()
+      .setEndpoint(Endpoints.newFixedEndpoint(address))
+      .setRequestInterceptor(new BasicAuthRequestInterceptor(username, password))
+      .setClient(new OkClient())
+      .setConverter(new JacksonConverter())
+      .build()
+      .create(BitBucketClient)
+  }
+
+  static class BasicAuthRequestInterceptor implements RequestInterceptor {
+
+    private final String username
+    private final String password
+
+    BasicAuthRequestInterceptor(String username, String password) {
+      this.username = username
+      this.password = password
+    }
+
+    @Override
+    void intercept(RequestInterceptor.RequestFacade request) {
+      request.addHeader("Authorization", Credentials.basic(username, password))
+    }
+  }
+
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/BitBucketProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/BitBucketProperties.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config
+
+import groovy.transform.CompileStatic
+import org.hibernate.validator.constraints.NotEmpty
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import javax.validation.constraints.NotNull
+
+/**
+ * Helper class to map masters in properties file into a validated property map
+ */
+@ConditionalOnProperty('bitbucket.baseUrl')
+@CompileStatic
+@ConfigurationProperties(prefix = 'bitbucket')
+class BitBucketProperties {
+  @NotEmpty
+  String baseUrl
+
+  @NotEmpty
+  String username
+
+  @NotEmpty
+  String password
+
+  @NotNull
+  Integer commitDisplayLength
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/ScmInfoController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/ScmInfoController.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.igor.scm
 
 import com.netflix.spinnaker.igor.scm.github.client.GitHubMaster
 import com.netflix.spinnaker.igor.scm.stash.client.StashMaster
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketMaster
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.RequestMapping
@@ -37,6 +38,9 @@ class ScmInfoController {
     @Autowired(required = false)
     GitHubMaster gitHubMaster
 
+    @Autowired(required = false)
+    BitBucketMaster bitBucketMaster
+
     @RequestMapping(value = '/masters', method = RequestMethod.GET)
     Map listMasters() {
         log.info('Getting list of masters')
@@ -46,6 +50,9 @@ class ScmInfoController {
 
         if(gitHubMaster)
             result << [gitHub : gitHubMaster.baseUrl]
+
+        if(bitBucketMaster)
+            result << [bitBucket : bitBucketMaster.baseUrl]
         result
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitController.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket
+
+import com.netflix.spinnaker.igor.scm.AbstractCommitController
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketMaster
+import com.netflix.spinnaker.igor.scm.bitbucket.client.model.CompareCommitsResponse
+import com.netflix.spinnaker.igor.config.BitBucketProperties
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import retrofit.RetrofitError
+
+@Slf4j
+@RestController(value = "BitBucketCommitController")
+@ConditionalOnProperty('bitbucket.baseUrl')
+@RequestMapping("/bitbucket")
+class CommitController extends AbstractCommitController {
+  @Autowired
+  BitBucketMaster bitBucketMaster
+
+  @Autowired
+  BitBucketProperties bitBucketProperties
+
+  @RequestMapping(value = '/{projectKey}/{repositorySlug}/compareCommits')
+  List compareCommits(@PathVariable(value = 'projectKey') String projectKey, @PathVariable(value='repositorySlug') repositorySlug, @RequestParam Map<String, String> requestParams) {
+    super.compareCommits(projectKey, repositorySlug, requestParams)
+    CompareCommitsResponse commitsResponse
+    List result = []
+
+    /*
+     * BitBucket Cloud API v2.0 does not implement a 'compare commits' feature like GitHub or BitBucket Server / Stash.
+     * Instead, you need to iteratively request commits until you have the range you need.
+     * BitBucket limits the number of commits retrieve to a max of 100 at a time.
+     */
+
+    try {
+      commitsResponse = bitBucketMaster.bitBucketClient.getCompareCommits(projectKey, repositorySlug, ['limit': 100, 'include': requestParams.to])
+      if (!commitsResponse.values.any { it.hash == requestParams.from }) {
+        while (!commitsResponse.values.any { it.hash == requestParams.from }) {
+          def response = bitBucketMaster.bitBucketClient.getCompareCommits(projectKey, repositorySlug, ['limit': 100, 'include': commitsResponse.values.last().hash])
+          commitsResponse.values.addAll(response.values)
+        }
+        commitsResponse.values.unique { a, b -> a.hash <=> b.hash }
+      }
+
+      def fromIndex = commitsResponse.values.findIndexOf { it.hash == requestParams.from }
+      if (fromIndex > -1) {
+        commitsResponse.values = commitsResponse.values.subList(0, fromIndex + 1)
+      }
+    } catch (RetrofitError e) {
+      if(e.getKind() == RetrofitError.Kind.NETWORK) {
+        throw new RuntimeException("Could not find the server ${bitBucketMaster.baseUrl}")
+      } else if(e.response.status == 404) {
+        return getNotFoundCommitsResponse(projectKey, repositorySlug, requestParams.to, requestParams.from, bitBucketMaster.baseUrl)
+      }
+    }
+
+    commitsResponse.values.each {
+      result << [displayId: it?.hash.substring(0,bitBucketProperties.commitDisplayLength), id: it?.hash,
+                 authorDisplayName: it?.author?.user?.display_name, timestamp: it?.date, message : it?.message,
+                 commitUrl: it?.html_href]
+    }
+
+    return result
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/BitBucketClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/BitBucketClient.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket.client
+
+import com.netflix.spinnaker.igor.scm.bitbucket.client.model.CompareCommitsResponse
+import retrofit.http.GET
+import retrofit.http.Path
+import retrofit.http.QueryMap
+
+/**
+ * Interface for interacting with a BitBucket Cloud REST API
+ * https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commits
+ */
+interface BitBucketClient {
+  @GET('/2.0/repositories/{projectKey}/{repositorySlug}/commits')
+  CompareCommitsResponse getCompareCommits(
+    @Path('projectKey') String projectKey,
+    @Path('repositorySlug') String repositorySlug,
+    @QueryMap Map queryMap)
+}
+

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/BitBucketMaster.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/BitBucketMaster.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket.client
+
+import com.netflix.spinnaker.igor.config.BitBucketProperties
+import com.squareup.okhttp.Credentials
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import retrofit.Endpoints
+import retrofit.RequestInterceptor
+import retrofit.RestAdapter
+import retrofit.client.OkClient
+import retrofit.converter.SimpleXMLConverter
+import javax.validation.Valid
+
+/**
+ * Wrapper class for a collection of BitBucket clients
+ */
+class BitBucketMaster {
+  BitBucketClient bitBucketClient
+  String baseUrl
+
+  @Bean
+  @ConditionalOnProperty('bitbucket.baseUrl')
+  BitBucketMaster bitBucketMaster(@Valid BitBucketProperties bitBucketProperties) {
+    log.info "bootstrapping ${bitBucketProperties.baseUrl}"
+    new BitBucketMaster(
+        bitBucketClient : bitBucketClient(bitBucketProperties.baseUrl, bitBucketProperties.username, bitBucketProperties.password),
+        baseUrl: bitBucketProperties.baseUrl)
+  }
+
+  BitBucketClient bitBucketClient(String address, String username, String password) {
+    new RestAdapter.Builder()
+      .setEndpoint(Endpoints.newFixedEndpoint(address))
+      .setRequestInterceptor(new BasicAuthRequestInterceptor(username, password))
+      .setClient(new OkClient())
+      .setConverter(new SimpleXMLConverter())
+      .build()
+      .create(BitBucketClient(address:address))
+  }
+
+  static class BasicAuthRequestInterceptor implements RequestInterceptor {
+
+    private final String username
+    private final String password
+
+    BasicAuthRequestInterceptor(String username, String password) {
+      this.username = username
+      this.password = password
+    }
+
+    @Override
+    void intercept(RequestInterceptor.RequestFacade request) {
+      request.addHeader("Authorization", Credentials.basic(username, password))
+    }
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/AbstractBitBucketResponse.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/AbstractBitBucketResponse.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket.client.model
+
+abstract class AbstractBitBucketResponse {
+  List<?> values
+  String next
+  Integer pagelen
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/Author.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/Author.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket.client.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Author {
+  String raw
+  User user
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/Commit.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/Commit.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket.client.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Commit {
+  String hash
+  Author author
+  String html_href
+  Date date
+  String message
+
+  @JsonProperty("links")
+  public void setUser(Map<String, Object> links) {
+    def html = links.get("html")
+    html_href = html.href.toString()
+  }
+
+  @JsonProperty(value = "date")
+  public void setDate(String utctimestamp) {
+    date = DateTime.parse(utctimestamp, ISODateTimeFormat.dateTimeNoMillis()).toDate();
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/CompareCommitsResponse.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/CompareCommitsResponse.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket.client.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class CompareCommitsResponse extends AbstractBitBucketResponse {
+  List<Commit> values
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/User.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/User.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket.client.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class User {
+  String username
+  String display_name
+}
+

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ScmInfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ScmInfoControllerSpec.groovy
@@ -20,6 +20,8 @@ import com.netflix.spinnaker.igor.scm.github.client.GitHubClient
 import com.netflix.spinnaker.igor.scm.github.client.GitHubMaster
 import com.netflix.spinnaker.igor.scm.stash.client.StashClient
 import com.netflix.spinnaker.igor.scm.stash.client.StashMaster
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketClient
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketMaster
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -33,10 +35,12 @@ class ScmInfoControllerSpec extends Specification {
 
     StashClient stashClient = Mock(StashClient)
     GitHubClient gitHubClient = Mock(GitHubClient)
+    BitBucketClient bitBucketClient = Mock(BitBucketClient)
 
     void setup() {
-        controller = new ScmInfoController(gitHubMaster: new GitHubMaster(gitHubClient: gitHubClient,
-            baseUrl: "https://github.com"), stashMaster: new StashMaster(stashClient: stashClient, baseUrl: "http://stash.com"))
+        controller = new ScmInfoController(gitHubMaster: new GitHubMaster(gitHubClient: gitHubClient, baseUrl: "https://github.com"),
+                                           stashMaster: new StashMaster(stashClient: stashClient, baseUrl: "http://stash.com"),
+                                           bitBucketMaster: new BitBucketMaster(bitBucketClient: bitBucketClient, baseUrl: "https://api.bitbucket.org"))
     }
 
     void 'list masters'() {
@@ -46,5 +50,6 @@ class ScmInfoControllerSpec extends Specification {
         then:
         listMastersResponse.stash == "http://stash.com"
         listMastersResponse.gitHub == "https://github.com"
+        listMastersResponse.bitBucket == "https://api.bitbucket.org"
     }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitControllerSpec.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket
+
+import com.netflix.spinnaker.igor.config.BitBucketProperties
+import com.netflix.spinnaker.igor.scm.AbstractCommitController
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketClient
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketMaster
+import com.netflix.spinnaker.igor.scm.bitbucket.client.model.Author
+import com.netflix.spinnaker.igor.scm.bitbucket.client.model.Commit
+import com.netflix.spinnaker.igor.scm.bitbucket.client.model.CompareCommitsResponse
+import com.netflix.spinnaker.igor.scm.bitbucket.client.model.User
+import retrofit.RetrofitError
+import retrofit.client.Response
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.util.concurrent.Executors
+
+/**
+ * Tests for CommitController
+ */
+class CommitControllerSpec extends Specification {
+
+  @Subject
+  CommitController controller
+
+  BitBucketClient client = Mock(BitBucketClient)
+
+  final BITBUCKET_ADDRESS = "https://api.bitbucket.org"
+
+  void setup() {
+    controller = new CommitController(executor: Executors.newSingleThreadExecutor(), bitBucketMaster: new BitBucketMaster(bitBucketClient: client, baseUrl : BITBUCKET_ADDRESS), bitBucketProperties: new BitBucketProperties(commitDisplayLength: 7))
+  }
+
+  void 'missing query params'() {
+    when:
+    controller.compareCommits(projectKey, repositorySlug, queryParams)
+
+    then:
+    thrown(AbstractCommitController.MissingParametersException)
+
+    where:
+    projectKey = 'key'
+    repositorySlug = 'slug'
+    queryParams | _
+    ['to' : "1234512345123451234512345"] | _
+    ['from' : "67890678906789067890"] | _
+  }
+
+  void 'get 404 from bitBucketClient and return one commit'() {
+    when:
+    1 * client.getCompareCommits(projectKey, repositorySlug, clientParams) >> {throw new RetrofitError(null, null, new Response("http://foo.com", 404, "test reason", [], null), null, null, null, null)}
+    def result = controller.compareCommits(projectKey, repositorySlug, controllerParams)
+
+    then:
+    result.size() == 1
+    result[0].id == "NOT_FOUND"
+
+    where:
+    projectKey = 'key'
+    repositorySlug = 'slug'
+    controllerParams =  ['to': "1234512345123451234512345", 'from': '67890678906789067890']
+    clientParams = ['limit': 100, 'include' : controllerParams.to]
+  }
+
+  void 'compare commits'() {
+    given:
+    1 * client.getCompareCommits(projectKey, repositorySlug, clientParams) >> new CompareCommitsResponse(values:
+      [new Commit(message: "my commit", hash: "1234512345123451234512345", date: "2017-02-13T22:44:51+00:00",
+                  author: new Author(raw: "Joe Coder <jcoder@code.com>",
+                  user: new User(display_name: "Joe Coder",  username: "jcoder")),
+                  html_href: "https://bitbucket.org/${projectKey}/${repositorySlug}/commits/1234512345123451234512345"
+                 ),
+       new Commit(message: "bug fix", hash: "67890678906789067890", date: "2017-02-15T22:44:51+00:00",
+                  author: new Author(raw: "Jane Coder <jane.coder@code.com>",
+                  user: new User(display_name: "Jane Coder", username: "jane.coder")),
+                  html_href: "https://bitbucket.org/${projectKey}/${repositorySlug}/commits/67890678906789067890"
+                 )
+      ])
+
+    when:
+    List commitsResponse = controller.compareCommits(projectKey, repositorySlug, controllerParams)
+
+    then:
+    commitsResponse.size == 2
+
+    with(commitsResponse[0]) {
+      displayId == "1234512"
+      id == "1234512345123451234512345"
+      authorDisplayName == "Joe Coder"
+      timestamp == new Date(1487025891000)
+      message == "my commit"
+      commitUrl == "https://bitbucket.org/${projectKey}/${repositorySlug}/commits/${commitsResponse[0].id}"
+    }
+
+    with(commitsResponse[1]) {
+      displayId == "6789067"
+      id == "67890678906789067890"
+      authorDisplayName == "Jane Coder"
+      timestamp == new Date(1487198691000)
+      message == "bug fix"
+      commitUrl == "https://bitbucket.org/${projectKey}/${repositorySlug}/commits/${commitsResponse[1].id}"
+    }
+
+    where:
+    projectKey = 'key'
+    repositorySlug = 'slug'
+    controllerParams =  ['to': "1234512345123451234512345", 'from': '67890678906789067890']
+    clientParams = ['limit': 100, 'include' : controllerParams.to]
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/BitBucketClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/BitBucketClientSpec.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.scm.bitbucket.client
+
+import com.netflix.spinnaker.igor.config.BitBucketConfig
+import com.netflix.spinnaker.igor.scm.bitbucket.client.model.CompareCommitsResponse
+import com.squareup.okhttp.mockwebserver.MockResponse
+import com.squareup.okhttp.mockwebserver.MockWebServer
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Tests that BitBucket bitBucketClient correctly binds to underlying model as expected
+ */
+class BitBucketClientSpec extends Specification {
+
+  @Shared
+  BitBucketClient client
+
+  @Shared
+  MockWebServer server
+
+  void setup() {
+    server = new MockWebServer()
+  }
+
+  void cleanup() {
+    server.shutdown()
+  }
+
+  private void setResponse(String body) {
+    server.enqueue(
+      new MockResponse()
+        .setBody(body)
+        .setHeader('Content-Type', 'text/xml;charset=UTF-8')
+    )
+    server.start()
+    client = new BitBucketConfig().bitBucketClient(server.getUrl('/').toString(), 'username', 'password')
+  }
+
+  void 'getCompareCommits'() {
+    given:
+    setResponse getCompareCommitsResponse()
+
+    when:
+    CompareCommitsResponse commitsResponse = client.getCompareCommits('foo', 'repo', [toCommit:'abcd', fromCommit:'defg'])
+
+    then:
+    commitsResponse.values.size() == 2
+
+    with(commitsResponse.values.get(0)) {
+      hash == 'adc708bb1251ac8177474d6a1b40f738f2dc44dc'
+      author.raw == 'Joe Coder <jcoder@code.com>'
+      author.user.username == 'jcoder'
+      author.user.display_name == 'Joe Coder'
+      message == "don't call evaluate if user is null"
+      date == new Date(1487025891000)
+    }
+
+    with(commitsResponse.values.get(1)) {
+      hash == '70a121a7e8f86c54467a43bd29066e5ff1174510'
+      author.raw == 'Jane Coder <jane.coder@code.com>'
+      author.user.username == 'jane.coder'
+      author.user.display_name == 'Jane Coder'
+      message == "Merge branch 'my-work' into master"
+      date == new Date(1487198691000)
+    }
+  }
+
+  String getCompareCommitsResponse() {
+
+    return '\n' +
+      '{ "pagelen": 100, "values": [ { "hash": "adc708bb1251ac8177474d6a1b40f738f2dc44dc", "links": { "self": ' +
+      '{ "href": "https://api.bitbucket.org/2.0/repositories/foo/repo/commit/adc708bb1251ac8177474d6a1b40f738f2dc44dc" }, ' +
+      '"html": { "href": "https://bitbucket.org/foo/repo/commits/adc708bb1251ac8177474d6a1b40f738f2dc44dc" } }, ' +
+      '"author": { "raw": "Joe Coder <jcoder@code.com>", "user": { "username": "jcoder", "display_name": "Joe Coder", ' +
+      '"type": "user", "links": { "self": { "href": "https://api.bitbucket.org/2.0/users/jcoder" }, "html": { ' +
+      '"href": "https://bitbucket.org/jcoder/" } } } }, "date": "2017-02-13T22:44:51+00:00", ' +
+      '"message": "don\'t call evaluate if user is null", "type": "commit" }, { "hash": "70a121a7e8f86c54467a43bd29066e5ff1174510", ' +
+      '"links": { "self": { "href": "https://api.bitbucket.org/2.0/repositories/foo/repo/commit/70a121a7e8f86c54467a43bd29066e5ff1174510" }, ' +
+      '"html": { "href": "https://bitbucket.org/foo/repo/commits/70a121a7e8f86c54467a43bd29066e5ff1174510" } }, ' +
+      '"author": { "raw": "Jane Coder <jane.coder@code.com>", "user": { "username": "jane.coder", "display_name": "Jane Coder", ' +
+      '"type": "user", "links": { "self": { "href": "https://api.bitbucket.org/2.0/users/jane.coder" }, "html": { ' +
+      '"href": "https://bitbucket.org/jane.coder/" } } } }, "date": "2017-02-15T22:44:51+00:00", ' +
+      '"message": "Merge branch \'my-work\' into master", "type": "commit" } ], ' +
+      '"next": "https://api.bitbucket.org/2.0/repositories/foo/repo/commits?pagelen=100&include=adc708bb1251ac8177474d6a1b40f738f2dc44dc&page=2"}'
+  }
+}


### PR DESCRIPTION
PR's are being opened against Deck, Echo, and Gate.

BitBucket Server (a.k.a. Stash) support already exists. This adds BitBucket Cloud support of pipeline triggers based on BitBucket webhooks and provides Orca the ability to retrieve a list of commits from BitBucket as part of it's GetCommits stage.