### PR TITLE
chore(logs): Adjusting log levels to reduce noise

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/IgorConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/IgorConfig.groovy
@@ -62,7 +62,6 @@ class IgorConfig extends WebMvcConfigurerAdapter {
 
     @Bean
     BuildMasters buildMasters() {
-        log.info "creating buildMaster"
         new BuildMasters()
     }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -77,14 +77,14 @@ class DockerMonitor implements PollingMonitor {
         String account = accountDetails.name
         Boolean trackDigests = accountDetails.trackDigests ?: false
 
-        log.info 'Checking for new tags for ' + account
+        log.debug 'Checking for new tags for ' + account
         try {
             lastPoll = System.currentTimeMillis()
             List<String> cachedImages = cache.getImages(account)
 
             def startTime = System.currentTimeMillis()
             List<TaggedImage> images = dockerRegistryAccounts.service.getImagesByAccount(account)
-            log.info("Took ${System.currentTimeMillis() - startTime}ms to retrieve images (account: ${account})")
+            log.debug("Took ${System.currentTimeMillis() - startTime}ms to retrieve images (account: ${account})")
 
             Map<String, TaggedImage> imageIds = images.collectEntries {
                 [(cache.makeKey(account, it.registry, it.repository, it.tag)): it]

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -148,11 +148,11 @@ class JenkinsBuildMonitor implements PollingMonitor {
         try {
             JenkinsService jenkinsService = buildMasters.map[master] as JenkinsService
             List<Project> jobs = jenkinsService.getProjects()?.getList() ?:[]
-            log.info("Jobs on master: ${master} ${jobs.size()}")
+            log.debug("Jobs on master: ${master} ${jobs.size()}")
 
             for (Project job : jobs) {
                 if (!job.lastBuild) {
-                    log.info("[${master}:${job.name}] has no builds skipping...")
+                    log.debug("[${master}:${job.name}] has no builds skipping...")
                     continue
                 }
 
@@ -160,14 +160,14 @@ class JenkinsBuildMonitor implements PollingMonitor {
                 Long lastBuildStamp = job.lastBuild.timestamp as Long
                 Date upperBound = new Date(lastBuildStamp)
 
-                log.info("[${master}:${job.name}] last cursor was ${cursor}, last build on this job was at ${upperBound}")
+                log.debug("[${master}:${job.name}] last cursor was ${cursor}, last build on this job was at ${upperBound}")
 
                 if (!cursor) {
-                    log.info("[${master}:${job.name}] setting new cursor to ${lastBuildStamp}")
+                    log.debug("[${master}:${job.name}] setting new cursor to ${lastBuildStamp}")
                     cache.setLastPollCycleTimestamp(master, job.name, lastBuildStamp);
                 } else {
                     if (cursor == lastBuildStamp) {
-                        log.info("[${master}:${job.name}] is up to date. skipping")
+                        log.debug("[${master}:${job.name}] is up to date. skipping")
                         continue
                     }
 
@@ -187,7 +187,7 @@ class JenkinsBuildMonitor implements PollingMonitor {
                     completedBuilds.forEach { build ->
                         Boolean eventPosted = cache.getEventPosted(master, job.name, cursor, build.number)
                         if (!eventPosted) {
-                            log.info("[${master}:${job.name}]:${build.number} event posted")
+                            log.debug("[${master}:${job.name}]:${build.number} event posted")
                             postEvent(echoService, new Project(name: job.name, lastBuild: build), master)
                             cache.setEventPosted(master, job.name, cursor, build.number)
                         }
@@ -205,7 +205,7 @@ class JenkinsBuildMonitor implements PollingMonitor {
             log.error("Error processing builds for ${master}", e)
         }
 
-        log.info("Took ${System.currentTimeMillis() - startTime}ms to retrieve projects (master: ${master})")
+        log.debug("Took ${System.currentTimeMillis() - startTime}ms to retrieve projects (master: ${master})")
     }
 
     static void postEvent(EchoService echoService,  Project project, String master) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/ScmInfoController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/ScmInfoController.groovy
@@ -43,7 +43,6 @@ class ScmInfoController {
 
     @RequestMapping(value = '/masters', method = RequestMethod.GET)
     Map listMasters() {
-        log.info('Getting list of masters')
         def result = [:]
         if(stashMaster)
             result << [stash : stashMaster.baseUrl]


### PR DESCRIPTION
A first, very small step towards cleaning up Spinnaker's overall logging story. Aim of this PR is just to tune down the amount of disproportionate noise igor generates into our ES cluster. I'm happy to straight up delete some of these messages, too.

Example of our ElasticSearch log lines over 15 minutes as it is today:

<img width="246" alt="screen shot 2017-06-20 at 7 58 56 pm" src="https://user-images.githubusercontent.com/108741/27408068-cde4b924-568f-11e7-992a-8cc8a5d5fbb6.png">

@spinnaker/reviewers PTAL