### PR TITLE
fix(polling): Fix igor startup with no active ci accounts

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/admin/AdminController.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/admin/AdminController.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.igor.admin;
 import com.netflix.spinnaker.igor.polling.CommonPollingMonitor;
 import com.netflix.spinnaker.igor.polling.PollingMonitor;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import java.util.ArrayList;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,8 +40,8 @@ public class AdminController {
     private final List<CommonPollingMonitor> pollingMonitors;
 
     @Autowired
-    public AdminController(List<CommonPollingMonitor> pollingMonitors) {
-        this.pollingMonitors = pollingMonitors;
+    public AdminController(Optional<List<CommonPollingMonitor>> pollingMonitors) {
+        this.pollingMonitors = pollingMonitors.orElseGet(ArrayList::new);
     }
 
     /**

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/admin/AdminControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/admin/AdminControllerSpec.groovy
@@ -25,7 +25,7 @@ class AdminControllerSpec extends Specification {
     def "should fully reindex a poller"() {
         given:
         def monitor = Mock(CommonPollingMonitor)
-        def subject = new AdminController([monitor])
+        def subject = new AdminController(Optional.of([monitor]))
 
         when:
         subject.fastForward("foo", null)
@@ -39,7 +39,7 @@ class AdminControllerSpec extends Specification {
     def "should reindex a partition in a poller"() {
         given:
         def monitor = Mock(CommonPollingMonitor)
-        def subject = new AdminController([monitor])
+        def subject = new AdminController(Optional.of([monitor]))
 
         and:
         def silencedContext = new PollContext("covfefe").fastForward()
@@ -61,7 +61,7 @@ class AdminControllerSpec extends Specification {
     def "should throw not found if poller isn't found"() {
         given:
         def monitor = Mock(CommonPollingMonitor)
-        def subject = new AdminController([monitor])
+        def subject = new AdminController(Optional.of([monitor]))
 
         when:
         subject.fastForward("baz", null)
@@ -69,6 +69,18 @@ class AdminControllerSpec extends Specification {
         then:
         thrown(NotFoundException)
         2 * monitor.getName() >> "foo"
+        0 * _
+    }
+
+    def "should handle no active pollers"() {
+        given:
+        def subject = new AdminController(Optional.empty())
+
+        when:
+        subject.fastForward("baz", null)
+
+        then:
+        thrown(NotFoundException)
         0 * _
     }
 }


### PR DESCRIPTION
Currently igor fails on startup when there are no active CI accounts,
due to a spring dependency error.