### PR TITLE
feat(jenkins): extension point for http request interceptor

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
@@ -37,10 +37,8 @@ class JenkinsProperties {
         @NotEmpty
         String address
 
-        @NotEmpty
         String username
 
-        @NotEmpty
         String password
 
         Boolean csrf = false

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/client/DefaultJenkinsRetrofitRequestInterceptorProvider.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/client/DefaultJenkinsRetrofitRequestInterceptorProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor.config.client;
+
+import com.netflix.spinnaker.igor.config.JenkinsProperties;
+import com.netflix.spinnaker.igor.config.auth.AuthRequestInterceptor;
+import retrofit.RequestInterceptor;
+
+public class DefaultJenkinsRetrofitRequestInterceptorProvider implements JenkinsRetrofitRequestInterceptorProvider {
+    @Override
+    public RequestInterceptor provide(JenkinsProperties.JenkinsHost host) {
+        return new AuthRequestInterceptor(host);
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/client/JenkinsRetrofitRequestInterceptorProvider.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/client/JenkinsRetrofitRequestInterceptorProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor.config.client;
+
+import com.netflix.spinnaker.igor.config.JenkinsProperties;
+import retrofit.RequestInterceptor;
+
+/**
+ * Abstracts away the logic for providing a Retrofit RequestInterceptor for Jenkins services.
+ */
+public interface JenkinsRetrofitRequestInterceptorProvider {
+
+    RequestInterceptor provide(JenkinsProperties.JenkinsHost host);
+}


### PR DESCRIPTION
Allows customization of the Jenkins request interceptor for http calls.
Makes username/password non manditory on jenkins host configuration.

Example use case would be x509 authentication in Jenkins where the identity
is extracted from the client certificate instead of an HTTP request header.
