### PR TITLE
fix(igor/log): Append to log instead of overwrite

### DIFF
--- a/igor-web/etc/init/igor.conf
+++ b/igor-web/etc/init/igor.conf
@@ -9,4 +9,4 @@ expect fork
 
 stop on stopping spinnaker
 
-exec /opt/igor/bin/igor 2>&1 > /var/log/spinnaker/igor/igor.log &
+exec /opt/igor/bin/igor 2>&1 >> /var/log/spinnaker/igor/igor.log &


### PR DESCRIPTION
Changing to appending to the log file so logs will correctly rotate.  This prevents large amounts of null data at the start of a rotated log file.