### PR TITLE
feat(travis/commit_info) Add commit message to the scm payload

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.groovy
@@ -20,19 +20,23 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 class GenericGitRevision {
-    String branch
-
     String name
-
+    String branch
     String sha1
-
     String committer
-
     String compareUrl
+    String message
 
     GenericGitRevision(String name, String branch, String sha1) {
         this.name = name
         this.branch = branch
         this.sha1 = sha1
+    }
+
+    GenericGitRevision(String name, String branch, String sha1, String committer, String compareUrl, String message) {
+        this(name, branch, sha1)
+        this.committer = committer
+        this.compareUrl = compareUrl
+        this.message = message
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Commit.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/Commit.groovy
@@ -27,11 +27,8 @@ import org.simpleframework.xml.Root
 @Root(name = 'commits')
 class Commit {
     int id
-
     String sha
-
     String branch
-
     String message
 
     @SerializedName("author_name")
@@ -41,14 +38,7 @@ class Commit {
     String compareUrl
 
     GenericGitRevision genericGitRevision() {
-        GenericGitRevision genericGitRevision = new GenericGitRevision(branch, branch, sha)
-        if (authorName) {
-            genericGitRevision.setCommitter(authorName)
-        }
-        if (compareUrl) {
-            genericGitRevision.setCompareUrl(compareUrl)
-        }
-        return genericGitRevision
+        return new GenericGitRevision(branch, branch, sha, authorName, compareUrl, message)
     }
 
     boolean isTag(){


### PR DESCRIPTION
This adds the commit message to the scm payload for travis builds.

The reason we do this is that we want to surface this information committer, sha1, link to diff and commit message in the UI. 