### PR TITLE
fix(travis) emmit build started events for new branches as well

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -87,7 +87,6 @@ class TravisBuildMonitor extends CommonPollingMonitor {
 
     List<Map> changedBuilds(String master) {
         log.info('Checking for new builds for {}', kv("master", master))
-        List<String> cachedRepoSlugs = buildCache.getJobNames(master)
         List<Map> results = []
         int updatedBuilds = 0
 
@@ -101,16 +100,11 @@ class TravisBuildMonitor extends CommonPollingMonitor {
                 List<V3Build> builds = travisService.getBuilds(repo, 5)
                 for (V3Build build : builds) {
                     boolean addToCache = false
-                    def cachedBuild = null
                     String branchedRepoSlug = build.branchedRepoSlug()
-                    if (cachedRepoSlugs.contains(branchedRepoSlug)) {
-                        cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug, TravisResultConverter.running(build.state))
-                        if (build.number > cachedBuild) {
-                            addToCache = true
-                            log.info("New build: {}: ${branchedRepoSlug} : ${build.number}", kv("master", master))
-                        }
-                    } else {
-                        addToCache = !TravisResultConverter.running(build.state)
+                    def cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug, TravisResultConverter.running(build.state))
+                    if (build.number > cachedBuild) {
+                        addToCache = true
+                        log.info("New build: {}: ${branchedRepoSlug} : ${build.number}", kv("master", master))
                     }
                     if (addToCache) {
                         updatedBuilds += 1

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -52,9 +52,6 @@ class TravisBuildMonitorSpec extends Specification {
         V3Build build = Mock(V3Build)
         V3Repository repository = Mock(V3Repository)
 
-        given:
-        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo/master']
-
         when:
         List<Map> receivedBuilds = travisBuildMonitor.changedBuilds(MASTER)
 
@@ -89,10 +86,6 @@ class TravisBuildMonitorSpec extends Specification {
         List<Repo> repos = [oldRepo, repo, noLastBuildStartedAtRepo]
         V3Build build = Mock(V3Build)
         V3Repository repository = Mock(V3Repository)
-
-
-        given:
-        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo/master']
 
         when:
         List<Map> builds = travisBuildMonitor.changedBuilds(MASTER)
@@ -129,9 +122,6 @@ class TravisBuildMonitorSpec extends Specification {
         List<Repo> repos = [repo]
         V3Build build = Mock(V3Build)
         V3Repository repository = Mock(V3Repository)
-
-        given:
-        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo/my_branch']
 
         when:
         travisBuildMonitor.changedBuilds(MASTER)
@@ -173,10 +163,6 @@ class TravisBuildMonitorSpec extends Specification {
         V3Build build = Mock(V3Build)
         V3Build buildDifferentBranch = Mock(V3Build)
         V3Repository repository = Mock(V3Repository)
-
-
-        given:
-        1 * buildCache.getJobNames(MASTER) >> ['test-org/test-repo/my_branch', 'test-org/test-repo/different_branch']
 
         when:
         travisBuildMonitor.changedBuilds(MASTER)


### PR DESCRIPTION
There is a bug in the current code where running builds only emits events if the branch is known to igor from one finished build. This will fix that and also simplify the code.