### PR TITLE
feat(docker): Redis key migration

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/IgorConfigurationProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/IgorConfigurationProperties.groovy
@@ -64,6 +64,15 @@ class IgorConfigurationProperties {
     static class RedisProperties {
         String connection = "redis://localhost:6379"
         int timeout = 2000
+
+        @Canonical
+        static class DockerV1KeyMigration {
+            int ttlDays = 30
+            int batchSize = 100
+        }
+
+        @NestedConfigurationProperty
+        DockerV1KeyMigration dockerV1KeyMigration = new DockerV1KeyMigration()
     }
 
     @NestedConfigurationProperty

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCache.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCache.java
@@ -24,10 +24,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.String.format;
+
 @Service
 public class DockerRegistryCache {
 
-    private final static String ID = "dockerRegistry";
+    final static String ID = "dockerRegistry";
 
     // docker-digest must conform to hash:hashvalue. The string "~" explicitly avoids this to act as an "empty" placeholder.
     private final static String EMPTY_DIGEST = "~";
@@ -44,12 +46,12 @@ public class DockerRegistryCache {
 
     public List<String> getImages(String account) {
         return redisClientDelegate.withMultiClient(c -> {
-            return new ArrayList<>(c.keys(prefix() + ":" + ID + ":" + account + "*"));
+            return new ArrayList<>(c.keys(makeIndexPattern(prefix(), account)));
         });
     }
 
     public String getLastDigest(String account, String registry, String repository, String tag) {
-        String key = makeKey(account, registry, repository, tag);
+        String key = makeKey(prefix(), account, registry, tag);
         return redisClientDelegate.withCommandsClient(c -> {
             Map<String, String> res = c.hgetAll(key);
             if (res.get("digest").equals(EMPTY_DIGEST)) {
@@ -60,21 +62,19 @@ public class DockerRegistryCache {
     }
 
     public void setLastDigest(String account, String registry, String repository, String tag, String digest) {
-        String key = makeKey(account, registry, repository, tag);
+        String key = makeKey(prefix(), account, registry, tag);
         String d = digest == null ? EMPTY_DIGEST : digest;
         redisClientDelegate.withCommandsClient(c -> {
             c.hset(key, "digest", d);
         });
     }
 
-    public void remove(String imageId) {
-        redisClientDelegate.withCommandsClient(c -> {
-            c.del(imageId);
-        });
+    static String makeIndexPattern(String prefix, String account) {
+        return format("%s:v2:%s:%s:*", prefix, ID, account);
     }
 
-    private String makeKey(String account, String registry, String repository, String tag) {
-        return prefix() + ":" + ID + ":" + account + ":" + registry + ":" + repository + ":" + tag;
+    static String makeKey(String prefix, String account, String registry, String tag) {
+        return format("%s:v2:%s:%s:%s:%s", prefix, ID, account, registry, tag);
     }
 
     private String prefix() {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCache.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCache.java
@@ -51,7 +51,7 @@ public class DockerRegistryCache {
     }
 
     public String getLastDigest(String account, String registry, String repository, String tag) {
-        String key = makeKey(prefix(), account, registry, tag);
+        String key = new DockerRegistryV2Key(prefix(), ID, account, registry, tag).toString();
         return redisClientDelegate.withCommandsClient(c -> {
             Map<String, String> res = c.hgetAll(key);
             if (res.get("digest").equals(EMPTY_DIGEST)) {
@@ -62,7 +62,7 @@ public class DockerRegistryCache {
     }
 
     public void setLastDigest(String account, String registry, String repository, String tag, String digest) {
-        String key = makeKey(prefix(), account, registry, tag);
+        String key = new DockerRegistryV2Key(prefix(), ID, account, registry, tag).toString();
         String d = digest == null ? EMPTY_DIGEST : digest;
         redisClientDelegate.withCommandsClient(c -> {
             c.hset(key, "digest", d);
@@ -70,11 +70,7 @@ public class DockerRegistryCache {
     }
 
     static String makeIndexPattern(String prefix, String account) {
-        return format("%s:v2:%s:%s:*", prefix, ID, account);
-    }
-
-    static String makeKey(String prefix, String account, String registry, String tag) {
-        return format("%s:v2:%s:%s:%s:%s", prefix, ID, account, registry, tag);
+        return format("%s:%s:v2:%s:*", prefix, ID, account);
     }
 
     private String prefix() {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigration.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigration.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor.docker;
+
+import com.google.common.collect.Iterables;
+import com.netflix.dyno.connectionpool.CursorBasedResult;
+import com.netflix.dyno.jedis.DynoJedisClient;
+import com.netflix.spinnaker.igor.IgorConfigurationProperties;
+import com.netflix.spinnaker.kork.dynomite.DynomiteClientDelegate;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.MultiKeyCommands;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+
+import javax.annotation.PostConstruct;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+/**
+ * Migrates docker registry cache keys from v1 to v2. This migrator is backwards-incompatible as the key format
+ * is destructive (data is being removed from the key). When this migrator is run, the old keys will be copied
+ * to the new key format, and the old keys TTL'ed.
+ */
+@Component
+@ConditionalOnProperty(value = "redis.dockerV1KeyMigration.enabled", matchIfMissing = true)
+public class DockerRegistryCacheV2KeysMigration {
+
+    private final static Logger log = LoggerFactory.getLogger(DockerRegistryCacheV2KeysMigration.class);
+
+    private final RedisClientDelegate redis;
+    private final IgorConfigurationProperties properties;
+    private final Scheduler scheduler;
+
+    private final AtomicBoolean running = new AtomicBoolean();
+
+    @Autowired
+    public DockerRegistryCacheV2KeysMigration(RedisClientDelegate redis,
+                                              IgorConfigurationProperties properties) {
+        this(redis, properties, Schedulers.io());
+    }
+
+    public DockerRegistryCacheV2KeysMigration(RedisClientDelegate redis,
+                                              IgorConfigurationProperties properties,
+                                              Scheduler scheduler) {
+        this.redis = redis;
+        this.properties = properties;
+        this.scheduler = scheduler;
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    @PostConstruct
+    void run() {
+        running.set(true);
+        try {
+            scheduler.createWorker().schedule(this::migrate);
+        } finally {
+            running.set(false);
+        }
+    }
+
+    private void migrate() {
+        log.info("Starting migration");
+
+        List<String> oldKeys = redis.withMultiClient(this::getV1Keys);
+        log.info("Migrating {} v1 keys", oldKeys.size());
+
+        int batchSize = properties.getRedis().getDockerV1KeyMigration().getBatchSize();
+        for (List<String> oldKeyBatch : Iterables.partition(oldKeys, batchSize)) {
+            // For each key: Check if old exists, if so, copy to new key, set ttl on old key, remove ttl on new key
+            migrateBatch(oldKeyBatch);
+        }
+    }
+
+    private void migrateBatch(List<String> oldKeys) {
+        int expireSeconds = (int) Duration.ofDays(properties.getRedis().getDockerV1KeyMigration().getTtlDays()).getSeconds();
+        redis.withCommandsClient(c -> {
+            for (String oldKey : oldKeys) {
+                String newKey = convertToNewFormat(oldKey);
+                if (c.exists(newKey)) {
+                    // Nothing to do here, just move on with life
+                    continue;
+                }
+
+                Map<String, String> value = c.hgetAll(oldKey);
+                c.hmset(newKey, value);
+                c.expire(oldKey, expireSeconds);
+            }
+        });
+    }
+
+    private List<String> getV1Keys(MultiKeyCommands client) {
+        // TODO rz - dyno does not yet support `scan` interface; exposed as `dyno_scan`
+        if (redis instanceof DynomiteClientDelegate) {
+            return keys((DynoJedisClient) client);
+        }
+        return keys((Jedis) client);
+    }
+
+    private List<String> keys(DynoJedisClient dyno) {
+        List<String> keys = new ArrayList<>();
+
+        String pattern = oldIndexPattern();
+        CursorBasedResult<String> result;
+        do {
+            result = dyno.dyno_scan(pattern);
+            keys.addAll(result.getResult().stream().filter(this::isOldKey).collect(Collectors.toList()));
+        } while (!result.isComplete());
+
+        return keys;
+    }
+
+    private List<String> keys(Jedis jedis) {
+        List<String> keys = new ArrayList<>();
+
+        ScanParams params = new ScanParams().match(oldIndexPattern()).count(1000);
+        String cursor = ScanParams.SCAN_POINTER_START;
+
+        ScanResult<String> result;
+        do {
+            result = jedis.scan(cursor, params);
+            keys.addAll(result.getResult().stream().filter(this::isOldKey).collect(Collectors.toList()));
+        } while (!result.getStringCursor().equals("0"));
+
+        return keys;
+    }
+
+    private boolean isOldKey(String key) {
+        // Target v1 keys. They include repository URLs, which can include ports, so eq/gt 6 parts.
+        return key.split(":").length >= 6;
+    }
+
+    private String convertToNewFormat(String oldKey) {
+        String[] tagParts = oldKey.split("/");
+        String[] parts = tagParts[0].split(":");
+
+        String account = parts[0];
+        String registry = parts[1];
+        String tag = tagParts[1];
+
+        return DockerRegistryCache.makeKey(prefix(), account, registry, tag);
+    }
+
+    private String oldIndexPattern() {
+        return format("%s:%s:*", prefix(), DockerRegistryCache.ID);
+    }
+
+    private String prefix() {
+        return properties.getSpinnaker().getJedis().getPrefix();
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFactory.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFactory.java
@@ -1,0 +1,80 @@
+package com.netflix.spinnaker.igor.docker;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.VerifyException;
+import com.netflix.spinnaker.igor.IgorConfigurationProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static com.google.common.base.Verify.verify;
+
+import java.util.List;
+
+@Service
+public class DockerRegistryKeyFactory {
+    private final static String ID = "dockerRegistry";
+    private final static Splitter SPLITTER = Splitter.on(':');
+
+    private final IgorConfigurationProperties igorConfigurationProperties;
+
+    @Autowired
+    public DockerRegistryKeyFactory(IgorConfigurationProperties igorConfigurationProperties) {
+        this.igorConfigurationProperties = igorConfigurationProperties;
+    }
+
+    DockerRegistryV1Key parseV1Key(String keyStr) throws DockerRegistryKeyFormatException {
+        return parseV1Key(keyStr, true);
+    }
+
+
+    DockerRegistryV1Key parseV1Key(String keyStr, boolean includeRepository) throws DockerRegistryKeyFormatException {
+        List<String> splits = SPLITTER.splitToList(keyStr);
+        try {
+            String prefix = splits.get(0);
+            verify(prefix.equals(prefix()), "Expected prefix '%s', found '%s'", prefix(), prefix);
+
+            String id = splits.get(1);
+            verify(ID.equals(id), "Expected ID '%s', found '%s'", ID, id);
+
+            String account = splits.get(2);
+            verify(!account.isEmpty(), "Empty account string");
+
+            String registry = splits.get(3);
+            verify(!registry.isEmpty(), "Empty registry string");
+
+            // the repository URL (typically without "http://"
+            // it may contain ':' (e.g. port number), so it may be split across multiple tokens
+            String repository = null;
+            if (includeRepository) {
+                List<String> repoSplits = splits.subList(4, splits.size() - 1);
+                repository = String.join(":", repoSplits);
+            }
+
+            String tag = splits.get(splits.size() - 1);
+            verify(!tag.isEmpty(), "Empty registry string");
+
+            return new DockerRegistryV1Key(prefix, id, account, registry, repository, tag);
+        } catch(IndexOutOfBoundsException | VerifyException e) {
+            throw new DockerRegistryKeyFormatException(String.format("Could not parse '%s' as a v1 key", keyStr), e);
+        }
+
+    }
+
+    DockerRegistryV1Key parseV2Key(String keyStr) throws DockerRegistryKeyFormatException {
+        throw new UnsupportedOperationException("parseV2Key not implemented yet");
+    }
+
+    DockerRegistryV2Key convert(DockerRegistryV1Key oldKey) {
+        return new DockerRegistryV2Key(
+            oldKey.getPrefix(),
+            oldKey.getId(),
+            oldKey.getAccount(),
+            oldKey.getRegistry(),
+            oldKey.getTag()
+        );
+    }
+
+    private String prefix() {
+        return igorConfigurationProperties.getSpinnaker().getJedis().getPrefix();
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFactory.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.spinnaker.igor.docker;
 
 import com.google.common.base.Splitter;
@@ -6,9 +21,9 @@ import com.netflix.spinnaker.igor.IgorConfigurationProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import static com.google.common.base.Verify.verify;
-
 import java.util.List;
+
+import static com.google.common.base.Verify.verify;
 
 @Service
 public class DockerRegistryKeyFactory {
@@ -25,7 +40,6 @@ public class DockerRegistryKeyFactory {
     DockerRegistryV1Key parseV1Key(String keyStr) throws DockerRegistryKeyFormatException {
         return parseV1Key(keyStr, true);
     }
-
 
     DockerRegistryV1Key parseV1Key(String keyStr, boolean includeRepository) throws DockerRegistryKeyFormatException {
         List<String> splits = SPLITTER.splitToList(keyStr);

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFormatException.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFormatException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.spinnaker.igor.docker;
 
 public class DockerRegistryKeyFormatException extends Throwable {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFormatException.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFormatException.java
@@ -1,0 +1,11 @@
+package com.netflix.spinnaker.igor.docker;
+
+public class DockerRegistryKeyFormatException extends Throwable {
+    public DockerRegistryKeyFormatException(String message) {
+        super(message);
+    }
+
+    public DockerRegistryKeyFormatException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV1Key.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV1Key.java
@@ -1,0 +1,62 @@
+package com.netflix.spinnaker.igor.docker;
+
+import javax.annotation.Nullable;
+
+public class DockerRegistryV1Key {
+    private final String prefix;
+    private final String id;
+    private final String account;
+    private final String registry;
+
+    @Nullable
+    private final String repository;
+    private final String tag;
+
+    public DockerRegistryV1Key(String prefix, String id, String account, String registry, String repository, String tag) {
+        this.prefix = prefix;
+        this.id = id;
+        this.account = account;
+        this.registry = registry;
+        this.repository = repository;
+        this.tag = tag;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+
+    public String getRegistry() {
+        return registry;
+    }
+
+    @Nullable
+    public String getRepository() {
+        return repository;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public String toString() {
+        return String.format("%s:%s:%s:%s:%s:%s", prefix, id, account, registry, repository, tag);
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof DockerRegistryV1Key && toString().equals(obj.toString());
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV1Key.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV1Key.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.spinnaker.igor.docker;
 
 import javax.annotation.Nullable;

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV2Key.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV2Key.java
@@ -1,0 +1,56 @@
+package com.netflix.spinnaker.igor.docker;
+
+public class DockerRegistryV2Key {
+    private static final String VERSION = "v2";
+    private final String prefix;
+    private final String id;
+    private final String account;
+    private final String registry;
+    private final String tag;
+
+    public DockerRegistryV2Key(String prefix, String id, String account, String registry, String tag) {
+        this.prefix = prefix;
+        this.id = id;
+        this.account = account;
+        this.registry = registry;
+        this.tag = tag;
+    }
+
+    public static String getVersion() {
+        return VERSION;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+
+    public String getRegistry() {
+        return registry;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public String toString() {
+        return String.format("%s:v2:%s:%s:%s:%s", prefix, id, account, registry, tag);
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof DockerRegistryV2Key && toString().equals(obj.toString());
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV2Key.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV2Key.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.spinnaker.igor.docker;
 
 public class DockerRegistryV2Key {
@@ -41,7 +56,7 @@ public class DockerRegistryV2Key {
     }
 
     public String toString() {
-        return String.format("%s:v2:%s:%s:%s:%s", prefix, id, account, registry, tag);
+        return String.format("%s:%s:v2:%s:%s:%s", prefix, id, account, registry, tag);
     }
 
     @Override

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -45,7 +45,7 @@ class DockerMonitorSpec extends Specification {
     @Unroll
     void 'should only publish events if account has been indexed previously'() {
         when:
-        new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService))
+        new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.empty())
             .postEvent(cachedImages, taggedImage, "imageId")
 
         then:
@@ -59,7 +59,7 @@ class DockerMonitorSpec extends Specification {
         })
 
         when: "should short circuit if `echoService` is not available"
-        new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.empty())
+        new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.empty(), Optional.empty())
             .postEvent(["imageId"], taggedImage, "imageId")
 
         then:
@@ -75,7 +75,7 @@ class DockerMonitorSpec extends Specification {
 
     void 'should include decorated artifact in the payload'() {
         when:
-        new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService))
+        new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.empty())
             .postEvent(["job1"], taggedImage, "imageId")
 
         then:

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigrationSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigrationSpec.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor.docker
+
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+import rx.schedulers.Schedulers
+import spock.lang.Specification
+import spock.lang.Subject
+
+class DockerRegistryCacheV2KeysMigrationSpec extends Specification {
+
+    EmbeddedRedis embeddedRedis
+    Jedis jedis
+    RedisClientDelegate redisClientDelegate
+    IgorConfigurationProperties igorConfigurationProperties = new IgorConfigurationProperties()
+    DockerRegistryKeyFactory keyFactory = new DockerRegistryKeyFactory(igorConfigurationProperties)
+
+    @Subject
+    DockerRegistryCacheV2KeysMigration subject
+
+    def setup() {
+        embeddedRedis = EmbeddedRedis.embed()
+        jedis = embeddedRedis.jedis
+        redisClientDelegate = new JedisClientDelegate(embeddedRedis.pool as JedisPool)
+        subject = new DockerRegistryCacheV2KeysMigration(
+            redisClientDelegate,
+            keyFactory, igorConfigurationProperties, Schedulers.immediate())
+    }
+
+    def tearDown() {
+        jedis.close()
+        embeddedRedis.destroy()
+    }
+
+    def "migrates all v1 keys to v2 format"() {
+        given:
+        def v1Keys = [
+            new DockerRegistryV1Key("igor", "dockerRegistry", "acct", "registry", "netflix.com", "tag"),
+            new DockerRegistryV1Key("igor", "dockerRegistry", "acct", "registry", "http://netflix.com", "tag"),
+            new DockerRegistryV1Key("igor", "dockerRegistry", "acct", "registry", "netflix.com:1111", "tag"),
+        ]
+        def v2Keys = [
+            new DockerRegistryV2Key("igor", "dockerRegistry", "acct", "registry", "tag"),
+            new DockerRegistryV2Key("igor", "dockerRegistry", "acct", "registry", "tag")
+        ]
+        def invalidKeys = [
+            new DockerRegistryV2Key("igor", "totalInvalid", "acct", "registry", "tag")
+
+        ]
+        def allKeys = [v1Keys, v2Keys, invalidKeys].flatten()
+        allKeys.each { jedis.hmset(it.toString(), [foo: "bar"]) }
+
+        expect:
+        jedis.keys("igor:*").size() == 5
+        jedis.keys("igor:*:v2:*").size() == v2Keys.size()
+
+        when:
+        subject.run()
+
+        then:
+        noExceptionThrown()
+        [v1Keys.collect { keyFactory.convert(it) }, v2Keys].flatten().unique().each {
+            assert jedis.exists(it.toString()), "${it} was not created"
+            assert jedis.hgetAll(it.toString()) == [foo: "bar"], "${it} did not get correct contents"
+        }
+        [v1Keys.each {
+            assert jedis.ttl(it.toString()) != null, "${it} did not get an expiration"
+        }]
+    }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFactorySpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryKeyFactorySpec.groovy
@@ -1,0 +1,64 @@
+package com.netflix.spinnaker.igor.docker
+
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DockerRegistryKeyFactorySpec extends Specification {
+    @Shared
+    def properties = new IgorConfigurationProperties()
+
+    @Shared
+    def keyFactory = new DockerRegistryKeyFactory(properties)
+
+    void 'encoding and decoding should be transparent'() {
+        def prefix = properties.getSpinnaker().getJedis().getPrefix()
+
+        when:
+        def originalKey = new DockerRegistryV1Key(prefix, DockerRegistryKeyFactory.ID, "account", "registry", "repository", "tag")
+        def decodedKey = keyFactory.parseV1Key(originalKey.toString())
+
+        then:
+        decodedKey == originalKey
+    }
+
+    @Unroll
+    void 'repository url #repository can be reconstituted'() {
+        def prefix = properties.getSpinnaker().getJedis().getPrefix()
+
+        when:
+        def originalKey = new DockerRegistryV1Key(prefix, DockerRegistryKeyFactory.ID, "account", "registry", repository, "tag")
+        def decodedKey = keyFactory.parseV1Key(originalKey.toString())
+
+        then:
+        decodedKey.getRepository() == repository
+
+        where:
+        repository << [
+            "registry.main.us-east-1.prod.example.net",
+            "registry.main.us-east-1.prod.example.net:7002",
+            "https://registry.main.us-east-1.prod.example.net:7002"
+        ]
+    }
+
+    @Unroll
+    void 'should be able to convert from v1 to v2 with includeRepository=#includeRepository'() {
+        def prefix = properties.getSpinnaker().getJedis().getPrefix()
+        def v1KeyStr = new DockerRegistryV1Key(prefix, DockerRegistryKeyFactory.ID, "account", "registry", "repository", "tag").toString()
+
+        when: // simulate having to parse an existing key string
+        def v1Key = keyFactory.parseV1Key(v1KeyStr, includeRepository)
+        def v2Key = keyFactory.convert(v1Key)
+
+        then:
+        v1Key.getPrefix() == v2Key.getPrefix()
+        v1Key.getId() == v2Key.getId()
+        v1Key.getAccount() == v2Key.getAccount()
+        v1Key.getRegistry() == v2Key.getRegistry()
+        v1Key.getTag() == v2Key.getTag()
+
+        where:
+        includeRepository << [true, false]
+    }
+}


### PR DESCRIPTION
Updates redis key format from v1 to v2 for docker registry cache, which removes the docker repository url from the key.