### PR TITLE
feat(authz): Add ability to specify Google service account credential…

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
@@ -21,6 +21,7 @@ import org.hibernate.validator.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 import javax.validation.Valid
+import javax.validation.constraints.Null
 
 /**
  * Helper class to map masters in properties file into a validated property map
@@ -43,5 +44,12 @@ class JenkinsProperties {
 
         @NotEmpty
         String password
+
+        // These are needed for Google-based OAuth with a service account credential
+        String jsonPath
+        List<String> oauthScopes = []
+
+        // Can be used directly, if available.
+        String token
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/auth/AuthRequestInterceptor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/auth/AuthRequestInterceptor.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config.auth
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.netflix.spinnaker.igor.config.JenkinsProperties
+import com.squareup.okhttp.Credentials
+import groovy.util.logging.Slf4j
+import retrofit.RequestInterceptor
+
+@Slf4j
+class AuthRequestInterceptor implements RequestInterceptor {
+    List<AuthorizationHeaderSupplier> suppliers = []
+
+    AuthRequestInterceptor(JenkinsProperties.JenkinsHost host) {
+        // Order may be significant here.
+        if (host.username && host.password) {
+            suppliers.add(new BasicAuthHeaderSupplier(host.username, host.password))
+        }
+        if (host.jsonPath && host.oauthScopes) {
+            suppliers.add(new GoogleBearerTokenHeaderSupplier(host.jsonPath, host.oauthScopes))
+        } else if (host.token) {
+            suppliers.add(new BearerTokenHeaderSupplier(token: host.token))
+        }
+    }
+
+    @Override
+    void intercept(RequestInterceptor.RequestFacade request) {
+        if (suppliers) {
+            def values = suppliers.join(", ")
+            request.addHeader("Authorization", values)
+        }
+    }
+
+    static interface AuthorizationHeaderSupplier {
+        /**
+         * Returns the value to be added as the value in the "Authorization" HTTP header.
+         * @return
+         */
+        String toString()
+    }
+
+    static class BasicAuthHeaderSupplier implements AuthorizationHeaderSupplier {
+
+        private final String username
+        private final String password
+
+        BasicAuthHeaderSupplier(String username, String password) {
+            this.username = username
+            this.password = password
+        }
+
+        String toString() {
+            log.debug("Including Basic digest in Authorization header")
+            return Credentials.basic(username, password)
+        }
+    }
+
+    static class GoogleBearerTokenHeaderSupplier implements AuthorizationHeaderSupplier {
+
+        private GoogleCredential credential
+
+        GoogleBearerTokenHeaderSupplier(String jsonPath, List<String> scopes) {
+            InputStream is = new File(jsonPath).newInputStream()
+            credential = GoogleCredential.fromStream(is).createScoped(scopes)
+        }
+
+        String toString() {
+            log.debug("Including Google Bearer token in Authorization header")
+            if (credential.expirationTimeMilliseconds < System.currentTimeMillis()) {
+                log.info("Google OAuth Access token expired. Refreshing.")
+                credential.refreshToken()
+            }
+            return credential.accessToken
+        }
+    }
+
+    static class BearerTokenHeaderSupplier implements AuthorizationHeaderSupplier {
+        private token
+
+        String toString() {
+            log.debug("Including raw bearer token in Authorization header")
+            return "Bearer ${token}".toString()
+        }
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -17,20 +17,20 @@
 package com.netflix.spinnaker.igor.build
 
 import com.netflix.spinnaker.igor.config.JenkinsConfig
+import com.netflix.spinnaker.igor.config.JenkinsProperties
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.service.BuildMasters
 import com.squareup.okhttp.mockwebserver.MockResponse
 import com.squareup.okhttp.mockwebserver.MockWebServer
-import spock.lang.Shared
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import spock.lang.Shared
 import spock.lang.Specification
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 
 /**
  * tests for the info controller
@@ -124,7 +124,11 @@ class InfoControllerSpec extends Specification {
                 .setHeader('Content-Type', 'text/xml;charset=UTF-8')
         )
         server.start()
-        service = new JenkinsConfig().jenkinsService("jenkins", new JenkinsConfig().jenkinsClient(server.getUrl('/').toString(), 'username', 'password'))
+        def host = new JenkinsProperties.JenkinsHost(
+            address: server.getUrl('/').toString(),
+            username: 'username',
+            password: 'password')
+        service = new JenkinsConfig().jenkinsService("jenkins", new JenkinsConfig().jenkinsClient(host))
     }
 
     void 'is able to get a job config'() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/config/auth/AuthRequestInterceptorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/config/auth/AuthRequestInterceptorSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config.auth
+
+import com.netflix.spinnaker.igor.config.JenkinsProperties
+import retrofit.RequestInterceptor
+import spock.lang.Specification
+
+class AuthRequestInterceptorSpec extends Specification {
+
+    def "should append each auth header supplier's value"() {
+        setup:
+        def interceptor = new AuthRequestInterceptor(host)
+        def request = Mock(RequestInterceptor.RequestFacade)
+
+        when:
+        interceptor.intercept(request)
+
+        then:
+        1 * request.addHeader("Authorization", expectedHeader)
+
+        where:
+        host                                                                                    || expectedHeader
+        new JenkinsProperties.JenkinsHost(username: "user", password: "password")               || "Basic dXNlcjpwYXNzd29yZA=="
+        new JenkinsProperties.JenkinsHost(token: "foo")                                         || "Bearer foo"
+        new JenkinsProperties.JenkinsHost(username: "user", password: "password", token: "foo") || "Basic dXNlcjpwYXNzd29yZA==, Bearer foo"
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClientSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.igor.jenkins.client
 
 import com.netflix.spinnaker.igor.config.JenkinsConfig
+import com.netflix.spinnaker.igor.config.JenkinsProperties
 import com.netflix.spinnaker.igor.jenkins.client.model.Build
 import com.netflix.spinnaker.igor.jenkins.client.model.BuildArtifact
 import com.netflix.spinnaker.igor.jenkins.client.model.JobConfig
@@ -216,7 +217,11 @@ class JenkinsClientSpec extends Specification {
                 .setHeader('Content-Type', 'text/xml;charset=UTF-8')
         )
         server.start()
-        client = new JenkinsConfig().jenkinsClient(server.getUrl('/').toString(), 'username', 'password')
+        def host = new JenkinsProperties.JenkinsHost(
+            address: server.getUrl('/').toString(),
+            username: 'username',
+            password: 'password')
+        client = new JenkinsConfig().jenkinsClient(host)
     }
 
     private String getJobConfig() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.igor.jenkins.service
 
 import com.netflix.spinnaker.igor.config.JenkinsConfig
+import com.netflix.spinnaker.igor.config.JenkinsProperties
 import com.netflix.spinnaker.igor.jenkins.client.JenkinsClient
 import com.netflix.spinnaker.igor.jenkins.client.model.Project
 import com.squareup.okhttp.mockwebserver.MockResponse
@@ -106,7 +107,11 @@ class JenkinsServiceSpec extends Specification {
 
     void 'get a list of projects with the folders plugin'() {
         given:
-        client = new JenkinsConfig().jenkinsClient(server.getUrl('/').toString(), 'username', 'password')
+        def host = new JenkinsProperties.JenkinsHost(
+            address: server.getUrl('/').toString(),
+            username: 'username',
+            password: 'password')
+        client = new JenkinsConfig().jenkinsClient(host)
         service = new JenkinsService('http://my.jenkins.net', client)
 
         when:


### PR DESCRIPTION
… or raw OAuth bearer token to Jenkins master request.

I'm not 100% sure this will actually work as expected. Most Jenkins masters with username/password protection (including the one I tested with) require the `Basic` header, so any Oauth-guarded proxy will also require the ability to discern multiple values in the `Authorization header`. 

According to https://stackoverflow.com/a/38515091/5569046, this should work by RFC spec, but may not actually work in the wild. (cc @katrielt ) 