### PR TITLE
fix(travis/triggers): Keep track of builds in flight.

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildCache.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildCache.java
@@ -75,8 +75,13 @@ public class BuildCache {
     }
 
     public Long getTTL(String master, String job) {
+        final String key = makeKey(master, job);
+        return getTTL(key);
+    }
+
+    private Long getTTL(String key) {
         return redisClientDelegate.withCommandsClient(c -> {
-            return c.ttl(makeKey(master, job));
+            return c.ttl(key);
         });
     }
 
@@ -103,17 +108,17 @@ public class BuildCache {
         return jobs;
     }
 
-    public Map getDeprecatedLastBuild(String master, String job) {
+    public Map<String, Object> getDeprecatedLastBuild(String master, String job) {
         String key = makeKey(master, job);
         Map<String, String> result = redisClientDelegate.withCommandsClient(c -> {
             if (!c.exists(key)) {
-                return new HashMap<>();
+                return null;
             }
             return c.hgetAll(key);
         });
 
-        if (result.isEmpty()) {
-            return result;
+        if (result == null) {
+            return new HashMap<>();
         }
 
         Map<String, Object> converted = new HashMap<>();
@@ -121,6 +126,37 @@ public class BuildCache {
         converted.put("lastBuildBuilding", Boolean.valueOf(result.get("lastBuildBuilding")));
 
         return converted;
+    }
+
+    public List<Map<String, String>> getTrackedBuilds(String master) {
+        List<Map<String, String>> builds = redisClientDelegate.withMultiClient(c -> {
+            return c.keys(baseKey() + ":track:" + master + ":*").stream()
+                .map(BuildCache::getTrackedBuild)
+                .collect(Collectors.toList());
+        });
+        return builds;
+    }
+
+    public void setTracking(String master, String job, int buildId, int ttl) {
+        String key = makeTrackKey(master, job, buildId);
+        redisClientDelegate.withCommandsClient(c -> {
+            c.set(key, "marked as running");
+        });
+        setTTL(key, ttl);
+    }
+
+    public void deleteTracking(String master, String job, int buildId) {
+        String key = makeTrackKey(master, job, buildId);
+        redisClientDelegate.withCommandsClient(c -> {
+            c.del(key);
+        });
+    }
+
+    private static Map<String, String> getTrackedBuild(String key) {
+        Map<String, String> build = new HashMap();
+        build.put("job", extractJobName(key));
+        build.put("buildId", extractBuildIdFromTrackingKey(key));
+        return build;
     }
 
     private void setBuild(String key, int lastBuild, boolean building, String master, String job, int ttl) {
@@ -147,8 +183,16 @@ public class BuildCache {
         return baseKey() + ":" + buildState + ":" + master + ":" + job.toUpperCase() + ":" + job;
     }
 
+    protected String makeTrackKey(String master, String job, int buildId) {
+        return baseKey() + ":track:" + master + ":" + job.toUpperCase() + ":" + job + ":" + buildId;
+    }
+
     private static String extractJobName(String key) {
         return key.split(":")[5];
+    }
+
+    private static String extractBuildIdFromTrackingKey(String key) {
+        return key.split(":")[6];
     }
 
     private static String extractDeprecatedJobName(String key) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsCache.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsCache.java
@@ -64,17 +64,17 @@ public class JenkinsCache {
         return results;
     }
 
-    public Map getLastBuild(String master, String job) {
+    public Map<String, Object> getLastBuild(String master, String job) {
         String key = makeKey(master, job);
         Map<String, String> result = redisClientDelegate.withCommandsClient(c -> {
             if (!c.exists(key)) {
-                return new HashMap<>();
+                return null;
             }
             return c.hgetAll(key);
         });
 
-        if (result.isEmpty()) {
-            return result;
+        if (result == null) {
+            return new HashMap<>();
         }
 
         Map<String, Object> converted = new HashMap<>();

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.igor.travis.client.model.RepoWrapper
 import com.netflix.spinnaker.igor.travis.client.model.Repos
 import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse
 import com.netflix.spinnaker.igor.travis.client.model.v3.Request
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Builds
 import retrofit.client.Response
 import retrofit.http.Body
@@ -98,6 +99,10 @@ interface TravisClient {
     ])
     @GET('/job/{jobId}/log')
     Response jobLog(@Header("Authorization") String accessToken , @Path('jobId') int jobId)
+
+    @GET('/build/{build_id}')
+    @Headers("Travis-API-Version: 3")
+    V3Build v3build(@Header("Authorization") String accessToken, @Path('build_id') int repositoryId)
 
     @GET('/repo/{repository_id}/builds')
     @Headers("Travis-API-Version: 3")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.groovy
@@ -76,4 +76,12 @@ class V3Build {
     boolean spinnakerTriggered(){
         return (eventType == "api" && commit.message == "Triggered from spinnaker")
     }
+
+    public String toString() {
+        String tmpSlug = "unknown/repository"
+        if (repository != null) {
+            tmpSlug = repository.slug
+        }
+        return "[" + tmpSlug + ":" + number + ":" + state + "]"
+    }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -132,6 +132,15 @@ class TravisService implements BuildService {
         ).execute()
     }
 
+    V3Build getV3Build(int buildId) {
+        new SimpleHystrixCommand<V3Build>(
+            groupKey, buildCommandKey("getV3Build"),
+            {
+                return travisClient.v3build(getAccessToken(), buildId)
+            }
+        ).execute()
+    }
+
     Builds getBuilds(String repoSlug, int buildNumber) {
         new SimpleHystrixCommand<Builds>(
             groupKey, buildCommandKey("getBuilds"),

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -42,7 +42,7 @@ class TravisBuildMonitorSpec extends Specification {
         travisBuildMonitor = new TravisBuildMonitor(buildCache: buildCache, buildMasters: new BuildMasters(map: [MASTER : travisService]), travisProperties: travisProperties)
     }
 
-    void 'flag a new build not found in the cache'() {
+    void 'flag a new build on master, but do not send event on repo if a newer build is present at repo level'() {
         Repo repo = new Repo()
         repo.slug = "test-org/test-repo"
         repo.lastBuildNumber = 4
@@ -61,8 +61,9 @@ class TravisBuildMonitorSpec extends Specification {
         build.branchedRepoSlug() >> "test-org/test-repo/master"
         build.getNumber() >> 4
         1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/master', false) >> 3
+        1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo', false) >> 5
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/master', 4, false, CACHED_JOB_TTL_SECONDS)
-        1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
+        0 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
 
         build.repository >> repository
         repository.slug >> 'test-org/test-repo'


### PR DESCRIPTION
* Explicit tracking of each running build igor sees.
    - travis api does not allways populate latest_build as one would expect.
* Removing some compiler warnings on cache classes
* Fixing the trigger logic on repo level triggers
