### PR TITLE
feat(igor/travis) Filter builds on branches, tags and pull requests to…

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -105,4 +105,20 @@ interface TravisClient {
     @Headers("Travis-API-Version: 3")
     V3Builds builds(@Header("Authorization") String accessToken, @Path('repository_id') int repositoryId, @Query('limit') int limit)
 
+    @GET('/repo/{repository_slug}/builds')
+    @Headers("Travis-API-Version: 3")
+    V3Builds v3builds(@Header("Authorization") String accessToken, @Path('repository_slug') String repositorySlug, @Query('limit') int limit)
+
+    @GET('/repo/{repository_slug}/builds')
+    @Headers("Travis-API-Version: 3")
+    V3Builds v3builds(@Header("Authorization") String accessToken, @Path('repository_slug') String repositorySlug, @Query('branch.name') String branchName, @Query('limit') int limit)
+
+    @GET('/repo/{repository_slug}/builds')
+    @Headers("Travis-API-Version: 3")
+    V3Builds v3builds(@Header("Authorization") String accessToken, @Path('repository_slug') String repositorySlug, @Query('branch.name') String branchName, @Query('event_type') String eventType, @Query('limit') int limit)
+
+    @GET('/repo/{repository_slug}/builds')
+    @Headers("Travis-API-Version: 3")
+    V3Builds v3buildsByEventType(@Header("Authorization") String accessToken, @Path('repository_slug') String repositorySlug, @Query('event_type') String EventType, @Query('limit') int limit)
+
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/TravisBuildType.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/TravisBuildType.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model.v3
+
+enum TravisBuildType {
+    branch, unknown, tag, pull_request
+
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.igor.travis.client.model.RepoRequest
 import com.netflix.spinnaker.igor.travis.client.model.RepoWrapper
 import com.netflix.spinnaker.igor.travis.client.model.Repos
 import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Builds
 import com.squareup.okhttp.mockwebserver.MockResponse
 import com.squareup.okhttp.mockwebserver.MockWebServer
 import retrofit.client.Response
@@ -383,6 +384,152 @@ class TravisClientSpec extends Specification {
         then:
         builds.commits.first().isTag()
 
+    }
+
+    def "Parse builds from the v3 api"() {
+        given:
+        setResponse '''
+{
+    "@type": "builds",
+    "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2",
+    "@representation": "standard",
+    "@pagination": {
+        "limit": 2,
+        "offset": 0,
+        "count": 160,
+        "is_first": true,
+        "is_last": false,
+        "next": {
+            "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2&offset=2",
+            "offset": 2,
+            "limit": 2
+        },
+        "prev": null,
+        "first": {
+            "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2",
+            "offset": 0,
+            "limit": 2
+        },
+        "last": {
+            "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2&offset=158",
+            "offset": 158,
+            "limit": 2
+        }
+    },
+    "builds": [
+        {
+            "@type": "build",
+            "@href": "/api/build/1386282",
+            "@representation": "standard",
+            "@permissions": {
+                "read": true,
+                "cancel": true,
+                "restart": true
+            },
+            "id": 1386282,
+            "number": "389",
+            "state": "passed",
+            "duration": 413,
+            "event_type": "push",
+            "previous_state": "passed",
+            "pull_request_title": null,
+            "pull_request_number": null,
+            "started_at": "2017-06-06T18:06:56Z",
+            "finished_at": "2017-06-06T18:13:49Z",
+            "repository": {
+                "@type": "repository",
+                "@href": "/api/repo/1996",
+                "@representation": "minimal",
+                "id": 1996,
+                "name": "orca",
+                "slug": "spt-infrastructure/orca"
+            },
+            "branch": {
+                "@type": "branch",
+                "@href": "/api/repo/1996/branch/sch_master",
+                "@representation": "minimal",
+                "name": "sch_master"
+            },
+            "commit": {
+                "@type": "commit",
+                "@representation": "minimal",
+                "id": 802307,
+                "sha": "3d38456a3656a65032c4db9c08d3648abb696b58",
+                "ref": "refs/heads/sch_master",
+                "message": "Merge pull request #54 from spt-infrastructure/DOCD-1025\\n\\nDocd 1025",
+                "compare_url": "https://github.schibsted.io/spt-infrastructure/orca/compare/0b373922a733...3d38456a3656",
+                "committed_at": "2017-06-06T18:06:51Z"
+            },
+            "jobs": [
+                {
+                    "@type": "job",
+                    "@href": "/api/job/1386283",
+                    "@representation": "minimal",
+                    "id": 1386283
+                }
+            ]
+        },
+        {
+            "@type": "build",
+            "@href": "/api/build/1384443",
+            "@representation": "standard",
+            "@permissions": {
+                "read": true,
+                "cancel": true,
+                "restart": true
+            },
+            "id": 1384443,
+            "number": "388",
+            "state": "passed",
+            "duration": 717,
+            "event_type": "pull_request",
+            "previous_state": "passed",
+            "pull_request_title": "Docd 1025",
+            "pull_request_number": 54,
+            "started_at": "2017-06-06T13:46:06Z",
+            "finished_at": "2017-06-06T13:58:03Z",
+            "repository": {
+                "@type": "repository",
+                "@href": "/api/repo/1996",
+                "@representation": "minimal",
+                "id": 1996,
+                "name": "orca",
+                "slug": "spt-infrastructure/orca"
+            },
+            "branch": {
+                "@type": "branch",
+                "@href": "/api/repo/1996/branch/sch_master",
+                "@representation": "minimal",
+                "name": "sch_master"
+            },
+            "commit": {
+                "@type": "commit",
+                "@representation": "minimal",
+                "id": 801226,
+                "sha": "40e8099ba9cab03febe17b38a650b8868434a068",
+                "ref": "refs/pull/54/merge",
+                "message": "DOCD-1025 enable pipelineTemplates and add proxy",
+                "compare_url": "https://github.schibsted.io/spt-infrastructure/orca/pull/54",
+                "committed_at": "2017-06-06T13:34:13Z"
+            },
+            "jobs": [
+                {
+                    "@type": "job",
+                    "@href": "/api/job/1384444",
+                    "@representation": "minimal",
+                    "id": 1384444
+                }
+            ]
+        }
+    ]
+}
+'''
+
+        when:
+        V3Builds builds = client.v3builds("someToken", "org/repo","bah", 2)
+
+        then:
+        builds.builds.size() == 2
     }
 
     def "commits, dont mark regular branches as tags"() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.igor.travis.client.model.AccessToken
 import com.netflix.spinnaker.igor.travis.client.model.Build
 import com.netflix.spinnaker.igor.travis.client.model.Builds
 import com.netflix.spinnaker.igor.travis.client.model.Commit
+import com.netflix.spinnaker.igor.travis.client.model.v3.TravisBuildType
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -177,5 +178,20 @@ class TravisServiceSpec extends Specification{
 
         then:
         branchedRepoSlug == "my/slug"
+    }
+
+    @Unroll
+    def "resolve travis build type from input repo slug"() {
+        expect:
+        service.travisBuildTypeFromRepoSlug(inputRepoSlug) == expectedTravisBuildType
+
+        where:
+        inputRepoSlug                     || expectedTravisBuildType
+        "my-org/repo"                     || TravisBuildType.unknown
+        "my-org/repo/branch"              || TravisBuildType.branch
+        "my-org/repo/branch/with/slashes" || TravisBuildType.branch
+        "my-org/repo/pull_request_master" || TravisBuildType.pull_request
+        "m/r/some_pull_request_in_name"   || TravisBuildType.branch
+        "my-org/repo/tags"                || TravisBuildType.tag
     }
 }


### PR DESCRIPTION
… populate reasonable amount of builds when manually triggering pipelines

The old implementation of this only took the last 25 builds from the travis job and filtered that list to give the user a list of builds to select from. Now we filter as much as we can in the request and this gives the user a more consistent experience when selecting builds to trigger with.

Tags is still handled differently, because there is no filter in the travis api to get only tag builds.