### PR TITLE
fix(jenkins): adding retry for gitDetails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
     apply plugin: 'groovy'
 
     ext {
-        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.117.0'
+        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.123.0'
     }
 
     def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]


### PR DESCRIPTION
Saw an error where the scm information was not pulled from jenkins during a pipeline. A re-run of the pipeline fixed this. I think adding a retry for this call to handle any jenkins blips might solve the problem. 

Thoughts? @jeyrschabu @robzienert 