### PR TITLE
fix(polling): Fast-forward flag correctly influencing send events

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/PollContext.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/PollContext.java
@@ -28,7 +28,7 @@ public class PollContext {
     }
 
     public PollContext(String partitionName, Map<String, Object> context) {
-        this(partitionName, context, true);
+        this(partitionName, context, false);
     }
 
     public PollContext(String partitionName, boolean fastForward) {
@@ -42,6 +42,6 @@ public class PollContext {
     }
 
     public PollContext fastForward() {
-        return new PollContext(partitionName, context, false);
+        return new PollContext(partitionName, context, true);
     }
 }


### PR DESCRIPTION
The fastforward flag was being set incorrectly, and thresholds were not influencing changing its value.