### PR TITLE
feat(jenkins): Adding a configurable lookBack window, off by default

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/IgorConfigurationProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/IgorConfigurationProperties.groovy
@@ -35,6 +35,9 @@ class IgorConfigurationProperties {
         @Canonical
         static class BuildProperties {
             int pollInterval = 60
+            int lookBackWindowMins = 10
+            boolean handleFirstBuilds = true
+            boolean processBuildsOlderThanLookBackWindow = true
         }
 
         @NestedConfigurationProperty


### PR DESCRIPTION
- When turned on, builds older than `lookBackWindowMins` will not be processed
- offsetting that with the polling interval