### PR TITLE
feat(travis): New caching strategy for builds

### DIFF
--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildCacheSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildCacheSpec.groovy
@@ -52,6 +52,7 @@ class BuildCacheSpec extends Specification {
 
     final master = 'master'
     final test = 'test'
+    final int TTL = 42
 
     void setupSpec() {
         System.setProperty('netflix.environment', 'test')
@@ -66,74 +67,65 @@ class BuildCacheSpec extends Specification {
 
     void 'new build numbers get overridden'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, true)
+        cache.setLastBuild(master, 'job1', 78, true, TTL)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildLabel == 78
+        cache.getLastBuild(master, 'job1', true) == 78
 
         when:
-        cache.setLastBuild(master, 'job1', 80, false)
+        cache.setLastBuild(master, 'job1', 80, true, TTL)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildLabel == 80
+        cache.getLastBuild(master, 'job1', true) == 80
     }
 
-    void 'statuses get overridden'() {
+    void 'running and completed builds are handled seperatly'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, true)
+        cache.setLastBuild(master, 'job1', 78, true, TTL)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildBuilding == true
+        cache.getLastBuild(master, 'job1', true) == 78
 
         when:
-        cache.setLastBuild(master, 'job1', 78, false)
+        cache.setLastBuild(master, 'job1', 80, false, TTL)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildBuilding == false
-
+        cache.getLastBuild(master, 'job1', false) == 80
+        cache.getLastBuild(master, 'job1', true) == 78
     }
 
-    void 'when value is not found, an empty collection is returned'() {
+    void 'when value is not found, -1 is returned'() {
         expect:
-        cache.getLastBuild('notthere', 'job1') == [:]
+        cache.getLastBuild('notthere', 'job1', true) == -1
     }
 
     void 'can set builds for multiple masters'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, true)
-        cache.setLastBuild('example2', 'job1', 88, true)
+        cache.setLastBuild(master, 'job1', 78, true, TTL)
+        cache.setLastBuild('example2', 'job1', 88, true, TTL)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildLabel == 78
-        cache.getLastBuild('example2', 'job1').lastBuildLabel == 88
+        cache.getLastBuild(master, 'job1', true) == 78
+        cache.getLastBuild('example2', 'job1', true) == 88
     }
 
     void 'correctly retrieves all jobsNames for a master'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, true)
-        cache.setLastBuild(master, 'job2', 11, false)
-        cache.setLastBuild(master, 'blurb', 1, false)
+        cache.setLastBuild(master, 'job1', 78, true, TTL)
+        cache.setLastBuild(master, 'job2', 11, false, TTL)
+        cache.setLastBuild(master, 'blurb', 1, false, TTL)
 
         then:
         cache.getJobNames(master) == ['blurb', 'job1', 'job2']
     }
 
-    void 'can remove details for a build'() {
-        when:
-        cache.setLastBuild(master, 'job1', 78, true)
-        cache.remove(master, 'job1')
-
-        then:
-        cache.getLastBuild(master, 'job1') == [:]
-    }
-
     @Unroll
     void 'retrieves all matching jobs for typeahead #query'() {
         when:
-        cache.setLastBuild(master, 'job1', 1, true)
-        cache.setLastBuild(test, 'job1', 1, false)
-        cache.setLastBuild(master, 'job2', 1, false)
-        cache.setLastBuild(test, 'job3', 1, false)
+        cache.setLastBuild(master, 'job1', 1, true, TTL)
+        cache.setLastBuild(test, 'job1', 1, false, TTL)
+        cache.setLastBuild(master, 'job2', 1, false, TTL)
+        cache.setLastBuild(test, 'job3', 1, false, TTL)
 
         then:
         cache.getTypeaheadResults(query) == expected
@@ -154,17 +146,44 @@ class BuildCacheSpec extends Specification {
         def altCfg = new IgorConfigurationProperties()
         altCfg.spinnaker.jedis.prefix = 'newPrefix'
         secondInstance.igorConfigurationProperties = altCfg
-        secondInstance.setLastBuild(master, 'job1', 1, false)
+        secondInstance.setLastBuild(master, 'job1', 1, false, TTL)
 
         then:
         secondInstance.getJobNames(master) == ['job1']
         cache.getJobNames(master) == []
 
         when:
-        cache.remove(master, 'job1')
+        Jedis resource = jedisPool.resource
+        resource.del(cache.makeKey(master, 'job1'))
+        jedisPool.returnResource(resource)
 
         then:
         secondInstance.getJobNames(master) == ['job1']
+    }
+
+    void 'should generate nice keys for completed jobs'() {
+        when:
+        String key = cache.makeKey("travis-ci", "myorg/myrepo", false)
+
+        then:
+        key == "igor:builds:completed:travis-ci:MYORG/MYREPO:myorg/myrepo"
+    }
+
+    void 'should generate nice keys for running jobs'() {
+        when:
+        String key = cache.makeKey("travis-ci", "myorg/myrepo", true)
+
+        then:
+        key == "igor:builds:running:travis-ci:MYORG/MYREPO:myorg/myrepo"
+    }
+
+    void 'completed and running jobs should live in separate key space'() {
+        when:
+        def masterKey = 'travis-ci'
+        def slug      = 'org/repo'
+
+        then:
+        cache.makeKey(masterKey, slug, false) != cache.makeKey(masterKey, slug, true)
     }
 
     @Configuration

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -62,16 +62,16 @@ class TravisBuildMonitorSpec extends Specification {
         1 * travisService.getBuilds(repo, 5) >> [ build ]
         build.branchedRepoSlug() >> "test-org/test-repo/master"
         build.getNumber() >> 4
-        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/master') >> [lastBuildLabel: 3]
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/master', false) >> 3
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/master', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
 
         build.repository >> repository
         repository.slug >> 'test-org/test-repo'
         receivedBuilds.size() == 1
-        receivedBuilds[0].current.slug == 'test-org/test-repo'
-        receivedBuilds[0].current.lastBuildNumber == 4
-        receivedBuilds[0].previous.lastBuildLabel == 3
+        receivedBuilds[0].slug == 'test-org/test-repo/master'
+        receivedBuilds[0].current == 4
+        receivedBuilds[0].previous == 3
     }
 
     void 'ignore old build not found in the cache'() {
@@ -103,7 +103,7 @@ class TravisBuildMonitorSpec extends Specification {
         build.getNumber() >> 4
 
 
-        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/master') >> [lastBuildLabel: 3]
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/master', false) >> 3
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/master', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
 
@@ -112,9 +112,9 @@ class TravisBuildMonitorSpec extends Specification {
 
         expect:
         builds.size() == 1
-        builds[0].current.slug == 'test-org/test-repo'
-        builds[0].current.lastBuildNumber == 4
-        builds[0].previous.lastBuildLabel == 3
+        builds[0].slug == 'test-org/test-repo/master'
+        builds[0].current == 4
+        builds[0].previous == 3
     }
 
     void 'send events for build both on branch and on repository'() {
@@ -141,7 +141,7 @@ class TravisBuildMonitorSpec extends Specification {
         build.branchedRepoSlug() >> "test-org/test-repo/my_branch"
         build.getNumber() >> 4
 
-        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/my_branch') >> [lastBuildLabel: 3]
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/my_branch', false) >> 3
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/my_branch', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
 
@@ -187,12 +187,12 @@ class TravisBuildMonitorSpec extends Specification {
         build.getNumber() >> 4
         buildDifferentBranch.branchedRepoSlug() >> "test-org/test-repo/different_branch"
         buildDifferentBranch.getNumber() >> 3
-        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/my_branch') >> [lastBuildLabel: 2]
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/my_branch', false) >> 2
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/my_branch', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 3, false, CACHED_JOB_TTL_SECONDS)
 
-        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/different_branch') >> [lastBuildLabel: 1]
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/different_branch', false) >> 1
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/different_branch', 3, false, CACHED_JOB_TTL_SECONDS)
 
         build.repository >> repository


### PR DESCRIPTION
* Track running and finished travis builds in separate caches
* Migrate old buildCache to new format (so we don't push redundant build events)
* Keep updating the old cache to support rollback

This change enable us to have more consistent trigger behaviour for repositories that
has many concurrent builds.

Old implementation:
```
buildNumber | state     | event
1           | running   | pushes build started event
2           | running   | pushes build started event
1           | finished  | none
2           | finished  | pushes build finished event
```
New implementation:
```
buildNumber | state     | event
1           | running   | pushes build started event
2           | running   | pushes build started event
1           | finished  | pushes build finished event
2           | finished  | pushes build finished event
```
