### PR TITLE
feat(artifact/decoration): Artifact decoration of docker events spinn…

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericArtifact.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericArtifact.groovy
@@ -30,10 +30,19 @@ class GenericArtifact {
     String type
     String version
 
+    Map<String, String> metadata;
+
     GenericArtifact(String fileName, String displayPath, String relativePath) {
         this.fileName = fileName
         this.displayPath = displayPath
         this.relativePath = relativePath
+    }
+
+    GenericArtifact(String type, String name, String version, String reference) {
+        this.type = type
+        this.name = name
+        this.version = version
+        this.reference = reference
     }
 
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.docker
 import com.netflix.appinfo.InstanceInfo
 import com.netflix.discovery.DiscoveryClient
 import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
 import com.netflix.spinnaker.igor.docker.model.DockerRegistryAccounts
 import com.netflix.spinnaker.igor.docker.service.TaggedImage
 import com.netflix.spinnaker.igor.history.EchoService
@@ -182,6 +183,8 @@ class DockerMonitor implements PollingMonitor {
         }
 
         log.info "Sending tagged image info to echo: ${image.account}: ${imageId}"
+        GenericArtifact dockerArtifact = new GenericArtifact("docker", image.repository, image.tag, "${image.registry}/${image.repository}:${image.tag}")
+        dockerArtifact.metadata = [registry: image.registry]
 
         echoService.postEvent(new DockerEvent(content: new DockerEvent.Content(
             registry: image.registry,
@@ -189,6 +192,6 @@ class DockerMonitor implements PollingMonitor {
             tag: image.tag,
             digest: image.digest,
             account: image.account,
-        )))
+        ), artifact: dockerArtifact))
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/DockerEvent.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/DockerEvent.groovy
@@ -16,8 +16,12 @@
 
 package com.netflix.spinnaker.igor.history.model
 
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
+
 class DockerEvent extends Event {
     Content content
+    GenericArtifact artifact
+
     Map details = [
         type  : 'docker',
         source: 'igor'

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -65,4 +65,31 @@ class DockerMonitorSpec extends Specification {
         ["job1"]     || 1
 
     }
+
+    void 'should include decorated artifact in the payload'() {
+        def echoService = Mock(EchoService)
+        def taggedImage = new TaggedImage(
+            tag: "tag",
+            account: "account",
+            registry: "registry",
+            repository: "repository",
+            digest: "digest"
+        )
+
+        when:
+        DockerMonitor.postEvent(
+            echoService, ["job1"], taggedImage, "imageId"
+        )
+
+        then:
+        1 * echoService.postEvent({ DockerEvent event ->
+            assert event.artifact.version           == taggedImage.tag
+            assert event.artifact.name              == taggedImage.repository
+            assert event.artifact.type              == "docker"
+            assert event.artifact.reference         == "registry/repository:tag"
+            assert event.artifact.metadata.registry == taggedImage.registry
+            return true
+        })
+
+    }
 }


### PR DESCRIPTION
 This PR makes the docker registry events from igor include decorated artifacts. This is to prepare for changing docker deployments to use decorated artifacts for deployments. spinnaker/spinnaker#1348

There is a similar PR in clouddriver https://github.com/spinnaker/clouddriver/pull/1586