### PR TITLE
chore(docker): Removing totally unreasonable log statement

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigration.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigration.java
@@ -146,7 +146,6 @@ public class DockerRegistryCacheV2KeysMigration {
 
             int size = keys.size();
 
-            log.info("Migrating {} v1 keys", size);
             migrateBatch(v1Keys);
 
             return size;


### PR DESCRIPTION
This is a nice log message, except that it's like the worst log message.