### PR TITLE
fix(travis/triggerBuild) Use request id given by travis for queue id.

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -94,7 +94,6 @@ class BuildController {
                 throw e
             }
         } else if (buildMasters.filteredMap(BuildServiceProvider.TRAVIS).containsKey(master)) {
-            log.info("pretending that I have a queue in travis for {}:{}", kv("master", master), kv("item", item))
             return buildMasters.map[master].queuedBuild(item)
         } else {
             throw new MasterNotFoundException("Master '${master}' not found, item: ${item}")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisCache.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisCache.groovy
@@ -63,14 +63,10 @@ class TravisCache {
 
     int setQueuedJob(String master, int repositoryId, int requestId) {
         Jedis resource = jedisPool.getResource()
-        int queueId = (int) (long) TimeUnit.MILLISECONDS.toSeconds(new Date().getTime())
         resource.withCloseable {
-            while (resource.exists(makeKey(master, queueId))) {
-                queueId++;
-            }
-            resource.hset(makeKey(master, queueId), 'requestId', requestId as String)
-            resource.hset(makeKey(master, queueId), 'repositoryId', repositoryId as String)
-            return queueId
+            resource.hset(makeKey(master, requestId), 'requestId', requestId as String)
+            resource.hset(makeKey(master, requestId), 'repositoryId', repositoryId as String)
+            return requestId
         }
     }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -110,8 +110,7 @@ class TravisService implements BuildService {
         TriggerResponse triggerResponse = travisClient.triggerBuild(getAccessToken(), repoSlug, repoRequest)
         if (triggerResponse.remainingRequests) {
             log.debug("{}: remaining requests: ${triggerResponse.remainingRequests}", kv("group", groupKey))
-            log.debug("{}: request id: ${triggerResponse.request.id}", kv("group", groupKey))
-            log.debug("{}: repository id: ${triggerResponse.request.repository.id}", kv("group", groupKey))
+            log.info("{}: Triggered build of ${inputRepoSlug}, requestId: ${triggerResponse.request.id}", kv("group", groupKey))
         }
         return travisCache.setQueuedJob(groupKey, triggerResponse.request.repository.id, triggerResponse.request.id)
     }
@@ -307,7 +306,7 @@ class TravisService implements BuildService {
         Map queuedJob = travisCache.getQueuedJob(groupKey, queueId)
         Request requestResponse = travisClient.request(getAccessToken(), queuedJob.repositoryId, queuedJob.requestId)
         if (requestResponse.builds.size() > 0) {
-            log.info "removing ${queueId} from ${groupKey} travisCache"
+            log.info("{}: Build found: [${requestResponse.repository.slug}:${requestResponse.builds.first().number}] . Removing ${queueId} from ${groupKey} travisCache.", kv("group", groupKey))
             travisCache.remove(groupKey, queueId)
             return ["number":requestResponse.builds.first().number]
         }


### PR DESCRIPTION
* improve logging of triggering and getting triggered builds

The current implementation generates a queueId using the timestamp to seconds. It has a check if the queued item already exists, but I believe it can still produce race conditions.
