### PR TITLE
POC: vanilla gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,56 +14,33 @@
  * limitations under the License.
  */
 
-buildscript {
-    ext {
-        springBootVersion = "1.5.7.RELEASE"
-    }
+allprojects {
+    apply plugin: 'base'
+    group = "com.netflix.spinnaker.igor"
     repositories {
-        jcenter()
-        maven { url "http://spinnaker.bintray.com/gradle" }
-        maven { url "https://plugins.gradle.org/m2/" }
-    }
-    dependencies {
-        classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:3.17.0'
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
+        jcenter() {
+          metadataSources { mavenPom() }
+        }
     }
 }
 
-allprojects {
-    apply plugin: 'spinnaker.project'
+subprojects {
     apply plugin: 'groovy'
-
-    ext {
-        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.129.0'
-    }
-
-    def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]
-    if (ext.has('versions')) {
-        def extVers = ext.get('versions')
-        if (extVers instanceof Map) {
-            checkLocalVersions.putAll(extVers)
-        }
-    }
-
-    def localVersions = checkLocalVersions.findAll { it.value.endsWith('-SNAPSHOT') }
-    if (localVersions) {
-        logger.info("Enabling mavenLocal repo for $localVersions")
-        repositories {
-            mavenLocal()
-        }
-    }
-
-    spinnaker {
-        dependenciesVersion = spinnakerDependenciesVersion
-    }
-
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+    apply plugin: 'maven-publish'
     test {
       testLogging {
         exceptionFormat = 'full'
       }
     }
-
-    group = "com.netflix.spinnaker.igor"
+    publishing {
+      publications {
+        mavenJava(MavenPublication) {
+          from components.java
+        }
+      }
+    }
 }
 
 defaultTasks 'bootRun'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -1,51 +1,109 @@
+
 ext {
   springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
-  repackage = System.getProperty('springBoot.repackage', "false")
+  versions = [
+    cglib: '3.2.0',
+    kork: '1.124.0',
+    eureka: '1.8.6',
+    groovy: '2.4.13',
+    hamcrest: '1.3',
+    jackson: '2.9.2',
+    junit: '4.12',
+    logstash: '4.11',
+    objenesis: '2.5.1',
+    okHttp: '2.7.0',
+    retrofit: '1.9.0',
+    rxJava: '1.0.16',
+    snakeyaml: '1.15',
+    spock: '1.1-groovy-2.4',
+    spring: '4.3.14.RELEASE',
+    springBoot: '1.5.10.RELEASE',
+  ]
 }
 
-tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
+apply plugin: 'groovy'
+apply plugin: 'application'
+
+applicationName = 'igor'
+mainClassName = 'com.netflix.spinnaker.igor.Main'
+applicationDefaultJvmArgs << '-Djava.security.egd=file:/dev/./urandom'
+
+run {
   systemProperty('spring.config.location', project.springConfigLocation)
 }
 
-apply plugin: 'org.springframework.boot'
-apply plugin: 'spinnaker.package'
+task bootRun(dependsOn: 'run')
+
+sourceSets {
+    main {
+        resources {
+            srcDir 'config'
+        }
+    }
+}
+
+jar {
+    exclude 'igor.yml'
+}
+
+distributions {
+    main {
+        contents {
+            from('config') { into 'config' }
+        }
+    }
+}
+
+startScripts {
+    defaultJvmOpts = applicationDefaultJvmArgs + ["-Dspring.config.location=/opt/spinnaker/config/"]
+    doLast {
+        unixScript.text = unixScript.text.replace('DEFAULT_JVM_OPTS=', '''\
+                    if [ -f /etc/default/spinnaker ]; then
+                      set -a
+                      . /etc/default/spinnaker
+                      set +a
+                    fi
+                    DEFAULT_JVM_OPTS='''.stripIndent())
+        unixScript.text = unixScript.text.replace('CLASSPATH=$APP_HOME', 'CLASSPATH=$APP_HOME/config:$APP_HOME')
+        windowsScript.text = windowsScript.text.replace('set CLASSPATH=', 'set CLASSPATH=%APP_HOME%\\config;')
+    }
+}
 
 dependencies {
-    spinnaker.group "test"
-    spinnaker.group "bootWeb"
-    spinnaker.group "jackson"
-    spinnaker.group "retrofitDefault"
+    compile "org.springframework.boot:spring-boot-starter-actuator:${versions.springBoot}"
+    compile "org.springframework.boot:spring-boot-starter-data-rest:${versions.springBoot}"
+    compile "org.springframework.boot:spring-boot-starter-web:${versions.springBoot}"
+    compile "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+    compile "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    compile "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
+    compile "com.squareup.okhttp:okhttp:${versions.okHttp}"
+    compile "com.squareup.okhttp:okhttp-urlconnection:${versions.okHttp}"
+    compile "com.squareup.okhttp:okhttp-apache:${versions.okHttp}"
+    compile "com.squareup.retrofit:retrofit:${versions.retrofit}"
+    compile "com.squareup.retrofit:converter-jackson:${versions.retrofit}"
+    compile "com.netflix.spinnaker.kork:kork-core:${versions.kork}"
+    compile "com.netflix.spinnaker.kork:kork-dynomite:${versions.kork}"
+    compile "com.netflix.spinnaker.kork:kork-jedis:${versions.kork}"
+    compile "com.netflix.spinnaker.kork:kork-stackdriver:${versions.kork}"
+    compile "com.netflix.spinnaker.kork:kork-hystrix:${versions.kork}"
+    compile "com.netflix.spinnaker.kork:kork-web:${versions.kork}"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
+    compile "org.codehaus.groovy:groovy-all:${versions.groovy}"
+    compile "io.reactivex:rxjava:${versions.rxJava}"
+    compile "com.netflix.eureka:eureka-client:${versions.eureka}"
+    compile "net.logstash.logback:logstash-logback-encoder:${versions.logstash}"
+    compile "org.yaml:snakeyaml:${versions.snakeyaml}"
+    compile "com.squareup.retrofit:converter-simplexml:${versions.retrofit}"
 
-    compile spinnaker.dependency("kork")
-    compile spinnaker.dependency("korkStackdriver")
-    compile spinnaker.dependency("korkWeb")
-    compile spinnaker.dependency("korkJedis")
-    compile spinnaker.dependency("korkDynomite")
-    compile spinnaker.dependency("jacksonJsr310")
-    compile spinnaker.dependency("groovy")
-    compile spinnaker.dependency("rxJava")
-    compile spinnaker.dependency("retrofit")
-    compile spinnaker.dependency("eurekaClient")
-    compile spinnaker.dependency("korkHystrix")
-    compile spinnaker.dependency("okHttp")
-    compile spinnaker.dependency('logstashEncoder')
-
-    compile 'org.yaml:snakeyaml:1.15'
-    compile 'com.squareup.retrofit:converter-simplexml:1.9.0'
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.0'
-
-    testCompile spinnaker.dependency("korkJedisTest")
+    testCompile "org.springframework.boot:spring-boot-starter-test:${versions.springBoot}"
+    testCompile "org.spockframework:spock-core:${versions.spock}"
+    testCompile "org.spockframework:spock-spring:${versions.spock}"
+    testCompile "org.springframework:spring-test:${versions.spring}"
+    testCompile "cglib:cglib-nodep:${versions.cglib}"
+    testCompile "org.objenesis:objenesis:${versions.objenesis}"
+    testCompile "junit:junit:${versions.junit}"
+    testCompile "org.hamcrest:hamcrest-core:${versions.hamcrest}"
+    testCompile "com.squareup.retrofit:retrofit-mock:${versions.retrofit}"
+    testCompile "com.squareup.okhttp:mockwebserver:${versions.okHttp}"
+    testCompile "com.netflix.spinnaker.kork:kork-jedis-test:${versions.kork}"
 }
-
-configurations.all {
-    resolutionStrategy {
-        force 'org.apache.log4j:log4j:1.2.17'
-        force 'commons-codec:commons-codec:1.7'
-    }
-    exclude group: 'javax.servlet', module: 'servlet-api'
-    exclude group: "org.slf4j", module: "slf4j-log4j12"
-    exclude group: "org.mortbay.jetty", module: "servlet-api"
-}
-
-
-tasks.bootRepackage.enabled = Boolean.valueOf(project.repackage)


### PR DESCRIPTION
just a proof of concept of stripping out some of the extensions we use on gradle and moving to a vanilla buildscript.

This could subsequently be extended by an external .gradle file included via gradle CLI (-I somefile.gradle) to add customized publishing.

This currently has no external buildscript dependencies (no non-core gradle plugins) but I'd expect we would still bring in the ospackage plugin to produce debs/rpms.

I also think once we are happy with the experience there is value in extracting the conventions back out into a simpler spinnaker gradle plugin instead of copy and pasting them in every project.

This build has no opinion on versioning (can be provided via -Pversion=whatever) or publishing (it does have the maven plugin so you can do an `install` to publish to maven local)

Also fwiw it doesn't bring in the spring-boot plugin (that conflates both the bootRun bit which is unnecessary given the application run task, and some dependency management stuff which is maybe a bit too much magic for what it provides)

