### PR TITLE
chore(dependencies): Bump spinnaker-dependencies to 0.103.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
     apply plugin: 'groovy'
 
     ext {
-        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.91.0'
+        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.103.0'
     }
 
     def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]


### PR DESCRIPTION
The generic exception handling from `kork-web` will now:
- include supplied exception messages in error responses
- propagate an underlying retrofit error's http status instead of http 500
