### PR TITLE
feat(builds): add logs endpoint for specific job output

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -248,6 +248,18 @@ class BuildController {
 
     }
 
+    @RequestMapping(value = '/masters/{name}/jobs/{jobName}/{buildNumber}/logs')
+    String getLogs(@PathVariable("name") String master,
+                   @PathVariable String jobName,
+                   @PathVariable Integer buildNumber) {
+        if (!buildMasters.map.containsKey(master)) {
+            throw new MasterNotFoundException("Master '${master}' not found")
+        }
+
+        def buildService = buildMasters.map[master]
+        return buildService.getLog(jobName, buildNumber)
+    }
+
     @ExceptionHandler(BuildJobError.class)
     void handleBuildJobError(HttpServletResponse response, BuildJobError e) throws IOException {
         log.error(e.getMessage())

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -83,6 +83,9 @@ interface JenkinsClient {
     @GET('/job/{jobName}/api/xml?exclude=/*/action&exclude=/*/build&exclude=/*/property[not(parameterDefinition)]')
     JobConfig getJobConfig(@EncodedPath('jobName') String jobName)
 
+    @GET('/job/{jobName}/{buildNumber}/consoleText')
+    Response getLog(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
+
     @Streaming
     @GET('/job/{jobName}/{buildNumber}/artifact/{fileName}')
     Response getPropertyFile(

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
@@ -35,8 +35,9 @@ import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.service.BuildService
 import org.springframework.web.util.UriUtils
 import retrofit.client.Response
+import retrofit.mime.TypedByteArray
 
-class JenkinsService implements BuildService{
+class JenkinsService implements BuildService {
     final String groupKey
     final JenkinsClient jenkinsClient
 
@@ -97,6 +98,12 @@ class JenkinsService implements BuildService{
 
     Build getBuild(String jobName, Integer buildNumber) {
         return jenkinsClient.getBuild(encode(jobName), buildNumber)
+    }
+
+    @Override
+    String getLog(String jobName, int buildNumber) {
+        Response response = jenkinsClient.getLog(encode(jobName), buildNumber)
+        return new String(((TypedByteArray) response.getBody()).getBytes())
     }
 
     @Override

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.groovy
@@ -29,4 +29,6 @@ interface BuildService {
 
     int triggerBuildWithParameters(String job, Map<String, String> queryParameters)
 
+    String getLog(String job, int buildNumber)
+
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -88,6 +88,10 @@ interface TravisClient {
     @GET('/jobs/{job_id}')
     Jobs jobs(@Header("Authorization") String accessToken , @Path('job_id') int jobId)
 
+    @Headers("Accept: text/plain")
+    @GET('/jobs/{job_id}/log')
+    String logForJob(@Header("Authorization") String accessToken , @Path('job_id') int jobId)
+
     @Streaming
     @Headers("Accept: text/plain")
     @GET('/logs/{logId}')

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -258,6 +258,13 @@ class TravisService implements BuildService {
         return buildLog
     }
 
+    String getLog(String jobName, int jobId) {
+        log.debug "fetching job log for ${jobId}"
+        Response response = travisClient.logForJob(getAccessToken(), jobId)
+        String job_log = new String(((TypedByteArray) response.getBody()).getBytes());
+        return job_log
+    }
+
     String getLog(int logId) {
         log.debug "fetching log by logId ${logId}"
         Response response = travisClient.log(getAccessToken(), logId)


### PR DESCRIPTION
Kicking around an idea for Orca to pull logs if a script stage fails and include them in the stage context as an alternative to https://github.com/spinnaker/deck/pull/3868

I took a wild guess at the TravisCI API - no idea if it's correct.