### PR TITLE
feat(jenkins): add log message when artifact cannot be found

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -264,6 +264,7 @@ class BuildController {
                 if (artifact) {
                     return artifact.relativePath
                 }
+                log.info("Could not find artifact {} for job {} on build #{}", fileName, job, buildNumber)
                 throw new ArtifactNotFoundException()
             }, 5, 2000, false)
         } catch (ArtifactNotFoundException ignored) {


### PR DESCRIPTION
Trying to trace through the original issue that caused us to add this retry logic. Probably should have included some logging in the first place.

cc @ajordens 