### PR TITLE
fix(bitbucket): Fix NPE caused by non-network retrofit errors

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitController.groovy
@@ -67,11 +67,12 @@ class CommitController extends AbstractCommitController {
         commitsResponse.values = commitsResponse.values.subList(0, fromIndex + 1)
       }
     } catch (RetrofitError e) {
-      if(e.getKind() == RetrofitError.Kind.NETWORK) {
+      if (e.getKind() == RetrofitError.Kind.NETWORK) {
         throw new RuntimeException("Could not find the server ${bitBucketMaster.baseUrl}")
-      } else if(e.response.status == 404) {
+      } else if (e.response.status == 404) {
         return getNotFoundCommitsResponse(projectKey, repositorySlug, requestParams.to, requestParams.from, bitBucketMaster.baseUrl)
       }
+      throw new RuntimeException("Unhandled bitbucket error for ${bitBucketMaster.baseUrl}", e)
     }
 
     commitsResponse.values.each {


### PR DESCRIPTION
Throwing a `RuntimeException` will cause the service to behave as it does today, but we'll avoid an NPE on L78.