### PR TITLE
feat(travis/commit_info) Add committer and compareUrl to the build status

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.groovy
@@ -16,12 +16,19 @@
 
 package com.netflix.spinnaker.igor.build.model
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class GenericGitRevision {
     String branch
 
     String name
 
     String sha1
+
+    String committer
+
+    String compareUrl
 
     GenericGitRevision(String name, String branch, String sha1) {
         this.name = name

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Commit.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Commit.groovy
@@ -41,7 +41,14 @@ class Commit {
     String compareUrl
 
     GenericGitRevision genericGitRevision() {
-        return new GenericGitRevision(branch, branch, sha)
+        GenericGitRevision genericGitRevision = new GenericGitRevision(branch, branch, sha)
+        if (authorName) {
+            genericGitRevision.setCommitter(authorName)
+        }
+        if (compareUrl) {
+            genericGitRevision.setCompareUrl(compareUrl)
+        }
+        return genericGitRevision
     }
 
     boolean isTag(){


### PR DESCRIPTION
This adds committer and compare url to the scm info when available in travis builds. This is the first step of making the pipeline in ui contain more relevant info for each pipeline execution.
```
{
"building":false,
"name":"org/repo",
"number":610,
"duration":626,
"timestamp":"1503563992000",
"result":"SUCCESS",
"artifacts":[],
"url":"https://travis.xxx.yy/org/repo/builds/1778996",
"scm":[
  {
    "branch":"master",
    "name":"master",
    "sha1":"7bd574b5a2eea9d6d3ddc41d26cfc0a7cb1bc7e1",
     "committer":"Gard Rimestad",
  
  "compareUrl":"https://github.com/org/repo/compare/939543bcee5b328012b869adb639f2df5c6f18ca...7bd574b5a2eea9d6d3ddc41d26cfc0a7cb1bc7e1"
  }
]
}
```
Ping @anotherchrisberry