### PR TITLE
Pubsub client

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -30,13 +30,15 @@ dependencies {
 
     compile 'org.yaml:snakeyaml:1.15'
     compile 'com.squareup.retrofit:converter-simplexml:1.9.0'
+    compile 'com.google.cloud:google-cloud-pubsub:0.21.1-beta'
     testCompile 'com.squareup.okhttp:mockwebserver:2.7.0'
 }
 
 configurations.all {
     resolutionStrategy {
         force 'org.apache.log4j:log4j:1.2.17'
-        force 'com.google.guava:guava:14.0.1'
+//        force 'com.google.guava:guava:14.0.1'
+        force 'com.google.guava:guava:20.0'
         force 'commons-codec:commons-codec:1.7'
     }
     exclude group: 'javax.servlet', module: 'servlet-api'

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -1,10 +1,12 @@
 ext {
   springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
+  springProfiles = System.getProperty('spring.profiles.active', "test,local")
   repackage = System.getProperty('springBoot.repackage', "false")
 }
 
 tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
   systemProperty('spring.config.location', project.springConfigLocation)
+  systemProperty('spring.profiles.active', project.springProfiles)
 }
 
 apply plugin: 'spring-boot'
@@ -37,7 +39,6 @@ dependencies {
 configurations.all {
     resolutionStrategy {
         force 'org.apache.log4j:log4j:1.2.17'
-//        force 'com.google.guava:guava:14.0.1'
         force 'com.google.guava:guava:20.0'
         force 'commons-codec:commons-codec:1.7'
     }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/IgorConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/IgorConfig.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.igor.config
 
 import com.netflix.hystrix.exception.HystrixRuntimeException
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.igor.pubsub.PubsubSubscribers
 import com.netflix.spinnaker.igor.service.ArtifactDecorator
 import com.netflix.spinnaker.igor.service.BuildMasters
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
@@ -63,6 +64,11 @@ class IgorConfig extends WebMvcConfigurerAdapter {
     @Bean
     BuildMasters buildMasters() {
         new BuildMasters()
+    }
+
+    @Bean
+    PubsubSubscribers pubsubSubscribers() {
+        new PubsubSubscribers()
     }
 
     @Bean

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/google/GooglePubsubConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/google/GooglePubsubConfig.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config.pubsub.google
+
+import com.netflix.spinnaker.igor.history.EchoService
+import com.netflix.spinnaker.igor.pubsub.PubsubMessageCache
+import com.netflix.spinnaker.igor.pubsub.PubsubSubscribers
+import com.netflix.spinnaker.igor.pubsub.googlePubsub.GooglePubsubSubscriber
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+import javax.validation.Valid
+
+@Configuration
+@Slf4j
+@CompileStatic
+@ConditionalOnProperty("googlePubsub.enabled")
+@EnableConfigurationProperties(GooglePubsubProperties)
+class GooglePubsubConfig {
+
+  @Bean
+  Map<String, GooglePubsubSubscriber> googlePubsubSubscribers(PubsubSubscribers pubsubSubscribers,
+                                                              EchoService echoService,
+                                                              PubsubMessageCache pubsubMessageCache,
+                                                              @Valid GooglePubsubProperties googlePubsubProperties) {
+    log.info("Creating Google Pubsub Subscribers")
+    Map<String, GooglePubsubSubscriber> subscriberMap = googlePubsubProperties?.subscriptions?.collectEntries { GooglePubsubProperties.GooglePubsubSubscription subscription ->
+      log.info "Bootstrapping Google Pubsub Subscriber listening to topic: ${subscription.name} in project: ${subscription.project}"
+      GooglePubsubSubscriber subscriber = GooglePubsubSubscriber
+          .buildSubscriber(subscription.name, subscription.project, subscription.jsonPath, subscription.ackDeadlineSeconds, echoService, pubsubMessageCache)
+      [("projects/${subscription.project}/topics/${subscription.name}".toString()): subscriber]
+    }
+
+    pubsubSubscribers.map.putAll subscriberMap
+    subscriberMap
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/google/GooglePubsubProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/google/GooglePubsubProperties.groovy
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import javax.validation.Valid
 import javax.validation.constraints.NotNull
 
-@ConfigurationProperties(prefix = 'googlePubsub')
+@ConfigurationProperties(prefix = 'pubsub.google')
 class GooglePubsubProperties {
   @Valid
   List<GooglePubsubSubscription> subscriptions
@@ -40,5 +40,4 @@ class GooglePubsubProperties {
     // Not required since topics can be public.
     String jsonPath
   }
-
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/google/GooglePubsubProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/google/GooglePubsubProperties.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config.pubsub.google
+
+import org.hibernate.validator.constraints.NotEmpty
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+@ConfigurationProperties(prefix = 'googlePubsub')
+class GooglePubsubProperties {
+  @Valid
+  List<GooglePubsubSubscription> subscriptions
+
+  static class GooglePubsubSubscription {
+    @NotEmpty
+    String project
+
+    @NotEmpty
+    String name
+
+    @NotNull
+    Integer ackDeadlineSeconds
+
+    // Not required since topics can be public.
+    String jsonPath
+  }
+
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/kafka/KafkaConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/kafka/KafkaConfig.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config.pubsub.kafka
+
+class KafkaConfig {
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/kafka/KafkaProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/kafka/KafkaProperties.groovy
@@ -1,0 +1,4 @@
+package com.netflix.spinnaker.igor.config.pubsub.kafka
+
+class KafkaProperties {
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/kafka/KafkaProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/pubsub/kafka/KafkaProperties.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.igor.config.pubsub.kafka
 
 class KafkaProperties {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/PubsubEvent.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/PubsubEvent.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.history.model
+
+/**
+ * A history entry containing a pubsub message payload
+ */
+class PubsubEvent extends Event {
+
+  /**
+   * JSON-encoded message payload
+   */
+  String payload
+  Map details = [
+      type  : 'pubsub',
+      source: 'igor'
+  ]
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/PubsubType.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/PubsubType.groovy
@@ -17,6 +17,17 @@
 package com.netflix.spinnaker.igor.model
 
 enum PubsubType {
-  GOOGLE,
-  KAFKA
+  GOOGLE('googlePubsub'),
+  KAFKA('kafka')
+
+  String type
+
+  PubsubType(String type) {
+    this.type = type
+  }
+
+  @Override
+  String toString() {
+    type
+  }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/PubsubType.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/PubsubType.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.model
+
+enum PubsubType {
+  GOOGLE,
+  KAFKA
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubMessageCache.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubMessageCache.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.pubsub
+
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import redis.clients.jedis.JedisPool
+
+/**
+ * Shared cache of received and handled pubsub message to synchronize clients.
+ */
+@Service
+class PubsubMessageCache {
+  @Autowired
+  JedisPool jedisPool
+
+  @Autowired
+  IgorConfigurationProperties igorConfigurationProperties
+
+  // TODO(jacobkiefer): This is a temporary in-memory store for handled
+  // messages before we implement the distributed Redis solution.
+  // This will function properly only with exactly one Igor instance.
+  private HashSet<String> handledMessages = new HashSet<String>()
+
+  String getPrefix() {
+    igorConfigurationProperties.spinnaker.jedis.prefix
+  }
+
+  Boolean handleMessage(String messageKey) {
+    if (handledMessages.contains(messageKey)) {
+      // Message has already been processed.
+      return false
+    } else {
+      return handledMessages.add(messageKey)
+    }
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubSubscriber.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubSubscriber.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.pubsub
+
+import com.netflix.spinnaker.igor.model.PubsubType
+
+interface PubsubSubscriber {
+  PubsubType pubsubType()
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubSubscriber.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubSubscriber.groovy
@@ -18,6 +18,10 @@ package com.netflix.spinnaker.igor.pubsub
 
 import com.netflix.spinnaker.igor.model.PubsubType
 
-interface PubsubSubscriber {
-  PubsubType pubsubType()
+import javax.naming.OperationNotSupportedException
+
+abstract class PubsubSubscriber {
+  static PubsubType pubsubType() {
+    throw new OperationNotSupportedException('Static function "pubsubType()" not implemented for abstract class')
+  }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubSubscribers.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubSubscribers.groovy
@@ -19,9 +19,17 @@ package com.netflix.spinnaker.igor.pubsub
 import com.netflix.spinnaker.igor.model.PubsubType
 
 class PubsubSubscribers {
-  Map<String, PubsubSubscriber> map = new HashMap<String, PubsubSubscriber>()
+  private Map<String, PubsubSubscriber> subscriberByName = new HashMap<String, PubsubSubscriber>()
+
+  void putAll(Map<String, PubsubSubscriber> newEntries) {
+    subscriberByName.putAll(newEntries)
+  }
 
   Map<String, PubsubSubscriber> filteredMap(PubsubType pubsubType) {
-    map.findAll { it.value.pubsubType() ==  pubsubType }
+    subscriberByName.findAll { it.value.pubsubType() ==  pubsubType }
+  }
+
+  PubsubSubscriber get(String topic) {
+    return subscriberByName[topic]
   }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubSubscribers.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/PubsubSubscribers.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.pubsub
+
+import com.netflix.spinnaker.igor.model.PubsubType
+
+class PubsubSubscribers {
+  Map<String, PubsubSubscriber> map = new HashMap<String, PubsubSubscriber>()
+
+  Map<String, PubsubSubscriber> filteredMap(PubsubType pubsubType) {
+    map.findAll { it.value.pubsubType() ==  pubsubType }
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/googlePubsub/GooglePubsubMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/googlePubsub/GooglePubsubMonitor.groovy
@@ -28,7 +28,6 @@ import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 
 import javax.annotation.PreDestroy
-import java.util.concurrent.TimeUnit
 
 /**
  * Monitors Google Cloud Pubsub subscriptions.
@@ -36,7 +35,7 @@ import java.util.concurrent.TimeUnit
 @Slf4j
 @Service
 @Async
-@ConditionalOnProperty('googlePubsub.enabled')
+@ConditionalOnProperty('pubsub.google.enabled')
 class GooglePubsubMonitor implements PollingMonitor {
 
   Long lastPoll
@@ -57,6 +56,7 @@ class GooglePubsubMonitor implements PollingMonitor {
 
   @Override
   void onApplicationEvent(ContextRefreshedEvent event) {
+    // TODO(jacobkiefer): Register Igor as enabled on startup.
     log.info('Starting async connections for Google Pubsub subscribers')
     pubsubSubscribers.filteredMap(PubsubType.GOOGLE).keySet().parallelStream().forEach(
         { subscription -> openConnection(subscription) }
@@ -68,12 +68,12 @@ class GooglePubsubMonitor implements PollingMonitor {
     def startTime = System.currentTimeMillis()
     lastPoll = startTime
 
-    GooglePubsubSubscriber subscriber = pubsubSubscribers.map[subscription] as GooglePubsubSubscriber
+    GooglePubsubSubscriber subscriber = pubsubSubscribers.get(subscription) as GooglePubsubSubscriber
     subscriber.subscriber.startAsync()
   }
 
   void closeConnection(String subscription) {
-    GooglePubsubSubscriber subscriber = pubsubSubscribers.map[subscription] as GooglePubsubSubscriber
+    GooglePubsubSubscriber subscriber = pubsubSubscribers.get(subscription) as GooglePubsubSubscriber
     subscriber.subscriber.stopAsync()
   }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/googlePubsub/GooglePubsubMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/googlePubsub/GooglePubsubMonitor.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.pubsub.googlePubsub
+
+import com.netflix.spinnaker.igor.config.pubsub.google.GooglePubsubProperties
+import com.netflix.spinnaker.igor.model.PubsubType
+import com.netflix.spinnaker.igor.polling.PollingMonitor
+import com.netflix.spinnaker.igor.pubsub.PubsubSubscribers
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+
+import javax.annotation.PreDestroy
+import java.util.concurrent.TimeUnit
+
+/**
+ * Monitors Google Cloud Pubsub subscriptions.
+ */
+@Slf4j
+@Service
+@Async
+@ConditionalOnProperty('googlePubsub.enabled')
+class GooglePubsubMonitor implements PollingMonitor {
+
+  Long lastPoll
+
+  @Autowired
+  PubsubSubscribers pubsubSubscribers
+
+  @Autowired
+  GooglePubsubProperties pubsubProperties
+
+  @PreDestroy
+  void closeAsyncConnections() {
+    log.info('Closing async connections for Google Pubsub subscribers')
+    pubsubSubscribers.filteredMap(PubsubType.GOOGLE).keySet().parallelStream().forEach(
+        { subscription -> closeConnection(subscription) }
+    )
+  }
+
+  @Override
+  void onApplicationEvent(ContextRefreshedEvent event) {
+    log.info('Starting async connections for Google Pubsub subscribers')
+    pubsubSubscribers.filteredMap(PubsubType.GOOGLE).keySet().parallelStream().forEach(
+        { subscription -> openConnection(subscription) }
+    )
+  }
+
+  void openConnection(String subscription) {
+    log.info("Opening async connection to ${subscription}")
+    def startTime = System.currentTimeMillis()
+    lastPoll = startTime
+
+    GooglePubsubSubscriber subscriber = pubsubSubscribers.map[subscription] as GooglePubsubSubscriber
+    subscriber.subscriber.startAsync()
+  }
+
+  void closeConnection(String subscription) {
+    GooglePubsubSubscriber subscriber = pubsubSubscribers.map[subscription] as GooglePubsubSubscriber
+    subscriber.subscriber.stopAsync()
+  }
+
+  @Override
+  String getName() {
+    "GooglePubsubMonitor"
+  }
+
+  @Override
+  boolean isInService() {
+    return true
+  }
+
+  @Override
+  Long getLastPoll() {
+    lastPoll
+  }
+
+  @Override
+  int getPollInterval() {
+    -1
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/googlePubsub/GooglePubsubSubscriber.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/googlePubsub/GooglePubsubSubscriber.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.pubsub.googlePubsub
+
+import com.google.api.core.ApiService
+import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.auth.Credentials
+import com.google.auth.oauth2.ServiceAccountCredentials
+import com.google.cloud.pubsub.v1.AckReplyConsumer
+import com.google.cloud.pubsub.v1.MessageReceiver
+import com.google.cloud.pubsub.v1.Subscriber
+import com.google.common.util.concurrent.MoreExecutors
+import com.google.pubsub.v1.PubsubMessage
+import com.google.pubsub.v1.SubscriptionName
+import com.netflix.spinnaker.igor.history.EchoService
+import com.netflix.spinnaker.igor.history.model.PubsubEvent
+import com.netflix.spinnaker.igor.model.PubsubType
+import com.netflix.spinnaker.igor.pubsub.PubsubMessageCache
+import com.netflix.spinnaker.igor.pubsub.PubsubSubscriber
+import groovy.util.logging.Slf4j
+
+import java.security.MessageDigest
+
+@Slf4j
+class GooglePubsubSubscriber implements PubsubSubscriber {
+  String name
+  String project
+  Subscriber subscriber
+  Integer ackDeadlineSeconds
+
+
+  @Override
+  PubsubType pubsubType() {
+    return PubsubType.GOOGLE
+  }
+
+  static GooglePubsubSubscriber buildSubscriber(String name,
+                                                String project,
+                                                String jsonPath,
+                                                Integer ackDeadlineSeconds,
+                                                EchoService echoService,
+                                                PubsubMessageCache pubsubMessageCache) {
+    Subscriber subscriber
+    GooglePubsubMessageReceiver messageReceiver = new GooglePubsubMessageReceiver(
+        ackDeadlineSeconds: ackDeadlineSeconds,
+        echoService: echoService,
+        subscriptionName: name,
+        pubsubMessageCache: pubsubMessageCache
+    )
+
+    if (jsonPath) {
+      Credentials credentials = ServiceAccountCredentials.fromStream(new FileInputStream(jsonPath))
+      subscriber = Subscriber
+          .defaultBuilder(SubscriptionName.create(project, name), messageReceiver)
+          .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
+          .build()
+    } else {
+      subscriber = Subscriber
+          .defaultBuilder(SubscriptionName.create(project, name), messageReceiver)
+          .build()
+    }
+
+    subscriber.addListener(new GooglePubsubFailureHandler(), MoreExecutors.directExecutor())
+
+    return new GooglePubsubSubscriber(
+        name: name,
+        project: project,
+        subscriber: subscriber,
+        ackDeadlineSeconds: ackDeadlineSeconds
+    )
+  }
+
+  static class GooglePubsubMessageReceiver implements MessageReceiver {
+    EchoService echoService
+
+    PubsubMessageCache pubsubMessageCache
+
+    Integer ackDeadlineSeconds
+
+    String subscriptionName
+
+    private MessageDigest digest = MessageDigest.getInstance("SHA-256")
+
+    @Override
+    void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+      String messagePayload = message.data.toStringUtf8()
+      log.debug("Received message with payload: ${messagePayload}")
+      String messageKey = makeKey(pubsubMessageCache.prefix, messagePayload)
+      if (pubsubMessageCache.handleMessage(messageKey)) {
+        consumer.ack()
+        postEvent(message)
+      } else {
+        consumer.nack()
+      }
+    }
+
+    private String makeKey(String prefix, String messagePayload) {
+      digest.reset()
+      digest.update(messagePayload.bytes)
+      String messageHash = new String(digest.digest())
+      return "${prefix}:googlePubsub:${subscriptionName}:${messageHash}"
+    }
+
+    void postEvent(PubsubMessage message) {
+      if (echoService) {
+        log.info("Posted message: ${message.data.toStringUtf8()} to Echo")
+//        echoService.postEvent(
+//            new PubsubEvent(payload: message.data.toStringUtf8())
+//        )
+      }
+    }
+  }
+
+  static class GooglePubsubFailureHandler extends ApiService.Listener {
+    @Override
+    void failed(ApiService.State from, Throwable failure) {
+      throw failure
+    }
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/kafka/KafkaPubsubMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/kafka/KafkaPubsubMonitor.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.pubsub.kafka
+
+class KafkaPubsubMonitor {
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/kafka/KafkaPubsubSubscriber.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/kafka/KafkaPubsubSubscriber.groovy
@@ -19,9 +19,9 @@ package com.netflix.spinnaker.igor.pubsub.kafka
 import com.netflix.spinnaker.igor.model.PubsubType
 import com.netflix.spinnaker.igor.pubsub.PubsubSubscriber
 
-class KafkaPubsubSubscriber implements PubsubSubscriber {
+class KafkaPubsubSubscriber extends PubsubSubscriber {
   @Override
-  PubsubType pubsubType() {
+  static PubsubType pubsubType() {
     return PubsubType.KAFKA
   }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/kafka/KafkaPubsubSubscriber.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/pubsub/kafka/KafkaPubsubSubscriber.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.pubsub.kafka
+
+import com.netflix.spinnaker.igor.model.PubsubType
+import com.netflix.spinnaker.igor.pubsub.PubsubSubscriber
+
+class KafkaPubsubSubscriber implements PubsubSubscriber {
+  @Override
+  PubsubType pubsubType() {
+    return PubsubType.KAFKA
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/utils/NodeIdentity.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/utils/NodeIdentity.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.utils
+
+import java.lang.management.ManagementFactory
+
+class NodeIdentity {
+
+  public static final String UNKNOWN_HOST = "UnknownHost"
+
+  String runtimeName
+  String hostName
+  String identity
+
+  NodeIdentity() {
+    this('www.google.com', 80)
+  }
+
+  NodeIdentity(String validationAddress, Integer validationPort) {
+    this.runtimeName = ManagementFactory.getRuntimeMXBean().getName()
+    this.hostName = resolveHostname(validationAddress, validationPort)
+    if (hostName != UNKNOWN_HOST) {
+      this.identity = "${this.hostName}:${this.runtimeName}"
+    }
+  }
+
+  @SuppressWarnings("PMD.EmptyCatchBlock")
+  private static String resolveHostname(String validationHost, int validationPort) {
+    final Enumeration<NetworkInterface> interfaces
+    try {
+      interfaces = NetworkInterface.getNetworkInterfaces()
+    } catch (SocketException ignored) {
+      return UNKNOWN_HOST
+    }
+    if (interfaces == null) {
+      return UNKNOWN_HOST
+    }
+
+    for (NetworkInterface networkInterface : Collections.list(interfaces)) {
+      try {
+        if (networkInterface.isLoopback()) {
+          continue
+        }
+
+        if (!networkInterface.isUp()) {
+          continue
+        }
+      } catch (SocketException ignored) {
+        continue
+      }
+
+      for (InetAddress address : Collections.list(networkInterface.getInetAddresses())) {
+        Socket socket = null
+        try {
+          socket = new Socket()
+          socket.bind(new InetSocketAddress(address, 0))
+          socket.connect(new InetSocketAddress(validationHost, validationPort), 125)
+          return address.getHostName()
+        } catch (IOException ignored) {
+          //ignored
+        } finally {
+          if (socket != null) {
+            try {
+              socket.close()
+            } catch (IOException ignored) {
+              //ignored
+            }
+          }
+        }
+      }
+    }
+
+    return UNKNOWN_HOST
+  }
+}


### PR DESCRIPTION
This is a start on adding pubsub clients into Igor. Two commits here:

1. Adds relevant configuration, subscription, and monitor classes for Kafka and Google Pubsub. Only Google Pubsub is implemented, Kafka is stubbed in. Handles accounting of received messages in memory.

2. Adds the Redis/Jedis-based client synchronization and uses said implementation in the Google Pubsub message handling.