### PR TITLE
refactor(safeguard): Setting default high value on item threshold

### DIFF
--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -5,10 +5,19 @@ netflix:
 spinnaker:
   build:
     pollInterval: 30
+  pollingSafeguard:
+    # A lower value can help prevent accidental re-triggers of pipelines, but may require hands-on operations if
+    # set low.
+    # See code documentation for more details. Class [PollingSafeguardProperties] in
+    # https://github.com/spinnaker/igor/blob/master/igor-web/src/main/groovy/com/netflix/spinnaker/igor/IgorConfigurationProperties.groovy#L47
+    itemUpperThreshold: 1000
+
 
 endpoints.health.sensitive: false
 
 spring.jackson.serialization.write_dates_as_timestamps: false
+
+
 
 #artifact:
 #  This is a feature toggle for decoration of artifacts.

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/IgorConfigurationProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/IgorConfigurationProperties.groovy
@@ -48,9 +48,10 @@ class IgorConfigurationProperties {
             /**
              * Defines the upper threshold for number of new cache items before a cache update cycle will be completely
              * rejected. This is to protect against potentially re-indexing old caches due to downstream service errors.
-             * Once this threshold is tripped, API-driven resolution may be required.
+             * Once this threshold is tripped, API-driven resolution may be required. By default set higher than most
+             * use cases would require since it's a feature that requires more hands-on operations.
              */
-            int itemUpperThreshold = 10
+            int itemUpperThreshold = 1000
         }
 
         @NestedConfigurationProperty


### PR DESCRIPTION
I've been getting a lot of questions about igor's new build index safeguard functionality. This feature was introduced to help guard against accidental re-indexing of build indexes (and potentially running pipelines against old code). 

This PR changes the default value from default-safe to default-basically-disabled.

Having initially launched this feature with a default-safe value, I've realized it's hard for people to upgrade to surprises, and frustrating for people who are in early adoption phase. For organizations that have Spinnaker operations stable, however, this is a setting that you'll want to use and right-size.

By right-sizing the `spinnaker.pollingSafeguard.itemUpperThreshold` to the number of new builds ~every 60 seconds (plus headroom), you can help prevent bad data (from your build system or from Spinnaker) from incorrectly retriggering pipelines. This is done via a circuit breaker that will stop indexing for a particular partition (one jenkins master is a different partition as Travis, or some other jenkins master) if the number of new items exceeds the threshold. The only official way for to get around this circuit breaker once tripped is by either:

1. Changing the configuration for igor and redeploying.
2. Running the [`fastForward` admin API](https://github.com/spinnaker/igor/blob/master/igor-web/src/main/groovy/com/netflix/spinnaker/igor/admin/AdminController.java), which will get you past a single circuit break.