### PR TITLE
fix(travis): Fix a regression that cause getBuilds() to be very slow

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -111,7 +111,7 @@ class TravisBuildMonitor extends CommonPollingMonitor<BuildDelta, BuildPollingDe
             V3Build build = item.build
             log.info("({}) Build update {} [running:{}]", kv("master", master), build.toString(), TravisResultConverter.running(build.state))
             if (build.state == TravisBuildState.passed) {
-                item.genericBuild = travisService.getGenericBuild(build) // This also parses the log for artifacts
+                item.genericBuild = travisService.getGenericBuild(build, true) // This also parses the log for artifacts
             }
             if (build.number > buildCache.getLastBuild(master, build.repository.slug, TravisResultConverter.running(build.state))) {
                 buildCache.setLastBuild(master, build.repository.slug, build.number, TravisResultConverter.running(build.state), buildCacheJobTTLSeconds())

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/service/TravisService.groovy
@@ -289,15 +289,19 @@ class TravisService implements BuildService {
         return travisClient.repoWrapper(getAccessToken(), repoSlug).repo
     }
 
-    GenericBuild getGenericBuild(Build build, String repoSlug) {
+    GenericBuild getGenericBuild(Build build, String repoSlug, boolean fetchLogs = false) {
         GenericBuild genericBuild = TravisBuildConverter.genericBuild(build, repoSlug, baseUrl)
-        parseAndDecorateArtifacts(getLog(build), genericBuild)
+        if (fetchLogs) {
+            parseAndDecorateArtifacts(getLog(build), genericBuild)
+        }
         return genericBuild
     }
 
-    GenericBuild getGenericBuild(V3Build build) {
+    GenericBuild getGenericBuild(V3Build build, boolean fetchLogs = false) {
         GenericBuild genericBuild = TravisBuildConverter.genericBuild(build, baseUrl)
-        parseAndDecorateArtifacts(getLog(build), genericBuild)
+        if (fetchLogs) {
+            parseAndDecorateArtifacts(getLog(build), genericBuild)
+        }
         return genericBuild
     }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -78,7 +78,7 @@ class TravisBuildMonitorSpec extends Specification {
         build.repository >> repository
         repository.slug >> 'test-org/test-repo'
 
-        1 * travisService.getGenericBuild(build) >> TravisBuildConverter.genericBuild(build, MASTER)
+        1 * travisService.getGenericBuild(build, true) >> TravisBuildConverter.genericBuild(build, MASTER)
         1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/master', false) >> 3
         1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo', false) >> 5
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/master', 4, false, CACHED_JOB_TTL_SECONDS)
@@ -118,7 +118,7 @@ class TravisBuildMonitorSpec extends Specification {
         build.repository >> repository
         repository.slug >> 'test-org/test-repo'
 
-        1 * travisService.getGenericBuild(build) >> TravisBuildConverter.genericBuild(build, MASTER)
+        1 * travisService.getGenericBuild(build, true) >> TravisBuildConverter.genericBuild(build, MASTER)
         1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/master', false) >> 3
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/master', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
@@ -153,7 +153,7 @@ class TravisBuildMonitorSpec extends Specification {
         build.repository >> repository
         repository.slug >> 'test-org/test-repo'
 
-        1 * travisService.getGenericBuild(build) >> TravisBuildConverter.genericBuild(build, MASTER)
+        1 * travisService.getGenericBuild(build, true) >> TravisBuildConverter.genericBuild(build, MASTER)
         1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/my_branch', false) >> 3
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/my_branch', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
@@ -226,8 +226,8 @@ class TravisBuildMonitorSpec extends Specification {
         buildDifferentBranch.getState() >> TravisBuildState.passed
         buildDifferentBranch.repository >> repository
         repository.slug >> 'test-org/test-repo'
-        1 * travisService.getGenericBuild(build) >> TravisBuildConverter.genericBuild(build, MASTER)
-        1 * travisService.getGenericBuild(buildDifferentBranch) >> TravisBuildConverter.genericBuild(buildDifferentBranch, MASTER)
+        1 * travisService.getGenericBuild(build, true) >> TravisBuildConverter.genericBuild(build, MASTER)
+        1 * travisService.getGenericBuild(buildDifferentBranch, true) >> TravisBuildConverter.genericBuild(buildDifferentBranch, MASTER)
         1 * buildCache.getLastBuild(MASTER, 'test-org/test-repo/my_branch', false) >> 2
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/my_branch', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)


### PR DESCRIPTION
The code was always _supposed_ to fetch logs in this code path. However, due to a bug in the JSON to Groovy deserialization, the field containing job id's was always null. Due to groovy's nature, this just caused Igor to not fetch any logs, instead of failing.
I fixed the issue (in #223), but then realized that the log fetching made the code way slower in places where we didn't really need artifacts. So I've disabled logs/artifacts fetching from everywhere but the TravisBuildMonitor.