### PR TITLE
chore(dependencies): Bump spinnaker-dependencies to 0.104.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
     apply plugin: 'groovy'
 
     ext {
-        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.103.0'
+        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.104.0'
     }
 
     def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]


### PR DESCRIPTION
Generic support for exceptions that have `@ResponseStatus` on a
super class (or interface).
