### PR TITLE
feat(travis/pro) Support fetching of logs from travis pro

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -93,6 +93,14 @@ interface TravisClient {
     @GET('/logs/{logId}')
     Response log(@Header("Authorization") String accessToken , @Path('logId') int logId)
 
+    @Streaming
+    @Headers([
+        "Travis-API-Version: 3",
+        "Accept: text/plain"
+    ])
+    @GET('/job/{jobId}/log')
+    Response jobLog(@Header("Authorization") String accessToken , @Path('jobId') int jobId)
+
     @GET('/repo/{repository_id}/builds')
     @Headers("Travis-API-Version: 3")
     V3Builds builds(@Header("Authorization") String accessToken, @Path('repository_id') int repositoryId, @Query('limit') int limit)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -233,14 +233,25 @@ class TravisService implements BuildService {
         String buildLog = ""
         build.job_ids.each {
             Job job = getJob(it.intValue())
-            buildLog += getLog(job.logId)
+            if (job.logId) {
+                buildLog += getLog(job.logId)
+            } else {
+                buildLog += getJobLog(job.id)
+            }
         }
         return buildLog
     }
 
     String getLog(int logId) {
-        log.debug "fetching log for ${logId}"
+        log.debug "fetching log by logId ${logId}"
         Response response = travisClient.log(getAccessToken(), logId)
+        String job_log = new String(((TypedByteArray) response.getBody()).getBytes());
+        return job_log
+    }
+
+    String getJobLog(int jobId) {
+        log.debug "fetching log by jobId ${jobId}"
+        Response response = travisClient.jobLog(getAccessToken(), jobId)
         String job_log = new String(((TypedByteArray) response.getBody()).getBytes());
         return job_log
     }


### PR DESCRIPTION
The travis pro api does not have log_id in the api response for jobs. This means we need to find the logs slightly different.
Travis has three products Open source, Pro and Enterprise, they all behave a little bit different.

@abrahamoshel can you test that this works for you?