### PR TITLE
feat(travis): Include artifacts in build event for completed builds

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -20,6 +20,7 @@ import com.netflix.discovery.DiscoveryClient
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.igor.IgorConfigurationProperties
 import com.netflix.spinnaker.igor.build.BuildCache
+import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.GenericProject
 import com.netflix.spinnaker.igor.config.TravisProperties
 import com.netflix.spinnaker.igor.history.EchoService
@@ -32,6 +33,7 @@ import com.netflix.spinnaker.igor.polling.PollContext
 import com.netflix.spinnaker.igor.polling.PollingDelta
 import com.netflix.spinnaker.igor.service.BuildMasters
 import com.netflix.spinnaker.igor.travis.client.model.Repo
+import com.netflix.spinnaker.igor.travis.client.model.v3.TravisBuildState
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
 import com.netflix.spinnaker.igor.travis.service.TravisBuildConverter
 import com.netflix.spinnaker.igor.travis.service.TravisResultConverter
@@ -103,7 +105,6 @@ class TravisBuildMonitor extends CommonPollingMonitor<BuildDelta, BuildPollingDe
     @Override
     protected void commitDelta(BuildPollingDelta delta) {
         String master = delta.master
-        TravisService travisService = buildMasters.map[master] as TravisService
 
         delta.items.parallelStream().forEach { item ->
             V3Build build = item.build
@@ -111,9 +112,9 @@ class TravisBuildMonitor extends CommonPollingMonitor<BuildDelta, BuildPollingDe
             buildCache.setLastBuild(master, item.branchedRepoSlug, build.number, TravisResultConverter.running(build.state), buildCacheJobTTLSeconds())
             if(build.number > buildCache.getLastBuild(master, build.repository.slug, TravisResultConverter.running(build.state))) {
                 buildCache.setLastBuild(master, build.repository.slug, build.number, TravisResultConverter.running(build.state), buildCacheJobTTLSeconds())
-                sendEventForBuild(build, build.repository.slug, master, travisService)
+                sendEventForBuild(item, build.repository.slug, master)
             }
-            sendEventForBuild(build, item.branchedRepoSlug, master, travisService)
+            sendEventForBuild(item, item.branchedRepoSlug, master)
         }
     }
 
@@ -165,17 +166,19 @@ class TravisBuildMonitor extends CommonPollingMonitor<BuildDelta, BuildPollingDe
     private List<BuildDelta> processBuilds(List<V3Build> builds, String master, TravisService travisService) {
         List<BuildDelta> results = []
         for (V3Build build : builds) {
-            boolean addToCache = false
             String branchedRepoSlug = build.branchedRepoSlug()
             def cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug, TravisResultConverter.running(build.state))
-            if (build.number > cachedBuild && !build.spinnakerTriggered()) {
-                addToCache = true
-                log.debug("({}) New build: {}", kv("master", master), build.toString())
+            def genericBuild
+            if (build.state == TravisBuildState.passed) {
+                genericBuild = travisService.getGenericBuild(build) // This also parses the log for artifacts
+            } else {
+                genericBuild = TravisBuildConverter.genericBuild(build, travisService.baseUrl)
             }
-            if (addToCache) {
+            if (build.number > cachedBuild && !build.spinnakerTriggered()) {
                 results.add(new BuildDelta(
                     branchedRepoSlug: branchedRepoSlug,
                     build: build,
+                    genericBuild: genericBuild,
                     travisBaseUrl: travisService.baseUrl,
                     currentBuildNum: build.number,
                     previousBuildNum: cachedBuild
@@ -196,11 +199,11 @@ class TravisBuildMonitor extends CommonPollingMonitor<BuildDelta, BuildPollingDe
         }
     }
 
-    private void sendEventForBuild(V3Build build, String branchedSlug, String master, TravisService travisService) {
+    private void sendEventForBuild(BuildDelta buildDelta, String branchedSlug, String master) {
         if (echoService.isPresent()) {
-            if (!build.spinnakerTriggered()) {
-                log.info("({}) pushing event for :${branchedSlug}:${build.number}", kv("master", master))
-                GenericProject project = new GenericProject(branchedSlug, TravisBuildConverter.genericBuild(build, travisService.baseUrl))
+            if (!buildDelta.build.spinnakerTriggered()) {
+                log.info("({}) pushing event for :${branchedSlug}:${buildDelta.build.number}", kv("master", master))
+                GenericProject project = new GenericProject(branchedSlug, buildDelta.genericBuild)
                 echoService.get().postEvent(
                     new GenericBuildEvent(content: new GenericBuildContent(project: project, master: master, type: 'travis'))
                 )
@@ -260,6 +263,7 @@ class TravisBuildMonitor extends CommonPollingMonitor<BuildDelta, BuildPollingDe
     static class BuildDelta implements DeltaItem {
         String branchedRepoSlug
         V3Build build
+        GenericBuild genericBuild
         String travisBaseUrl
         int currentBuildNum
         int previousBuildNum

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -200,17 +200,17 @@ class TravisBuildMonitor extends CommonPollingMonitor<BuildDelta, BuildPollingDe
     }
 
     private void sendEventForBuild(BuildDelta buildDelta, String branchedSlug, String master) {
-        if (echoService.isPresent()) {
-            if (!buildDelta.build.spinnakerTriggered()) {
+        if (!buildDelta.build.spinnakerTriggered()) {
+            if (echoService.isPresent()) {
                 log.info("({}) pushing event for :${branchedSlug}:${buildDelta.build.number}", kv("master", master))
                 GenericProject project = new GenericProject(branchedSlug, buildDelta.genericBuild)
                 echoService.get().postEvent(
                     new GenericBuildEvent(content: new GenericBuildContent(project: project, master: master, type: 'travis'))
                 )
+            } else {
+                log.warn("Cannot send build event notification: Echo is not configured")
+                registry.counter(missedNotificationId.withTag("monitor", getClass().simpleName)).increment()
             }
-        } else {
-            log.warn("Cannot send build event notification: Echo is not configured")
-            registry.counter(missedNotificationId.withTag("monitor", getClass().simpleName)).increment()
         }
     }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/TravisClient.groovy
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse
 import com.netflix.spinnaker.igor.travis.client.model.v3.Request
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Builds
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Log
 import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.EncodedPath
@@ -92,13 +93,12 @@ interface TravisClient {
     @GET('/logs/{logId}')
     Response log(@Header("Authorization") String accessToken , @Path('logId') int logId)
 
-    @Streaming
     @Headers([
         "Travis-API-Version: 3",
         "Accept: text/plain"
     ])
     @GET('/job/{jobId}/log')
-    Response jobLog(@Header("Authorization") String accessToken , @Path('jobId') int jobId)
+    V3Log jobLog(@Header("Authorization") String accessToken, @Path('jobId') int jobId)
 
     @GET('/build/{build_id}')
     @Headers("Travis-API-Version: 3")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.groovy
@@ -48,8 +48,7 @@ class V3Build {
     TravisBuildState state
     @JsonProperty("finished_at")
     Instant finishedAt
-    @JsonProperty(value = "job_ids")
-    List <Integer> job_ids
+    List<V3Job> jobs
     Config config
 
     long timestamp() {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Job.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Job.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model.v3;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class V3Job {
+  private Integer id;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model.v3;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class V3Log {
+  private Integer id;
+  private String content;
+  @JsonProperty("log_parts")
+  private List<V3LogPart> logParts;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getContent() {
+    if (content != null) {
+      return content;
+    } else if (logParts != null && !logParts.isEmpty()) {
+      return logParts.stream()
+        .map(V3LogPart::getContent)
+        .collect(Collectors.joining());
+    } else {
+      return null;
+    }
+  }
+
+  public void setContent(String content) {
+    this.content = content;
+  }
+
+  public void setLogParts(List<V3LogPart> logParts) {
+    this.logParts = logParts;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class V3LogPart {
+    private String content;
+    private Integer number;
+
+    public String getContent() {
+      return content;
+    }
+
+    public void setContent(String content) {
+      this.content = content;
+    }
+
+    public Integer getNumber() {
+      return number;
+    }
+
+    public void setNumber(Integer number) {
+      this.number = number;
+    }
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -16,8 +16,11 @@
 
 package com.netflix.spinnaker.igor.travis.service
 
+import com.netflix.spinnaker.igor.build.artifact.decorator.DebDetailsDecorator
+import com.netflix.spinnaker.igor.build.artifact.decorator.RpmDetailsDecorator
 import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.Result
+import com.netflix.spinnaker.igor.service.ArtifactDecorator
 import com.netflix.spinnaker.igor.travis.client.TravisClient
 import com.netflix.spinnaker.igor.travis.client.model.AccessToken
 import com.netflix.spinnaker.igor.travis.client.model.Build
@@ -38,9 +41,13 @@ class TravisServiceSpec extends Specification{
     @Shared
     TravisService service
 
+    @Shared
+    ArtifactDecorator artifactDecorator
+
     void setup() {
         client = Mock(TravisClient)
-        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', 25, client, null, [])
+        artifactDecorator = new ArtifactDecorator([new DebDetailsDecorator(), new RpmDetailsDecorator()], null)
+        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', 25, client, null, artifactDecorator, [])
 
         AccessToken accessToken = new AccessToken()
         accessToken.accessToken = "someToken"


### PR DESCRIPTION
This is needed for filtering build events based on artifacts. Depends on an upcoming change in echo.
Kind of a duplicate of #132, but this change will only query Travis for artifacts for completed builds, and only once per event.