### PR TITLE
refactor(core): Reduce code duplication in polling monitors

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor.polling
+
+import com.netflix.appinfo.InstanceInfo
+import com.netflix.discovery.DiscoveryClient
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import rx.Scheduler
+import rx.functions.Action0
+import rx.schedulers.Schedulers
+
+import java.util.concurrent.TimeUnit
+
+abstract class CommonPollingMonitor implements PollingMonitor {
+    Logger log = LoggerFactory.getLogger(getClass())
+
+    @Autowired(required = false)
+    DiscoveryClient discoveryClient
+
+    @Autowired
+    IgorConfigurationProperties igorConfigurationProperties
+
+    Scheduler scheduler = Schedulers.io()
+
+    Scheduler.Worker worker = scheduler.createWorker()
+
+    Long lastPoll
+
+    @Override
+    void onApplicationEvent(RemoteStatusChangedEvent event) {
+        log.info('Started')
+        initialize()
+        worker.schedulePeriodically({
+            if (isInService()) {
+                lastPoll = System.currentTimeMillis()
+                poll()
+            } else {
+                log.info("not in service (lastPoll: ${lastPoll ?: 'n/a'})")
+                lastPoll = null
+            }
+        } as Action0, 0, pollInterval, TimeUnit.SECONDS)
+    }
+
+    abstract void initialize()
+    abstract void poll()
+
+    @Override
+    boolean isInService() {
+        if (discoveryClient == null) {
+            log.info("no DiscoveryClient, assuming InService")
+            true
+        } else {
+            def remoteStatus = discoveryClient.instanceRemoteStatus
+            log.info("current remote status ${remoteStatus}")
+            remoteStatus == InstanceInfo.InstanceStatus.UP
+        }
+    }
+
+    @Override
+    int getPollInterval() {
+        return igorConfigurationProperties.spinnaker.build.pollInterval
+    }
+
+    @Override
+    Long getLastPoll() {
+        return lastPoll
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -36,7 +36,7 @@ class DockerMonitorSpec extends Specification {
         )
 
         when:
-        DockerMonitor.postEvent(
+        new DockerMonitor().postEvent(
             echoService, cachedImages, taggedImage, "imageId"
         )
 
@@ -51,7 +51,7 @@ class DockerMonitorSpec extends Specification {
         })
 
         when: "should short circuit if `echoService` is not available"
-        DockerMonitor.postEvent(
+        new DockerMonitor().postEvent(
             null, ["imageId"], taggedImage, "imageId"
         )
 
@@ -77,7 +77,7 @@ class DockerMonitorSpec extends Specification {
         )
 
         when:
-        DockerMonitor.postEvent(
+        new DockerMonitor().postEvent(
             echoService, ["job1"], taggedImage, "imageId"
         )
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
@@ -40,7 +40,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
     final PROJECTS = new ProjectsList(list: [])
     final TestScheduler scheduler = new TestScheduler()
 
-    void 'scheduller polls periodically'() {
+    void 'scheduler polls periodically'() {
         given:
         cache.getJobNames(MASTER) >> []
         BuildMasters buildMasters = Mock(BuildMasters)


### PR DESCRIPTION
This PR fixes https://github.com/spinnaker/spinnaker/issues/2166.

The basic idea is to reduce the code duplication by using [template method design pattern](https://en.wikipedia.org/wiki/Template_method_pattern). All the common code is pushed to `CommonPollingMonitor`.