### PR TITLE
WIP: feat(gitlab CI integration) (spinnaker/spinnaker#2047)

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildCache.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildCache.groovy
@@ -54,14 +54,14 @@ class BuildCache {
         results
     }
 
-    int getLastBuild(String master, String job, boolean running) {
+    long getLastBuild(String master, String job, boolean running) {
         Jedis resource = jedisPool.resource
         def key = makeKey(master, job, running)
         if (!resource.exists(key)) {
             jedisPool.returnResource(resource)
             return -1
         }
-        int buildNumber = resource.get(key) as Integer
+        int buildNumber = resource.get(key) as Long
 
         jedisPool.returnResource(resource)
         buildNumber
@@ -80,7 +80,7 @@ class BuildCache {
         jedisPool.returnResource(resource)
     }
 
-    void setLastBuild(String master, String job, int lastBuild, boolean building, int ttl) {
+    void setLastBuild(String master, String job, long lastBuild, boolean building, int ttl) {
         if(!building) {
             // This is here to support rollback to igor versions
             setBuild(makeKey(master, job), lastBuild, building, master, job, ttl)
@@ -112,7 +112,7 @@ class BuildCache {
 
 
 
-    private void setBuild(String key, int lastBuild, boolean building, String master, String job, int ttl) {
+    private void setBuild(String key, long lastBuild, boolean building, String master, String job, int ttl) {
         Jedis resource = jedisPool.resource
         resource.hset(key, 'lastBuildLabel', lastBuild as String)
         resource.hset(key, 'lastBuildBuilding', building as String)
@@ -120,7 +120,7 @@ class BuildCache {
         setTTL(key, ttl)
     }
 
-    private void storeLastBuild(String key, int lastBuild, int ttl) {
+    private void storeLastBuild(String key, long lastBuild, int ttl) {
         Jedis resource = jedisPool.resource
         resource.set(key, lastBuild as String)
         jedisPool.returnResource(resource)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -60,7 +60,7 @@ class BuildController {
     ArtifactDecorator artifactDecorator
 
     @RequestMapping(value = '/builds/status/{buildNumber}/{master:.+}/**')
-    GenericBuild getJobStatus(@PathVariable String master, @PathVariable Integer buildNumber, HttpServletRequest request) {
+    GenericBuild getJobStatus(@PathVariable String master, @PathVariable Long buildNumber, HttpServletRequest request) {
         def job = (String) request.getAttribute(
             HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE).split('/').drop(5).join('/')
         if (buildMasters.map.containsKey(master)) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/InfoController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/InfoController.groovy
@@ -16,24 +16,19 @@
 
 package com.netflix.spinnaker.igor.build
 
+import com.netflix.spinnaker.igor.config.GitlabCiProperties
 import com.netflix.spinnaker.igor.config.JenkinsProperties
 import com.netflix.spinnaker.igor.config.TravisProperties
-import com.netflix.spinnaker.igor.jenkins.client.model.JobConfig
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.service.BuildMasters
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
-
-import javax.servlet.http.HttpServletRequest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.HandlerMapping
+
+import javax.servlet.http.HttpServletRequest
 
 /**
  * A controller that provides jenkins information
@@ -54,6 +49,9 @@ class InfoController {
     @Autowired(required = false)
     TravisProperties travisProperties
 
+    @Autowired(required = false)
+    GitlabCiProperties gitlabCiProperties
+
     @RequestMapping(value = '/masters', method = RequestMethod.GET)
     List<Object> listMasters(@RequestParam(value = "showUrl", defaultValue = "false") String showUrl) {
         if (showUrl == 'true') {
@@ -65,6 +63,14 @@ class InfoController {
             }
             masterList.addAll(
                 travisProperties?.masters.collect {
+                    [
+                        "name": it.name,
+                        "address": it.address
+                    ]
+                }
+            )
+            masterList.addAll(
+                gitlabCiProperties?.masters.collect {
                     [
                         "name": it.name,
                         "address": it.address

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericBuild.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericBuild.groovy
@@ -25,7 +25,7 @@ class GenericBuild {
     boolean building
     String fullDisplayName
     String name
-    int number
+    long number
     Integer duration
     String timestamp
     Result result

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.groovy
@@ -1,13 +1,22 @@
 package com.netflix.spinnaker.igor.config
 
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.igor.gitlabci.client.GitlabCiClient
 import com.netflix.spinnaker.igor.gitlabci.service.GitlabCiService
 import com.netflix.spinnaker.igor.service.BuildMasters
+import com.squareup.okhttp.OkHttpClient
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import retrofit.Endpoints
+import retrofit.RequestInterceptor
+import retrofit.RestAdapter
+import retrofit.client.OkClient
+
+import java.util.concurrent.TimeUnit
 
 @Configuration
 @Slf4j
@@ -16,17 +25,54 @@ import org.springframework.context.annotation.Configuration
 @EnableConfigurationProperties(GitlabCiProperties)
 class GitlabCiConfig {
 
-    // TODO timeout for the gitlab ci client
     @Bean
-    Map<String, GitlabCiService> gitlabCiMasters(BuildMasters buildMasters, GitlabCiProperties gitlabCiProperties) {
+    Map<String, GitlabCiService> gitlabCiMasters(BuildMasters buildMasters, IgorConfigurationProperties igorConfigurationProperties, GitlabCiProperties gitlabCiProperties) {
         log.info "creating gitlabCiMasters"
         Map<String, GitlabCiService> gitlabCiMasters = (gitlabCiProperties?.masters?.collectEntries { GitlabCiProperties.GitlabCiHost host ->
             String hostName = "gitlab-ci-${host.name}"
             log.info "bootstrapping ${host.address} as ${hostName}"
 
-            [(hostName): new GitlabCiService()]
+            [(hostName): gitlabCiService(igorConfigurationProperties, gitlabCiProperties)]
         })
         buildMasters.map.putAll gitlabCiMasters
         return gitlabCiMasters
+    }
+
+    // TODO can there really be multiple masters?
+    static GitlabCiService gitlabCiService(IgorConfigurationProperties igorConfigurationProperties, GitlabCiProperties gitlabCiProperties) {
+        def host = gitlabCiProperties.masters[0]
+        return new GitlabCiService(gitlabCiClient(host.address, host.privateToken, igorConfigurationProperties.client.timeout), host.limitByMembership, host.limitByOwnership)
+    }
+
+    static GitlabCiClient gitlabCiClient(String address, String privateToken, int timeout = 30000) {
+        OkHttpClient client = new OkHttpClient()
+        client.setReadTimeout(timeout, TimeUnit.MILLISECONDS)
+
+        //Need this code because without FULL log level, fetching logs will fail. Ref https://github.com/square/retrofit/issues/953.
+        RestAdapter.Log fooLog = new RestAdapter.Log() {
+            @Override public void log(String message) {
+            }
+        }
+        new RestAdapter.Builder()
+            .setEndpoint(Endpoints.newFixedEndpoint(address))
+            .setRequestInterceptor(new GitlabCiHeaders(privateToken))
+            .setClient(new OkClient(client))
+            .setLog(fooLog)
+            .setLogLevel(RestAdapter.LogLevel.FULL)
+            .build()
+            .create(GitlabCiClient)
+    }
+
+    static class GitlabCiHeaders implements RequestInterceptor {
+        private String privateToken;
+
+        GitlabCiHeaders(String privateToken) {
+            this.privateToken = privateToken
+        }
+
+        @Override
+        void intercept(RequestInterceptor.RequestFacade request) {
+            request.addHeader("PRIVATE-TOKEN", privateToken)
+        }
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.groovy
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.igor.config
+
+import com.netflix.spinnaker.igor.gitlabci.service.GitlabCiService
+import com.netflix.spinnaker.igor.service.BuildMasters
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@Slf4j
+@CompileStatic
+@ConditionalOnProperty('gitlab-ci.enabled')
+@EnableConfigurationProperties(GitlabCiProperties)
+class GitlabCiConfig {
+
+    // TODO timeout for the gitlab ci client
+    @Bean
+    Map<String, GitlabCiService> gitlabCiMasters(BuildMasters buildMasters, GitlabCiProperties gitlabCiProperties) {
+        log.info "creating gitlabCiMasters"
+        Map<String, GitlabCiService> gitlabCiMasters = (gitlabCiProperties?.masters?.collectEntries { GitlabCiProperties.GitlabCiHost host ->
+            String hostName = "gitlab-ci-${host.name}"
+            log.info "bootstrapping ${host.address} as ${hostName}"
+
+            [(hostName): new GitlabCiService()]
+        })
+        buildMasters.map.putAll gitlabCiMasters
+        return gitlabCiMasters
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.groovy
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.igor.service.BuildMasters
 import com.squareup.okhttp.OkHttpClient
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import org.apache.commons.lang3.StringUtils
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -32,16 +33,14 @@ class GitlabCiConfig {
             String hostName = "gitlab-ci-${host.name}"
             log.info "bootstrapping ${host.address} as ${hostName}"
 
-            [(hostName): gitlabCiService(igorConfigurationProperties, gitlabCiProperties)]
+            [(hostName): gitlabCiService(igorConfigurationProperties, host)]
         })
         buildMasters.map.putAll gitlabCiMasters
         return gitlabCiMasters
     }
 
-    // TODO can there really be multiple masters?
-    static GitlabCiService gitlabCiService(IgorConfigurationProperties igorConfigurationProperties, GitlabCiProperties gitlabCiProperties) {
-        def host = gitlabCiProperties.masters[0]
-        return new GitlabCiService(gitlabCiClient(host.address, host.privateToken, igorConfigurationProperties.client.timeout), host.limitByMembership, host.limitByOwnership)
+    static GitlabCiService gitlabCiService(IgorConfigurationProperties igorConfigurationProperties, GitlabCiProperties.GitlabCiHost host) {
+        return new GitlabCiService(gitlabCiClient(host.address, host.privateToken, igorConfigurationProperties.client.timeout), host.address, host.limitByMembership, host.limitByOwnership)
     }
 
     static GitlabCiClient gitlabCiClient(String address, String privateToken, int timeout = 30000) {
@@ -50,7 +49,7 @@ class GitlabCiConfig {
 
         //Need this code because without FULL log level, fetching logs will fail. Ref https://github.com/square/retrofit/issues/953.
         RestAdapter.Log fooLog = new RestAdapter.Log() {
-            @Override public void log(String message) {
+            @Override void log(String message) {
             }
         }
         new RestAdapter.Builder()
@@ -64,7 +63,7 @@ class GitlabCiConfig {
     }
 
     static class GitlabCiHeaders implements RequestInterceptor {
-        private String privateToken;
+        private String privateToken
 
         GitlabCiHeaders(String privateToken) {
             this.privateToken = privateToken
@@ -72,7 +71,9 @@ class GitlabCiConfig {
 
         @Override
         void intercept(RequestInterceptor.RequestFacade request) {
-            request.addHeader("PRIVATE-TOKEN", privateToken)
+            if (!StringUtils.isEmpty(privateToken)) {
+                request.addHeader("PRIVATE-TOKEN", privateToken)
+            }
         }
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.groovy
@@ -33,14 +33,14 @@ class GitlabCiConfig {
             String hostName = "gitlab-ci-${host.name}"
             log.info "bootstrapping ${host.address} as ${hostName}"
 
-            [(hostName): gitlabCiService(igorConfigurationProperties, host)]
+            [(hostName): gitlabCiService(igorConfigurationProperties, host, hostName)]
         })
         buildMasters.map.putAll gitlabCiMasters
         return gitlabCiMasters
     }
 
-    static GitlabCiService gitlabCiService(IgorConfigurationProperties igorConfigurationProperties, GitlabCiProperties.GitlabCiHost host) {
-        return new GitlabCiService(gitlabCiClient(host.address, host.privateToken, igorConfigurationProperties.client.timeout), host.address, host.limitByMembership, host.limitByOwnership)
+    static GitlabCiService gitlabCiService(IgorConfigurationProperties igorConfigurationProperties, GitlabCiProperties.GitlabCiHost host, String hostName) {
+        return new GitlabCiService(hostName, gitlabCiClient(host.address, host.privateToken, igorConfigurationProperties.client.timeout), host.address, host.limitByMembership, host.limitByOwnership)
     }
 
     static GitlabCiClient gitlabCiClient(String address, String privateToken, int timeout = 30000) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.groovy
@@ -12,6 +12,8 @@ import javax.validation.Valid
 @Validated
 class GitlabCiProperties {
 
+    int cachedJobTTLDays = 60
+
     @Valid
     List<GitlabCiHost> masters
 
@@ -20,8 +22,6 @@ class GitlabCiProperties {
         String name
         @NotEmpty
         String address
-        // TODO should this field be also not empty?
-        // TODO Set proper token (reuse from the ci settings?)
         String privateToken
         boolean limitByMembership = false
         boolean limitByOwnership = true

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.groovy
@@ -1,0 +1,26 @@
+package com.netflix.spinnaker.igor.config
+
+import groovy.transform.CompileStatic
+import org.hibernate.validator.constraints.NotEmpty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+
+import javax.validation.Valid
+
+@CompileStatic
+@ConfigurationProperties(prefix = 'gitlab-ci')
+@Validated
+class GitlabCiProperties {
+
+    @Valid
+    List<GitlabCiHost> masters
+
+    static class GitlabCiHost {
+        @NotEmpty
+        String name
+        @NotEmpty
+        String address
+        // TODO should this field be also not empty?
+        String token
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.groovy
@@ -21,6 +21,9 @@ class GitlabCiProperties {
         @NotEmpty
         String address
         // TODO should this field be also not empty?
-        String token
+        // TODO Set proper token (reuse from the ci settings?)
+        String privateToken
+        boolean limitByMembership = false
+        boolean limitByOwnership = true
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -16,37 +16,22 @@
 
 package com.netflix.spinnaker.igor.docker
 
-import com.netflix.appinfo.InstanceInfo
-import com.netflix.discovery.DiscoveryClient
-import com.netflix.spinnaker.igor.IgorConfigurationProperties
 import com.netflix.spinnaker.igor.build.model.GenericArtifact
 import com.netflix.spinnaker.igor.docker.model.DockerRegistryAccounts
 import com.netflix.spinnaker.igor.docker.service.TaggedImage
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.history.model.DockerEvent
-import com.netflix.spinnaker.igor.polling.PollingMonitor
-import groovy.util.logging.Slf4j
+import com.netflix.spinnaker.igor.polling.CommonPollingMonitor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.stereotype.Service
-import rx.Scheduler
-import rx.functions.Action0
-import rx.schedulers.Schedulers
-
-import javax.inject.Provider
-import java.util.concurrent.TimeUnit
 
 import static net.logstash.logback.argument.StructuredArguments.kv
 
-@Slf4j
 @Service
 @SuppressWarnings('CatchException')
 @ConditionalOnProperty('dockerRegistry.enabled')
-class DockerMonitor implements PollingMonitor {
-
-    Scheduler scheduler = Schedulers.newThread()
-    Scheduler.Worker worker = scheduler.createWorker()
+class DockerMonitor extends CommonPollingMonitor {
 
     @Autowired
     DockerRegistryCache cache
@@ -58,21 +43,15 @@ class DockerMonitor implements PollingMonitor {
     EchoService echoService
 
     @Override
-    void onApplicationEvent(ContextRefreshedEvent event) {
-        log.info('Started')
-        worker.schedulePeriodically(
-                {
-                    if (isInService()) {
-                        dockerRegistryAccounts.updateAccounts()
-                        dockerRegistryAccounts.accounts.forEach({ account ->
-                            changedTags(account)
-                        })
-                    } else {
-                        log.info("not in service (lastPoll: ${lastPoll ?: 'n/a'})")
-                        lastPoll = null
-                    }
-                } as Action0, 0, pollInterval, TimeUnit.SECONDS
-        )
+    void initialize() {
+    }
+
+    @Override
+    void poll() {
+        dockerRegistryAccounts.updateAccounts()
+        dockerRegistryAccounts.accounts.forEach({ account ->
+            changedTags(account)
+        })
     }
 
     private void changedTags(Map accountDetails) {
@@ -81,7 +60,6 @@ class DockerMonitor implements PollingMonitor {
 
         log.debug 'Checking for new tags for ' + account
         try {
-            lastPoll = System.currentTimeMillis()
             List<String> cachedImages = cache.getImages(account)
 
             def startTime = System.currentTimeMillis()
@@ -138,42 +116,7 @@ class DockerMonitor implements PollingMonitor {
         "dockerTagMonitor"
     }
 
-    @Autowired(required = false)
-    Provider<DiscoveryClient> discoveryClient
-
-    String lastStatus
-
-    @Override
-    boolean isInService() {
-        if (discoveryClient.get() == null) {
-            log.info("no discoveryClient, assuming InService")
-            true
-        } else {
-            def remoteStatus = discoveryClient.get().instanceRemoteStatus
-            if (remoteStatus != lastStatus) {
-                log.info("current remote status ${remoteStatus}")
-            }
-            lastStatus=remoteStatus
-            remoteStatus == InstanceInfo.InstanceStatus.UP
-        }
-    }
-
-    Long lastPoll
-
-    @Override
-    Long getLastPoll() {
-        lastPoll
-    }
-
-    @Autowired
-    IgorConfigurationProperties igorConfigurationProperties
-
-    @Override
-    int getPollInterval() {
-        igorConfigurationProperties.spinnaker.build.pollInterval
-    }
-
-    static void postEvent(EchoService echoService, List<String> cachedImagesForAccount, TaggedImage image, String imageId) {
+    void postEvent(EchoService echoService, List<String> cachedImagesForAccount, TaggedImage image, String imageId) {
         if (!cachedImagesForAccount) {
             // avoid publishing an event if this account has no indexed images (protects against a flushed redis)
             return

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.groovy
@@ -1,0 +1,28 @@
+package com.netflix.spinnaker.igor.gitlabci
+
+import com.netflix.spinnaker.igor.polling.CommonPollingMonitor
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+
+@Service
+@ConditionalOnProperty('gitlab-ci.enabled')
+class GitlabCiBuildMonitor extends CommonPollingMonitor {
+    @Override
+    void initialize() {
+    }
+
+    @Override
+    void poll() {
+        log.info('tickie')
+    }
+
+    @Override
+    String getName() {
+        return "gitlabCiBuildMonitor";
+    }
+
+    @Override
+    Long getLastPoll() {
+        return null;
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.groovy
@@ -84,7 +84,7 @@ class GitlabCiBuildMonitor extends CommonPollingMonitor {
                         updatedBuilds += 1
                         log.info("Build update [${branchedRepoSlug}:${pipeline.id}] [status:${pipeline.status}] [running:${GitlabCiResultConverter.running(pipeline.status)}]")
                         buildCache.setLastBuild(master, branchedRepoSlug, pipeline.id, GitlabCiResultConverter.running(pipeline.status), buildCacheJobTTLSeconds())
-                        buildCache.setLastBuild(master, pipeline.ref, pipeline.id, GitlabCiResultConverter.running(pipeline.status), buildCacheJobTTLSeconds())
+                        buildCache.setLastBuild(master, project.path_with_namespace, pipeline.id, GitlabCiResultConverter.running(pipeline.status), buildCacheJobTTLSeconds())
                         sendEventForPipeline(project, pipeline, gitlabCiService.getAddress(), branchedRepoSlug, master)
                     }
                 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.groovy
@@ -1,29 +1,44 @@
 package com.netflix.spinnaker.igor.gitlabci
 
 import com.netflix.spinnaker.igor.build.BuildCache
+import com.netflix.spinnaker.igor.build.model.GenericProject
+import com.netflix.spinnaker.igor.config.GitlabCiProperties
+import com.netflix.spinnaker.igor.gitlabci.client.model.Pipeline
 import com.netflix.spinnaker.igor.gitlabci.client.model.Project
+import com.netflix.spinnaker.igor.gitlabci.service.GitlabCiPipelineConverter
+import com.netflix.spinnaker.igor.gitlabci.service.GitlabCiResultConverter
 import com.netflix.spinnaker.igor.gitlabci.service.GitlabCiService
+import com.netflix.spinnaker.igor.history.EchoService
+import com.netflix.spinnaker.igor.history.model.GenericBuildContent
+import com.netflix.spinnaker.igor.history.model.GenericBuildEvent
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.polling.CommonPollingMonitor
 import com.netflix.spinnaker.igor.service.BuildMasters
-import com.netflix.spinnaker.igor.travis.client.model.Repo
-import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
-import com.netflix.spinnaker.igor.travis.service.TravisResultConverter
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 import rx.Observable
+
+import java.util.concurrent.TimeUnit
 
 import static net.logstash.logback.argument.StructuredArguments.kv
 
 @Service
 @ConditionalOnProperty('gitlab-ci.enabled')
 class GitlabCiBuildMonitor extends CommonPollingMonitor {
+    private static final int MAX_NUMBER_OF_PIPELINES = 5
+
+    @Autowired(required = false)
+    EchoService echoService
+
     @Autowired
     BuildCache buildCache
 
     @Autowired
     BuildMasters buildMasters
+
+    @Autowired
+    GitlabCiProperties gitlabCiProperties
 
     @Override
     void initialize() {
@@ -36,74 +51,78 @@ class GitlabCiBuildMonitor extends CommonPollingMonitor {
         }
     }
 
-    List<Map> changedBuilds(String master) {
+    void changedBuilds(String master) {
         log.info('Checking for new builds for {}', kv("master", master))
         List<String> cachedRepoSlugs = buildCache.getJobNames(master)
-        List<Map> results = []
         int updatedBuilds = 0
 
         GitlabCiService gitlabCiService = buildMasters.map[master] as GitlabCiService
 
         def startTime = System.currentTimeMillis()
 
+        // TODO what if this method throws an exception?
         List<Project> projects = gitlabCiService.getProjects()
-        for (Project p : projects) {
-            log.info(p.name_with_namespace)
-        }
-
+        // TODO filter out projects with too old builds?
 //        List<Repo> repos = filterOutOldBuilds(gitlabCiService.getReposForAccounts())
-//        log.info("Took ${System.currentTimeMillis() - startTime}ms to retrieve ${repos.size()} repositories (master: {})", kv("master", master))
-//        Observable.from(repos).subscribe(
-//            { Repo repo ->
-//                List<V3Build> builds = gitlabCiService.getBuilds(repo, 5)
-//                for (V3Build build : builds) {
-//                    boolean addToCache = false
-//                    def cachedBuild = null
-//                    String branchedRepoSlug = build.branchedRepoSlug()
-//                    if (cachedRepoSlugs.contains(branchedRepoSlug)) {
-//                        cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug, TravisResultConverter.running(build.state))
-//                        if (build.number > cachedBuild) {
-//                            addToCache = true
-//                            log.info("New build: {}: ${branchedRepoSlug} : ${build.number}", kv("master", master))
-//                        }
-//                    } else {
-//                        addToCache = !TravisResultConverter.running(build.state)
-//                    }
-//                    if (addToCache) {
-//                        updatedBuilds += 1
-//                        log.info("Build update [${branchedRepoSlug}:${build.number}] [status:${build.state}] [running:${TravisResultConverter.running(build.state)}]")
-//                        buildCache.setLastBuild(master, branchedRepoSlug, build.number, TravisResultConverter.running(build.state), buildCacheJobTTLSeconds())
-//                        buildCache.setLastBuild(master, build.repository.slug, build.number, TravisResultConverter.running(build.state), buildCacheJobTTLSeconds())
-//                        if (!build.spinnakerTriggered()) {
-//                            sendEventForBuild(build, branchedRepoSlug, master, gitlabCiService)
-//                        }
-//                        results << [slug: branchedRepoSlug, previous: cachedBuild, current: build.number]
-//                    }
-//                }
-//            }, {
-//            log.error("Error: ${it.message} (master: {})", kv("master", master))
-//        }
-//        )
-//        if (updatedBuilds) {
-//            log.info("Found {} new builds (master: {})", updatedBuilds, kv("master", master))
-//        }
-//        log.info("Last poll took ${System.currentTimeMillis() - startTime}ms (master: {})", kv("master", master))
-//        if (travisProperties.repositorySyncEnabled) {
-//            startTime = System.currentTimeMillis()
-//            gitlabCiService.syncRepos()
-//            log.info("repositorySync: Took ${System.currentTimeMillis() - startTime}ms to sync repositories for {}", kv("master", master))
-//        }
-//        results
+        log.info("Took ${System.currentTimeMillis() - startTime}ms to retrieve ${projects.size()} repositories (master: {})", kv("master", master))
+        // TODO do we really need to use the Observable here?
+        Observable.from(projects).subscribe({ Project project ->
+            List<Pipeline> pipelines = gitlabCiService.getPipelines(project, MAX_NUMBER_OF_PIPELINES)
+            for (Pipeline pipeline : pipelines) {
+                boolean addToCache = false
+                String branchedRepoSlug = gitlabCiService.getBranchedPipelineSlug(project, pipeline)
 
+                if (cachedRepoSlugs.contains(branchedRepoSlug)) {
+                    def cachedBuildId = buildCache.getLastBuild(master, branchedRepoSlug, GitlabCiResultConverter.running(pipeline.status))
+                    // In case of Gitlab CI the pipeline ids are increasing so we can use it for ordering
+                    if (pipeline.id > cachedBuildId) {
+                        addToCache = true
+                        log.info("New build: {}: ${branchedRepoSlug} : ${pipeline.id}", kv("master", master))
+                    }
+                } else {
+                    addToCache = !GitlabCiResultConverter.running(pipeline.status)
+                }
+
+                if (addToCache) {
+                    updatedBuilds += 1
+                    log.info("Build update [${branchedRepoSlug}:${pipeline.id}] [status:${pipeline.status}] [running:${GitlabCiResultConverter.running(pipeline.status)}]")
+                    buildCache.setLastBuild(master, branchedRepoSlug, pipeline.id, GitlabCiResultConverter.running(pipeline.status), buildCacheJobTTLSeconds())
+                    buildCache.setLastBuild(master, pipeline.ref, pipeline.id, GitlabCiResultConverter.running(pipeline.status), buildCacheJobTTLSeconds())
+                    sendEventForPipeline(project, pipeline, gitlabCiService.getAddress(), branchedRepoSlug, master)
+                }
+            }
+        }, {
+            log.error("Error: ${it.message} (master: {})", kv("master", master))
+        })
+        if (updatedBuilds) {
+            log.info("Found {} new builds (master: {})", updatedBuilds, kv("master", master))
+        }
+        log.info("Last poll took ${System.currentTimeMillis() - startTime}ms (master: {})", kv("master", master))
     }
 
     @Override
     String getName() {
-        return "gitlabCiBuildMonitor";
+        return "gitlabCiBuildMonitor"
     }
 
-    @Override
-    Long getLastPoll() {
-        return null;
+    private int buildCacheJobTTLSeconds() {
+        return TimeUnit.DAYS.toSeconds(gitlabCiProperties.cachedJobTTLDays)
+    }
+
+    private void sendEventForPipeline(Project project, Pipeline pipeline, String address, String branchedSlug, String master) {
+        if (echoService) {
+            log.info("pushing event for {}:${pipeline.ref}:${pipeline.id}", kv("master", master))
+            GenericProject genericProject = new GenericProject(pipeline.ref,
+                GitlabCiPipelineConverter.genericBuild(pipeline, project.path_with_namespace, address))
+            echoService.postEvent(
+                new GenericBuildEvent(content: new GenericBuildContent(project: genericProject, master: master, type: 'gitlab-ci'))
+            )
+            log.info("pushing event for {}:${branchedSlug}:${pipeline.id}", kv("master", master))
+            genericProject = new GenericProject(branchedSlug,
+                GitlabCiPipelineConverter.genericBuild(pipeline, project.path_with_namespace, address))
+            echoService.postEvent(
+                new GenericBuildEvent(content: new GenericBuildContent(project: genericProject, master: master, type: 'gitlab-ci'))
+            )
+        }
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.groovy
@@ -1,19 +1,100 @@
 package com.netflix.spinnaker.igor.gitlabci
 
+import com.netflix.spinnaker.igor.build.BuildCache
+import com.netflix.spinnaker.igor.gitlabci.client.model.Project
+import com.netflix.spinnaker.igor.gitlabci.service.GitlabCiService
+import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.polling.CommonPollingMonitor
+import com.netflix.spinnaker.igor.service.BuildMasters
+import com.netflix.spinnaker.igor.travis.client.model.Repo
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
+import com.netflix.spinnaker.igor.travis.service.TravisResultConverter
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
+import rx.Observable
+
+import static net.logstash.logback.argument.StructuredArguments.kv
 
 @Service
 @ConditionalOnProperty('gitlab-ci.enabled')
 class GitlabCiBuildMonitor extends CommonPollingMonitor {
+    @Autowired
+    BuildCache buildCache
+
+    @Autowired
+    BuildMasters buildMasters
+
     @Override
     void initialize() {
     }
 
     @Override
     void poll() {
-        log.info('tickie')
+        buildMasters.filteredMap(BuildServiceProvider.GITLAB_CI).keySet().each { master ->
+            changedBuilds(master)
+        }
+    }
+
+    List<Map> changedBuilds(String master) {
+        log.info('Checking for new builds for {}', kv("master", master))
+        List<String> cachedRepoSlugs = buildCache.getJobNames(master)
+        List<Map> results = []
+        int updatedBuilds = 0
+
+        GitlabCiService gitlabCiService = buildMasters.map[master] as GitlabCiService
+
+        def startTime = System.currentTimeMillis()
+
+        List<Project> projects = gitlabCiService.getProjects()
+        for (Project p : projects) {
+            log.info(p.name_with_namespace)
+        }
+
+//        List<Repo> repos = filterOutOldBuilds(gitlabCiService.getReposForAccounts())
+//        log.info("Took ${System.currentTimeMillis() - startTime}ms to retrieve ${repos.size()} repositories (master: {})", kv("master", master))
+//        Observable.from(repos).subscribe(
+//            { Repo repo ->
+//                List<V3Build> builds = gitlabCiService.getBuilds(repo, 5)
+//                for (V3Build build : builds) {
+//                    boolean addToCache = false
+//                    def cachedBuild = null
+//                    String branchedRepoSlug = build.branchedRepoSlug()
+//                    if (cachedRepoSlugs.contains(branchedRepoSlug)) {
+//                        cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug, TravisResultConverter.running(build.state))
+//                        if (build.number > cachedBuild) {
+//                            addToCache = true
+//                            log.info("New build: {}: ${branchedRepoSlug} : ${build.number}", kv("master", master))
+//                        }
+//                    } else {
+//                        addToCache = !TravisResultConverter.running(build.state)
+//                    }
+//                    if (addToCache) {
+//                        updatedBuilds += 1
+//                        log.info("Build update [${branchedRepoSlug}:${build.number}] [status:${build.state}] [running:${TravisResultConverter.running(build.state)}]")
+//                        buildCache.setLastBuild(master, branchedRepoSlug, build.number, TravisResultConverter.running(build.state), buildCacheJobTTLSeconds())
+//                        buildCache.setLastBuild(master, build.repository.slug, build.number, TravisResultConverter.running(build.state), buildCacheJobTTLSeconds())
+//                        if (!build.spinnakerTriggered()) {
+//                            sendEventForBuild(build, branchedRepoSlug, master, gitlabCiService)
+//                        }
+//                        results << [slug: branchedRepoSlug, previous: cachedBuild, current: build.number]
+//                    }
+//                }
+//            }, {
+//            log.error("Error: ${it.message} (master: {})", kv("master", master))
+//        }
+//        )
+//        if (updatedBuilds) {
+//            log.info("Found {} new builds (master: {})", updatedBuilds, kv("master", master))
+//        }
+//        log.info("Last poll took ${System.currentTimeMillis() - startTime}ms (master: {})", kv("master", master))
+//        if (travisProperties.repositorySyncEnabled) {
+//            startTime = System.currentTimeMillis()
+//            gitlabCiService.syncRepos()
+//            log.info("repositorySync: Took ${System.currentTimeMillis() - startTime}ms to sync repositories for {}", kv("master", master))
+//        }
+//        results
+
     }
 
     @Override

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.groovy
@@ -1,10 +1,21 @@
 package com.netflix.spinnaker.igor.gitlabci.client
 
+import com.netflix.spinnaker.igor.gitlabci.client.model.Pipeline
+import com.netflix.spinnaker.igor.gitlabci.client.model.PipelineSummary
 import com.netflix.spinnaker.igor.gitlabci.client.model.Project
 import retrofit.http.GET
+import retrofit.http.Path
 import retrofit.http.Query
 
 interface GitlabCiClient {
+    int MAX_PAGE_SIZE = 100
+
     @GET("/api/v4/projects")
     List<Project> getProjects(@Query("membership") boolean limitByMembership, @Query("owned") boolean limitByOwnership, @Query("page") int page)
+
+    @GET("/api/v4/projects/{projectId}/pipelines")
+    List<PipelineSummary> getPipelineSummaries(@Path("projectId") String projectId, @Query("per_page") int pageLimit)
+
+    @GET("/api/v4/projects/{projectId}/pipelines/{pipelineId}")
+    Pipeline getPipeline(@Path("projectId") String projectId, @Path("pipelineId") String pipelineId)
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.groovy
@@ -1,0 +1,10 @@
+package com.netflix.spinnaker.igor.gitlabci.client
+
+import com.netflix.spinnaker.igor.gitlabci.client.model.Project
+import retrofit.http.GET
+import retrofit.http.Query
+
+interface GitlabCiClient {
+    @GET("/api/v4/projects")
+    List<Project> getProjects(@Query("membership") boolean limitByMembership, @Query("owned") boolean limitByOwnership, @Query("page") int page)
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.groovy
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.igor.gitlabci.client
 
+import com.netflix.spinnaker.igor.gitlabci.client.model.Commit
 import com.netflix.spinnaker.igor.gitlabci.client.model.Pipeline
 import com.netflix.spinnaker.igor.gitlabci.client.model.PipelineSummary
 import com.netflix.spinnaker.igor.gitlabci.client.model.Project
@@ -18,4 +19,7 @@ interface GitlabCiClient {
 
     @GET("/api/v4/projects/{projectId}/pipelines/{pipelineId}")
     Pipeline getPipeline(@Path("projectId") String projectId, @Path("pipelineId") String pipelineId)
+
+    @GET("/api/v4/projects/{projectId}/repository/commits/{commitHash}")
+    Commit getCommit(@Path("projectId") String projectId, @Path("commitHash") String commitHash)
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/Commit.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/Commit.groovy
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.igor.gitlabci.client.model
+
+class Commit {
+    String id
+    String committer_name
+    String message
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/Pipeline.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/Pipeline.groovy
@@ -1,0 +1,11 @@
+package com.netflix.spinnaker.igor.gitlabci.client.model
+
+class Pipeline {
+    long id
+    String sha
+    String ref
+    PipelineStatus status
+    boolean tag
+    int duration
+    Date finished_at
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/PipelineStatus.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/PipelineStatus.groovy
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.igor.gitlabci.client.model
+
+enum PipelineStatus {
+    running, pending, success, failed, canceled, skipped
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/PipelineSummary.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/PipelineSummary.groovy
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.igor.gitlabci.client.model
+
+class PipelineSummary {
+    long id
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/Project.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/Project.groovy
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.igor.gitlabci.client.model
 
 class Project {
-    String name_with_namespace
+    String id
+    String path_with_namespace
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/Project.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/Project.groovy
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.igor.gitlabci.client.model
+
+class Project {
+    String name_with_namespace
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiPipelineConverter.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiPipelineConverter.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gitlabci.service
+
+import com.netflix.spinnaker.igor.build.model.GenericBuild
+import com.netflix.spinnaker.igor.gitlabci.client.model.Pipeline
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class GitlabCiPipelineConverter {
+    static GenericBuild genericBuild(Pipeline pipeline, String repoSlug, String baseUrl) {
+        GenericBuild genericBuild = new GenericBuild(building: GitlabCiResultConverter.running(pipeline.status),
+            number: pipeline.id,
+            duration: pipeline.duration,
+            result: GitlabCiResultConverter.getResultFromGitlabCiState(pipeline.status),
+            name: repoSlug,
+            url: url(repoSlug, baseUrl, pipeline.id))
+
+        if (pipeline.finished_at) {
+            genericBuild.timestamp = pipeline.finished_at.getTime()
+        }
+        return genericBuild
+    }
+
+    static String url(String repoSlug, String baseUrl, long id) {
+        return "${baseUrl}/${repoSlug}/pipelines/${id}"
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiResultConverter.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiResultConverter.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gitlabci.service
+
+import com.netflix.spinnaker.igor.build.model.Result
+import com.netflix.spinnaker.igor.gitlabci.client.model.PipelineStatus
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+
+@CompileStatic
+@Slf4j
+class GitlabCiResultConverter {
+    static Result getResultFromGitlabCiState(PipelineStatus state) {
+        switch (state) {
+            case PipelineStatus.pending:
+                return Result.NOT_BUILT
+            case PipelineStatus.running:
+                return Result.BUILDING
+            case PipelineStatus.success:
+                return Result.SUCCESS
+            case PipelineStatus.canceled:
+                return Result.ABORTED
+            case PipelineStatus.failed:
+                return Result.FAILURE
+            case PipelineStatus.skipped:
+                return Result.NOT_BUILT
+            default:
+                log.info("could not convert ${state}")
+                throw new IllegalArgumentException("state: ${state} is not known")
+        }
+    }
+
+    static Boolean running(PipelineStatus status) {
+        switch (status) {
+            case PipelineStatus.pending:
+                return true
+            case PipelineStatus.running:
+                return true
+            default:
+                return false
+        }
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
@@ -1,12 +1,26 @@
 package com.netflix.spinnaker.igor.gitlabci.service
 
+import com.netflix.spinnaker.hystrix.SimpleHystrixCommand
 import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.GenericGitRevision
+import com.netflix.spinnaker.igor.gitlabci.client.GitlabCiClient
+import com.netflix.spinnaker.igor.gitlabci.client.model.Project
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.service.BuildService
+import groovy.transform.TailRecursive
 import sun.reflect.generics.reflectiveObjects.NotImplementedException
 
 class GitlabCiService implements BuildService {
+
+    private GitlabCiClient client
+    private boolean limitByMembership
+    private boolean limitByOwnership
+
+    GitlabCiService(GitlabCiClient client, boolean limitByMembership, boolean limitByOwnership) {
+        this.client = client
+        this.limitByMembership = limitByMembership
+        this.limitByOwnership = limitByOwnership
+    }
 
     @Override
     BuildServiceProvider buildServiceProvider() {
@@ -27,4 +41,20 @@ class GitlabCiService implements BuildService {
     int triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
         throw new NotImplementedException()
     }
+
+    List<Project> getProjects() {
+        return getProjectsRec([], 1)
+    }
+
+    @TailRecursive
+    private List<Project> getProjectsRec(List<Project> projects, int page) {
+        List<Project> slice = client.getProjects(limitByMembership, limitByOwnership, page)
+        if (slice.isEmpty()) {
+            return projects
+        } else {
+            projects.addAll(slice)
+            return getProjectsRec(projects, page + 1)
+        }
+    }
+
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
@@ -1,0 +1,30 @@
+package com.netflix.spinnaker.igor.gitlabci.service
+
+import com.netflix.spinnaker.igor.build.model.GenericBuild
+import com.netflix.spinnaker.igor.build.model.GenericGitRevision
+import com.netflix.spinnaker.igor.model.BuildServiceProvider
+import com.netflix.spinnaker.igor.service.BuildService
+import sun.reflect.generics.reflectiveObjects.NotImplementedException
+
+class GitlabCiService implements BuildService {
+
+    @Override
+    BuildServiceProvider buildServiceProvider() {
+        return BuildServiceProvider.GITLAB_CI
+    }
+
+    @Override
+    List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber) {
+        throw new NotImplementedException()
+    }
+
+    @Override
+    GenericBuild getGenericBuild(String job, int buildNumber) {
+        throw new NotImplementedException()
+    }
+
+    @Override
+    int triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
+        throw new NotImplementedException()
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.igor.gitlabci.service
 
 import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.GenericGitRevision
+import com.netflix.spinnaker.igor.build.model.GenericJobConfiguration
 import com.netflix.spinnaker.igor.gitlabci.client.GitlabCiClient
 import com.netflix.spinnaker.igor.gitlabci.client.model.Pipeline
 import com.netflix.spinnaker.igor.gitlabci.client.model.PipelineSummary
@@ -42,6 +43,11 @@ class GitlabCiService implements BuildService {
 
     @Override
     int triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
+        throw new NotImplementedException()
+    }
+
+    @Override
+    GenericJobConfiguration getJobConfig(String jobName) {
         throw new NotImplementedException()
     }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
@@ -1,9 +1,10 @@
 package com.netflix.spinnaker.igor.gitlabci.service
 
-import com.netflix.spinnaker.hystrix.SimpleHystrixCommand
 import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.GenericGitRevision
 import com.netflix.spinnaker.igor.gitlabci.client.GitlabCiClient
+import com.netflix.spinnaker.igor.gitlabci.client.model.Pipeline
+import com.netflix.spinnaker.igor.gitlabci.client.model.PipelineSummary
 import com.netflix.spinnaker.igor.gitlabci.client.model.Project
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.service.BuildService
@@ -13,11 +14,13 @@ import sun.reflect.generics.reflectiveObjects.NotImplementedException
 class GitlabCiService implements BuildService {
 
     private GitlabCiClient client
+    private String address
     private boolean limitByMembership
     private boolean limitByOwnership
 
-    GitlabCiService(GitlabCiClient client, boolean limitByMembership, boolean limitByOwnership) {
+    GitlabCiService(GitlabCiClient client, String address, boolean limitByMembership, boolean limitByOwnership) {
         this.client = client
+        this.address = address
         this.limitByMembership = limitByMembership
         this.limitByOwnership = limitByOwnership
     }
@@ -46,6 +49,26 @@ class GitlabCiService implements BuildService {
         return getProjectsRec([], 1)
     }
 
+    List<Pipeline> getPipelines(Project project, int limit) {
+        isValidPageSize(limit)
+
+        List<PipelineSummary> pipelineSummaries = client.getPipelineSummaries(project.id, limit)
+
+        return pipelineSummaries.collect({
+            client.getPipeline(project.id, String.valueOf(it.id))
+        })
+    }
+
+    static String getBranchedPipelineSlug(Project project, Pipeline pipeline) {
+        return pipeline.isTag()?
+            "${project.path_with_namespace}/tags" :
+            "${project.path_with_namespace}/${pipeline.ref}"
+    }
+
+    String getAddress() {
+        return address
+    }
+
     @TailRecursive
     private List<Project> getProjectsRec(List<Project> projects, int page) {
         List<Project> slice = client.getProjects(limitByMembership, limitByOwnership, page)
@@ -57,4 +80,10 @@ class GitlabCiService implements BuildService {
         }
     }
 
+    private static void isValidPageSize(int perPage) {
+        if (perPage > GitlabCiClient.MAX_PAGE_SIZE) {
+            throw new IllegalArgumentException("Gitlab API call page size should be less than ${GitlabCiClient.MAX_PAGE_SIZE} " +
+                "but was $perPage")
+        }
+    }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.groovy
@@ -48,7 +48,7 @@ class GitlabCiService implements BuildService {
 
     @Override
     GenericJobConfiguration getJobConfig(String jobName) {
-        throw new NotImplementedException()
+        return new GenericJobConfiguration(jobName, jobName, jobName, true, "$address/$jobName/pipelines", true, [])
     }
 
     List<Project> getProjects() {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -16,9 +16,6 @@
 
 package com.netflix.spinnaker.igor.jenkins
 
-import com.netflix.appinfo.InstanceInfo
-import com.netflix.discovery.DiscoveryClient
-import com.netflix.spinnaker.igor.IgorConfigurationProperties
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.history.model.BuildContent
 import com.netflix.spinnaker.igor.history.model.BuildEvent
@@ -26,42 +23,31 @@ import com.netflix.spinnaker.igor.jenkins.client.model.Build
 import com.netflix.spinnaker.igor.jenkins.client.model.Project
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
-import com.netflix.spinnaker.igor.polling.PollingMonitor
+import com.netflix.spinnaker.igor.polling.CommonPollingMonitor
 import com.netflix.spinnaker.igor.service.BuildMasters
-import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
-import rx.Scheduler
-import rx.Scheduler.Worker
-import rx.functions.Action0
-import rx.schedulers.Schedulers
 
 import javax.annotation.PreDestroy
-import java.util.concurrent.TimeUnit
 
 import static net.logstash.logback.argument.StructuredArguments.kv
 
 /**
  * Monitors new jenkins builds
  */
-@Slf4j
 @Service
 @SuppressWarnings('CatchException')
 @ConditionalOnProperty('jenkins.enabled')
-class JenkinsBuildMonitor implements PollingMonitor {
+class JenkinsBuildMonitor extends CommonPollingMonitor {
 
     @Autowired
     Environment environment
 
     @Value('${jenkins.polling.enabled:true}')
     boolean pollingEnabled = true
-
-    Scheduler scheduler = Schedulers.io()
-    Worker worker = scheduler.createWorker()
 
     @Autowired
     JenkinsCache cache
@@ -72,63 +58,27 @@ class JenkinsBuildMonitor implements PollingMonitor {
     @Autowired
     BuildMasters buildMasters
 
-    Long lastPoll
-
-    @Override
-    Long getLastPoll() {
-        lastPoll
-    }
-
-    @Autowired
-    IgorConfigurationProperties igorConfigurationProperties
-
-    @Override
-    int getPollInterval() {
-        igorConfigurationProperties.spinnaker.build.pollInterval
-    }
-
-    @Autowired(required = false)
-    DiscoveryClient discoveryClient
-
     @Override
     String getName() {
         "jenkinsBuildMonitor"
     }
 
-    String lastStatus
-
     @Override
     boolean isInService() {
-        if (discoveryClient == null) {
-            log.info("no DiscoveryClient, assuming InService")
-            return pollingEnabled
-        } else {
-            def remoteStatus = discoveryClient.instanceRemoteStatus
-            if (remoteStatus != lastStatus) {
-                log.info("current remote status ${remoteStatus}")
-            }
-            lastStatus=remoteStatus
-            remoteStatus == InstanceInfo.InstanceStatus.UP && pollingEnabled
-        }
+        pollingEnabled && super.isInService()
     }
 
     @Override
-    void onApplicationEvent(ContextRefreshedEvent event) {
-        log.info('Started')
-        worker.schedulePeriodically(
-                {
-                    if (isInService()) {
-                        log.info "- Polling cycle started - ${new Date()}"
-                        buildMasters.filteredMap(BuildServiceProvider.JENKINS).keySet().parallelStream().forEach(
-                                { master -> changedBuilds(master) }
-                        )
-                        log.info "- Polling cycle done - ${new Date()}"
-                    } else {
-                        log.info("not in service (lastPoll: ${lastPoll ?: 'n/a'})")
-                        lastPoll = null
-                    }
-                } as Action0, 0, pollInterval, TimeUnit.SECONDS
+    void initialize() {
+    }
+
+    @Override
+    void poll() {
+        log.info "- Polling cycle started - ${new Date()}"
+        buildMasters.filteredMap(BuildServiceProvider.JENKINS).keySet().parallelStream().forEach(
+            { master -> changedBuilds(master) }
         )
+        log.info "- Polling cycle done - ${new Date()}"
     }
 
     @PreDestroy
@@ -149,7 +99,6 @@ class JenkinsBuildMonitor implements PollingMonitor {
     void changedBuilds(String master) {
         log.debug("Checking for new builds for ${master}")
         def startTime = System.currentTimeMillis()
-        lastPoll = startTime
 
         try {
             JenkinsService jenkinsService = buildMasters.map[master] as JenkinsService

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -57,10 +57,10 @@ interface JenkinsClient {
     BuildDependencies getDependencies(@EncodedPath('jobName') String jobName)
 
     @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(totalCount)]&tree=actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url,fullDisplayName,artifacts[displayPath,fileName,relativePath]')
-    Build getBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
+    Build getBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') long buildNumber)
 
     @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(lastBuiltRevision)]&tree=actions[remoteUrl,lastBuiltRevision[branch[name,SHA1]]]')
-    ScmDetails getGitDetails(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
+    ScmDetails getGitDetails(@EncodedPath('jobName') String jobName, @Path('buildNumber') Long buildNumber)
 
     @GET('/job/{jobName}/lastCompletedBuild/api/xml')
     Build getLatestBuild(@EncodedPath('jobName') String jobName)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
@@ -99,12 +99,12 @@ class JenkinsService implements BuildService{
         }).execute()
     }
 
-    Build getBuild(String jobName, Integer buildNumber) {
+    Build getBuild(String jobName, long buildNumber) {
         return jenkinsClient.getBuild(encode(jobName), buildNumber)
     }
 
     @Override
-    GenericBuild getGenericBuild(String jobName, int buildNumber) {
+    GenericBuild getGenericBuild(String jobName, long buildNumber) {
         return getBuild(jobName, buildNumber).genericBuild(jobName)
     }
 
@@ -125,7 +125,7 @@ class JenkinsService implements BuildService{
         return queuedLocation.split('/')[-1].toInteger()
     }
 
-    ScmDetails getGitDetails(String jobName, Integer buildNumber) {
+    ScmDetails getGitDetails(String jobName, Long buildNumber) {
         new SimpleHystrixCommand<ScmDetails>(
             groupKey, buildCommandKey("getGitDetails"), {
             return jenkinsClient.getGitDetails(encode(jobName), buildNumber)
@@ -180,7 +180,7 @@ class JenkinsService implements BuildService{
     }
 
     @Override
-    List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber) {
+    List<GenericGitRevision> getGenericGitRevisions(String job, long buildNumber) {
         ScmDetails scmDetails = getGitDetails(job, buildNumber)
         if (scmDetails?.action?.lastBuiltRevision?.branch?.name) {
             return scmDetails.genericGitRevisions()

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/BuildServiceProvider.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/BuildServiceProvider.groovy
@@ -18,5 +18,6 @@ package com.netflix.spinnaker.igor.model
 
 enum BuildServiceProvider {
   JENKINS,
-  TRAVIS
+  TRAVIS,
+  GITLAB_CI
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.groovy
@@ -1,0 +1,70 @@
+package com.netflix.spinnaker.igor.polling
+
+import com.netflix.appinfo.InstanceInfo
+import com.netflix.discovery.DiscoveryClient
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.event.ContextRefreshedEvent
+import rx.Scheduler
+import rx.functions.Action0
+import rx.schedulers.Schedulers
+
+import java.util.concurrent.TimeUnit
+
+abstract class CommonPollingMonitor implements PollingMonitor {
+    Logger log = LoggerFactory.getLogger(getClass())
+
+    @Autowired(required = false)
+    DiscoveryClient discoveryClient
+
+    @Autowired
+    IgorConfigurationProperties igorConfigurationProperties
+
+    Scheduler scheduler = Schedulers.io()
+
+    Scheduler.Worker worker = scheduler.createWorker()
+
+    Long lastPoll
+
+    @Override
+    void onApplicationEvent(ContextRefreshedEvent event) {
+        log.info('Started')
+        initialize()
+        worker.schedulePeriodically({
+            if (isInService()) {
+                lastPoll = System.currentTimeMillis()
+                poll()
+            } else {
+                log.info("not in service (lastPoll: ${lastPoll ?: 'n/a'})")
+                lastPoll = null
+            }
+        } as Action0, 0, pollInterval, TimeUnit.SECONDS)
+    }
+
+    abstract void initialize()
+    abstract void poll()
+
+    @Override
+    boolean isInService() {
+        if (discoveryClient == null) {
+            log.info("no DiscoveryClient, assuming InService")
+            true
+        } else {
+            def remoteStatus = discoveryClient.instanceRemoteStatus
+            log.info("current remote status ${remoteStatus}")
+            remoteStatus == InstanceInfo.InstanceStatus.UP
+        }
+    }
+
+    @Override
+    int getPollInterval() {
+        return igorConfigurationProperties.spinnaker.build.pollInterval
+    }
+
+    @Override
+    Long getLastPoll() {
+        return lastPoll
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.groovy
@@ -29,4 +29,6 @@ interface BuildService {
 
     int triggerBuildWithParameters(String job, Map<String, String> queryParameters)
 
+    Object getJobConfig(String jobName)
+
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.groovy
@@ -23,9 +23,9 @@ import com.netflix.spinnaker.igor.model.BuildServiceProvider
 interface BuildService {
     BuildServiceProvider buildServiceProvider()
 
-    List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber)
+    List<GenericGitRevision> getGenericGitRevisions(String job, long buildNumber)
 
-    GenericBuild getGenericBuild(String job, int buildNumber)
+    GenericBuild getGenericBuild(String job, long buildNumber)
 
     int triggerBuildWithParameters(String job, Map<String, String> queryParameters)
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -16,9 +16,6 @@
 
 package com.netflix.spinnaker.igor.travis
 
-import com.netflix.appinfo.InstanceInfo
-import com.netflix.discovery.DiscoveryClient
-import com.netflix.spinnaker.igor.IgorConfigurationProperties
 import com.netflix.spinnaker.igor.build.BuildCache
 import com.netflix.spinnaker.igor.build.model.GenericProject
 import com.netflix.spinnaker.igor.config.TravisProperties
@@ -26,36 +23,31 @@ import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.history.model.GenericBuildContent
 import com.netflix.spinnaker.igor.history.model.GenericBuildEvent
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
-import com.netflix.spinnaker.igor.polling.PollingMonitor
+import com.netflix.spinnaker.igor.polling.CommonPollingMonitor
 import com.netflix.spinnaker.igor.service.BuildMasters
 import com.netflix.spinnaker.igor.travis.client.model.Repo
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
 import com.netflix.spinnaker.igor.travis.service.TravisBuildConverter
 import com.netflix.spinnaker.igor.travis.service.TravisResultConverter
 import com.netflix.spinnaker.igor.travis.service.TravisService
-import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.stereotype.Service
 import rx.Observable
 import rx.Scheduler
-import rx.functions.Action0
 import rx.schedulers.Schedulers
 
 import java.util.concurrent.TimeUnit
 
 import static net.logstash.logback.argument.StructuredArguments.kv
 
-
 /**
  * Monitors new travis builds
  */
-@Slf4j
 @Service
 @SuppressWarnings('CatchException')
 @ConditionalOnProperty('travis.enabled')
-class TravisBuildMonitor implements PollingMonitor{
+class TravisBuildMonitor extends CommonPollingMonitor {
 
     Scheduler.Worker worker = Schedulers.io().createWorker()
 
@@ -65,68 +57,30 @@ class TravisBuildMonitor implements PollingMonitor{
     @Autowired(required = false)
     EchoService echoService
 
-    @Autowired(required = false)
-    DiscoveryClient discoveryClient
-
     @Autowired
     BuildMasters buildMasters
 
-    Long lastPoll
-
-    static final int NEW_BUILD_EVENT_THRESHOLD = 1
-
     static final long BUILD_STARTED_AT_THRESHOLD = TimeUnit.SECONDS.toMillis(30)
-
-    @Autowired
-    IgorConfigurationProperties igorConfigurationProperties
 
     @Autowired
     TravisProperties travisProperties
 
     @Override
-    void onApplicationEvent(ContextRefreshedEvent event) {
-        log.info('Started')
+    void initialize() {
         setBuildCacheTTL()
         migrateToNewBuildCache()
-        worker.schedulePeriodically(
-            {
-                if (isInService()) {
-                    buildMasters.filteredMap(BuildServiceProvider.TRAVIS).keySet().each { master ->
-                        changedBuilds(master)
-                    }
-                } else {
-                    log.info("not in service (lastPoll: ${lastPoll ?: 'n/a'})")
-                    lastPoll = null
-                }
-            } as Action0, 0, pollInterval, TimeUnit.SECONDS
-        )
+    }
+
+    @Override
+    void poll() {
+        buildMasters.filteredMap(BuildServiceProvider.TRAVIS).keySet().each { master ->
+            changedBuilds(master)
+        }
     }
 
     @Override
     String getName() {
         return "travisBuildMonitor"
-    }
-
-    @Override
-    boolean isInService() {
-        if (discoveryClient == null) {
-            log.info("no DiscoveryClient, assuming InService")
-            true
-        } else {
-            def remoteStatus = discoveryClient.instanceRemoteStatus
-            log.info("current remote status ${remoteStatus}")
-            remoteStatus == InstanceInfo.InstanceStatus.UP
-        }
-    }
-
-    @Override
-    Long getLastPoll() {
-        return lastPoll
-    }
-
-    @Override
-    int getPollInterval() {
-        return igorConfigurationProperties.spinnaker.build.pollInterval
     }
 
     List<Map> changedBuilds(String master) {
@@ -135,9 +89,8 @@ class TravisBuildMonitor implements PollingMonitor{
         List<Map> results = []
         int updatedBuilds = 0
 
-        TravisService travisService = buildMasters.map[master]
+        TravisService travisService = buildMasters.map[master] as TravisService
 
-        lastPoll = System.currentTimeMillis()
         def startTime = System.currentTimeMillis()
         List<Repo> repos = filterOutOldBuilds(travisService.getReposForAccounts())
         log.info("Took ${System.currentTimeMillis() - startTime}ms to retrieve ${repos.size()} repositories (master: {})", kv("master", master))
@@ -175,7 +128,7 @@ class TravisBuildMonitor implements PollingMonitor{
         if (updatedBuilds) {
             log.info("Found {} new builds (master: {})", updatedBuilds, kv("master", master))
         }
-        log.info("Last poll took ${System.currentTimeMillis() - lastPoll}ms (master: {})", kv("master", master))
+        log.info("Last poll took ${System.currentTimeMillis() - startTime}ms (master: {})", kv("master", master))
         if (travisProperties.repositorySyncEnabled) {
             startTime = System.currentTimeMillis()
             travisService.syncRepos()

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -62,10 +62,10 @@ interface TravisClient {
     Build build(@Header("Authorization") String accessToken, @Path('build_id') int buildId)
 
     @GET('/builds')
-    Build build(@Header("Authorization") String accessToken, @Query('repository_id') int repositoryId, @Query('number') int buildNumber)
+    Build build(@Header("Authorization") String accessToken, @Query('repository_id') int repositoryId, @Query('number') long buildNumber)
 
     @GET('/builds')
-    Builds builds(@Header("Authorization") String accessToken, @Query('slug') String repoSlug, @Query('number') int buildNumber)
+    Builds builds(@Header("Authorization") String accessToken, @Query('slug') String repoSlug, @Query('number') long buildNumber)
 
     @GET('/repos')
     Repos repos(@Header("Authorization") String accessToken , @Query('member') String login, @Query('active') boolean active,  @Query('limit') int limit, @Query('offset') int offset)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -80,7 +80,7 @@ class TravisService implements BuildService {
     }
 
     @Override
-    List<GenericGitRevision> getGenericGitRevisions(String inputRepoSlug, int buildNumber) {
+    List<GenericGitRevision> getGenericGitRevisions(String inputRepoSlug, long buildNumber) {
         new SimpleHystrixCommand<List<GenericGitRevision>>(
             groupKey, buildCommandKey("getGenericGitRevisions"),
             {
@@ -92,7 +92,7 @@ class TravisService implements BuildService {
     }
 
     @Override
-    GenericBuild getGenericBuild(String inputRepoSlug, int buildNumber) {
+    GenericBuild getGenericBuild(String inputRepoSlug, long buildNumber) {
         new SimpleHystrixCommand<GenericBuild>(
             groupKey, buildCommandKey("getGenericBuild"),
             {
@@ -123,7 +123,7 @@ class TravisService implements BuildService {
         return builds.builds
     }
 
-    Build getBuild(Repo repo, int buildNumber) {
+    Build getBuild(Repo repo, long buildNumber) {
         new SimpleHystrixCommand<Build>(
             groupKey, buildCommandKey("getBuild"),
             {
@@ -132,7 +132,7 @@ class TravisService implements BuildService {
         ).execute()
     }
 
-    Builds getBuilds(String repoSlug, int buildNumber) {
+    Builds getBuilds(String repoSlug, long buildNumber) {
         new SimpleHystrixCommand<Builds>(
             groupKey, buildCommandKey("getBuilds"),
             {
@@ -141,7 +141,7 @@ class TravisService implements BuildService {
         ).execute()
     }
 
-    Build getBuild(String repoSlug, int buildNumber) {
+    Build getBuild(String repoSlug, long buildNumber) {
         Builds builds = getBuilds(repoSlug, buildNumber)
         return builds.builds.size() > 0 ? builds.builds.first() : null
     }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -16,7 +16,10 @@
 
 package com.netflix.spinnaker.igor.build
 
+import com.netflix.spinnaker.igor.config.GitlabCiProperties
 import com.netflix.spinnaker.igor.config.JenkinsConfig
+import com.netflix.spinnaker.igor.config.JenkinsProperties
+import com.netflix.spinnaker.igor.config.TravisProperties
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.service.BuildMasters
@@ -44,6 +47,9 @@ class InfoControllerSpec extends Specification {
     MockMvc mockMvc
     BuildCache cache
     BuildMasters buildMasters
+    JenkinsProperties jenkinsProperties
+    TravisProperties travisProperties
+    GitlabCiProperties gitlabCiProperties
 
     @Shared
     JenkinsService service
@@ -58,7 +64,16 @@ class InfoControllerSpec extends Specification {
     void setup() {
         cache = Mock(BuildCache)
         buildMasters = Mock(BuildMasters)
-        mockMvc = MockMvcBuilders.standaloneSetup(new InfoController(buildCache: cache, buildMasters: buildMasters)).build()
+        jenkinsProperties = Mock(JenkinsProperties)
+        travisProperties = Mock(TravisProperties)
+        gitlabCiProperties = Mock(GitlabCiProperties)
+        mockMvc = MockMvcBuilders.standaloneSetup(
+            new InfoController(buildCache: cache,
+                buildMasters: buildMasters,
+                jenkinsProperties: jenkinsProperties,
+                travisProperties: travisProperties,
+                gitlabCiProperties: gitlabCiProperties))
+            .build()
         server = new MockWebServer()
     }
 
@@ -70,6 +85,23 @@ class InfoControllerSpec extends Specification {
         then:
         1 * buildMasters.map >> ['master2': [], 'build.buildMasters.blah': [], 'master1': []]
         response.contentAsString == '["build.buildMasters.blah","master1","master2"]'
+    }
+
+    void 'is able to get a list of buildMasters with urls'() {
+        when:
+        MockHttpServletResponse response = mockMvc.perform(get('/masters')
+            .param("showUrl", "true")
+            .accept(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .response
+
+        then:
+        1 * jenkinsProperties.masters >> [['name': 'jenkins-foo', 'address': 'http://jenkins-bar']]
+        1 * travisProperties.masters >> [['name': 'travis-foo', 'address': 'http://travis-bar']]
+        1 * gitlabCiProperties.masters >> [['name': 'gitlab-foo', 'address': 'http://gitlab-bar']]
+        response.getContentAsString() == '[{"name":"jenkins-foo","address":"http://jenkins-bar"},' +
+            '{"name":"travis-foo","address":"http://travis-bar"},' +
+            '{"name":"gitlab-foo","address":"http://gitlab-bar"}]'
     }
 
     void 'is able to get jobs for a jenkins master'() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -36,7 +36,7 @@ class DockerMonitorSpec extends Specification {
         )
 
         when:
-        DockerMonitor.postEvent(
+        new DockerMonitor().postEvent(
             echoService, cachedImages, taggedImage, "imageId"
         )
 
@@ -51,7 +51,7 @@ class DockerMonitorSpec extends Specification {
         })
 
         when: "should short circuit if `echoService` is not available"
-        DockerMonitor.postEvent(
+        new DockerMonitor().postEvent(
             null, ["imageId"], taggedImage, "imageId"
         )
 
@@ -77,7 +77,7 @@ class DockerMonitorSpec extends Specification {
         )
 
         when:
-        DockerMonitor.postEvent(
+        new DockerMonitor().postEvent(
             echoService, ["job1"], taggedImage, "imageId"
         )
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiServiceSpec.groovy
@@ -14,13 +14,13 @@ class GitlabCiServiceSpec extends Specification {
 
     void setup() {
         client = Mock(GitlabCiClient)
-        service = new GitlabCiService(client, false, false)
+        service = new GitlabCiService(client, null, false, false)
     }
 
     def "verify project pagination"() {
         given:
-        client.getProjects(_, _, 1) >> [new Project(name_with_namespace: "project1")]
-        client.getProjects(_, _, 2) >> [new Project(name_with_namespace: "project2")]
+        client.getProjects(_, _, 1) >> [new Project(path_with_namespace: "project1")]
+        client.getProjects(_, _, 2) >> [new Project(path_with_namespace: "project2")]
         client.getProjects(_, _, 3) >> []
 
         when:

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiServiceSpec.groovy
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.igor.gitlabci.service
+
+import com.netflix.spinnaker.igor.gitlabci.client.GitlabCiClient
+import com.netflix.spinnaker.igor.gitlabci.client.model.Project
+import spock.lang.Shared
+import spock.lang.Specification
+
+class GitlabCiServiceSpec extends Specification {
+    @Shared
+    GitlabCiClient client
+
+    @Shared
+    GitlabCiService service
+
+    void setup() {
+        client = Mock(GitlabCiClient)
+        service = new GitlabCiService(client, false, false)
+    }
+
+    def "verify project pagination"() {
+        given:
+        client.getProjects(_, _, 1) >> [new Project(name_with_namespace: "project1")]
+        client.getProjects(_, _, 2) >> [new Project(name_with_namespace: "project2")]
+        client.getProjects(_, _, 3) >> []
+
+        when:
+        def projects = service.getProjects()
+
+        then:
+        projects.size() == 2
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
@@ -41,7 +41,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
     final PROJECTS = new ProjectsList(list: [])
     final TestScheduler scheduler = new TestScheduler()
 
-    void 'scheduller polls periodically'() {
+    void 'scheduler polls periodically'() {
         given:
         cache.getJobNames(MASTER) >> []
         BuildMasters buildMasters = Mock(BuildMasters)


### PR DESCRIPTION
**This is a work-in-progress PR. Do not merge.**

This is the part of https://github.com/spinnaker/spinnaker/issues/2047 and the follow-up for https://github.com/spinnaker/igor/pull/197 to not only the SCM but also the CI aspect of Gitlab.

This is a work-in-progress implementation of support for Gitlab CI, namely:
- triggering of Spinnaker pipelines after completions of Gitlab CI pipelines
- pulling artifacts from Gitlab CI pipelines for bake stages
- Triggering of Gitlab CI pipelines from Spinnaker steps

I've been working on the Gitlab CI integration: https://github.com/spinnaker/igor/pull/207. This is still work-in-progress but I'd like to have some input because the PR is growing bigger and bigger. Mainly because I felt like I needed to do some refactoring:
- Changing type of build number from int to long since for gitlab.com they apparently use a global id counter for all pipelines and it's not unrealistic that there'll be an integer overflow in the near future. So it's better to be on the safe side
- Extracting of common parts polling monitors into CommonPollingMonitor
- Defining some common methods into BuildService interface

So I have the following questions to you guys:
- What's the general feeling about the PR? Should we keep it as a big one or is it better to split it into several parts?
- Since the change touches the existing integrations (Travis, Jenkins, Docker etc) what would be the best way to test it?
- Also changes in other services will be needed (orca, gate, deck) but I believe that they should be in separate PRs.