### PR TITLE
fix(polling): Regression causes send event logic to be inverted

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
@@ -81,7 +81,7 @@ public class GitlabCiBuildMonitor extends CommonPollingMonitor<GitlabCiBuildMoni
     @Override
     public void poll(boolean sendEvents) {
         buildMasters.filteredMap(BuildServiceProvider.GITLAB_CI).keySet().stream()
-            .map(it -> new PollContext(it, sendEvents))
+            .map(it -> new PollContext(it, !sendEvents))
             .forEach(this::pollSingle);
     }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -93,7 +93,7 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
         long startTime = System.currentTimeMillis()
         log.info "Polling cycle started: ${new Date()}"
         buildMasters.filteredMap(BuildServiceProvider.JENKINS).keySet().parallelStream().forEach(
-            { master -> pollSingle(new PollContext(master)) }
+            { master -> pollSingle(new PollContext(master, !sendEvents)) }
         )
         log.info "Polling cycle done in ${System.currentTimeMillis() - startTime}ms"
     }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.groovy
@@ -86,7 +86,7 @@ class TravisBuildMonitor extends CommonPollingMonitor<BuildDelta, BuildPollingDe
     @Override
     void poll(boolean sendEvents) {
         buildMasters.filteredMap(BuildServiceProvider.TRAVIS).keySet().each { master ->
-            pollSingle(new PollContext(master, sendEvents))
+            pollSingle(new PollContext(master, !sendEvents))
         }
     }
 


### PR DESCRIPTION
#241 lead to Travis and Gitlab no longer sending events when they should (and sending events when they should not). Also, the send event flag was ignored for Jenkins; this commit also fixes that.

FYI @robzienert 