### PR TITLE
fix(jenkins): Fixing missed build events on concurrent builds

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -165,7 +165,7 @@ class JenkinsBuildMonitor implements PollingMonitor {
                     { log.error("Error: ${it.message}") }
             )
 
-            builds.parallelStream().forEach(
+            builds.stream().forEach(
                     { Project project ->
                         try {
                             boolean addToCache = false
@@ -198,6 +198,7 @@ class JenkinsBuildMonitor implements PollingMonitor {
                                                         Project oldProject = new Project(name: project.name, lastBuild: build)
                                                         if (build.number != lastBuild
                                                                 || (build.number == lastBuild && cachedBuild.lastBuildBuilding != build.building)) {
+                                                            log.info  "sending event for intermediate build ${build.number}"
                                                             postEvent(echoService, cachedBuilds, oldProject, master)
                                                         }
                                                     } catch (e) {


### PR DESCRIPTION
- Removed the use of parallelStream while processing builds
- parallelStream may lead to a concurrency issue with redis read/write for close enough builds