### PR TITLE
fix(discovery): Fixing cyclic dependency issue on startup when discovery client avail

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/NoDiscoveryApplicationStatusPublisher.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/NoDiscoveryApplicationStatusPublisher.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor;
+
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
+import com.netflix.discovery.StatusChangeEvent;
+import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+public class NoDiscoveryApplicationStatusPublisher implements ApplicationListener<ContextRefreshedEvent> {
+
+    private static final Logger log = LoggerFactory.getLogger(NoDiscoveryApplicationStatusPublisher.class);
+
+    private final ApplicationEventPublisher publisher;
+
+    private static InstanceStatus instanceStatus = InstanceStatus.UNKNOWN;
+
+    public NoDiscoveryApplicationStatusPublisher(ApplicationEventPublisher publisher) {
+        this.publisher = publisher;
+    }
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        log.warn("No discovery client is available, assuming application is up");
+        setInstanceStatus(InstanceStatus.UP);
+    }
+
+    private void setInstanceStatus(InstanceStatus current) {
+        InstanceStatus previous = instanceStatus;
+        instanceStatus = current;
+        publisher.publishEvent(new RemoteStatusChangedEvent(new StatusChangeEvent(previous, current)));
+    }
+
+    public void setInstanceEnabled(boolean enabled) {
+        setInstanceStatus(enabled ? InstanceStatus.UP : InstanceStatus.OUT_OF_SERVICE);
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DiscoveryPollingConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DiscoveryPollingConfig.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config
+
+import com.netflix.appinfo.InstanceInfo
+import com.netflix.discovery.DiscoveryClient
+import com.netflix.spinnaker.igor.NoDiscoveryApplicationStatusPublisher
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.ApplicationListener
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.event.ContextRefreshedEvent
+
+@Configuration
+class DiscoveryPollingConfig {
+
+    @Configuration
+    @ConditionalOnMissingBean(DiscoveryClient.class)
+    static class NoDiscoveryConfig {
+        @Autowired
+        ApplicationEventPublisher publisher
+
+        @Value('${spring.application.name:igor}')
+        String appName
+
+        @Bean
+        ApplicationListener<ContextRefreshedEvent> discoveryStatusPoller() {
+            new NoDiscoveryApplicationStatusPublisher(publisher)
+        }
+    }
+
+    @Configuration
+    @ConditionalOnBean(DiscoveryClient.class)
+    static class DiscoveryConfig {
+
+        @Bean
+        String currentInstanceId(InstanceInfo instanceInfo) {
+            instanceInfo.getInstanceId()
+        }
+
+    }
+
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -25,10 +25,10 @@ import com.netflix.spinnaker.igor.docker.service.TaggedImage
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.history.model.DockerEvent
 import com.netflix.spinnaker.igor.polling.PollingMonitor
+import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.stereotype.Service
 import rx.Scheduler
 import rx.functions.Action0
@@ -58,7 +58,7 @@ class DockerMonitor implements PollingMonitor {
     EchoService echoService
 
     @Override
-    void onApplicationEvent(ContextRefreshedEvent event) {
+    void onApplicationEvent(RemoteStatusChangedEvent event) {
         log.info('Started')
         worker.schedulePeriodically(
                 {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -28,13 +28,12 @@ import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.polling.PollingMonitor
 import com.netflix.spinnaker.igor.service.BuildMasters
+import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 import groovy.time.TimeCategory
 import groovy.util.logging.Slf4j
-import org.apache.commons.lang3.time.DateUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import rx.Scheduler
@@ -115,7 +114,7 @@ class JenkinsBuildMonitor implements PollingMonitor {
     }
 
     @Override
-    void onApplicationEvent(ContextRefreshedEvent event) {
+    void onApplicationEvent(RemoteStatusChangedEvent event) {
         log.info('Started')
         worker.schedulePeriodically(
                 {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/PollingMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/PollingMonitor.groovy
@@ -16,14 +16,14 @@
 
 package com.netflix.spinnaker.igor.polling
 
+import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 import org.springframework.context.ApplicationListener
-import org.springframework.context.event.ContextRefreshedEvent
 
 /*
  * An interface for monitors which rely on polling.
  */
-interface PollingMonitor extends ApplicationListener<ContextRefreshedEvent> {
-    void onApplicationEvent(ContextRefreshedEvent event)
+interface PollingMonitor extends ApplicationListener<RemoteStatusChangedEvent> {
+    void onApplicationEvent(RemoteStatusChangedEvent event)
 
     String getName()
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -33,10 +33,10 @@ import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
 import com.netflix.spinnaker.igor.travis.service.TravisBuildConverter
 import com.netflix.spinnaker.igor.travis.service.TravisResultConverter
 import com.netflix.spinnaker.igor.travis.service.TravisService
+import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.stereotype.Service
 import rx.Observable
 import rx.Scheduler
@@ -46,7 +46,6 @@ import rx.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 
 import static net.logstash.logback.argument.StructuredArguments.kv
-
 
 /**
  * Monitors new travis builds
@@ -84,7 +83,7 @@ class TravisBuildMonitor implements PollingMonitor{
     TravisProperties travisProperties
 
     @Override
-    void onApplicationEvent(ContextRefreshedEvent event) {
+    void onApplicationEvent(RemoteStatusChangedEvent event) {
         log.info('Started')
         setBuildCacheTTL()
         migrateToNewBuildCache()

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
@@ -21,12 +21,11 @@ import com.netflix.spinnaker.igor.jenkins.client.model.ProjectsList
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.service.BuildMasters
-import org.springframework.context.event.ContextRefreshedEvent
+import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 import rx.schedulers.TestScheduler
 import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
-
 /**
  * Ensures that build monitor runs periodically
  */
@@ -51,7 +50,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
         monitor.worker = scheduler.createWorker()
 
         when:
-        monitor.onApplicationEvent(Mock(ContextRefreshedEvent))
+        monitor.onApplicationEvent(Mock(RemoteStatusChangedEvent))
         scheduler.advanceTimeBy(1L, TimeUnit.SECONDS.MILLISECONDS)
 
         then: 'initial poll'
@@ -97,7 +96,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
         monitor.worker = scheduler.createWorker()
 
         when:
-        monitor.onApplicationEvent(Mock(ContextRefreshedEvent))
+        monitor.onApplicationEvent(Mock(RemoteStatusChangedEvent))
         scheduler.advanceTimeBy(1L, TimeUnit.SECONDS.MILLISECONDS)
 
         then: 'initial poll'


### PR DESCRIPTION
When running igor with Discovery & Dynomite enabled at the same time, we run into a pretty awesome cycle:

```
   buildCache defined in URL [jar:file:/BuildCache.class]
┌─────┐
|  dynomiteClientDelegate defined in class path resource [DynomiteConfig.class]
↑     ↓
|  dynoJedisClient defined in class path resource [DynomiteConfig.class]
↑     ↓
|  discoveryClient defined in class path resource [EurekaComponents.class]
↑     ↓
|  optionalArgs defined in class path resource [EurekaComponents.class]
↑     ↓
|  healthCheckHandler defined in class path resource [EurekaComponents.class]
↑     ↓
|  pollingMonitorHealth (field private PollingMonitorHealth.pollers)
↑     ↓
|  dockerMonitor (field private DockerMonitor.cache)
↑     ↓
|  dockerRegistryCache defined in URL [jar:file://DockerRegistryCache.class]
└─────┘
```

Despite `DockerMonitor` using a provided DiscoveryClient, the class listens on all `ContextRefreshedEvent`, which happens quite a lot in startup. Rather than scheduling a discovery poller on every refresh event, altered the monitors to use `RemoteStatusChangedEvent` instead, which should offer the same behavior, but also let wiring happen without cycles.

cc @cfieber 

😍 Cameron for showing me `-Ddebug`