### PR TITLE
feat(docker): Fallback value for item circuit breaker in Docker poller

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DockerRegistryConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DockerRegistryConfig.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.igor.docker.service.ClouddriverService
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
 import groovy.transform.CompileStatic
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import retrofit.Endpoints
@@ -32,6 +33,7 @@ import retrofit.client.OkClient
 
 @Configuration
 @ConditionalOnProperty(['services.clouddriver.baseUrl', 'dockerRegistry.enabled'])
+@EnableConfigurationProperties(DockerRegistryProperties)
 @CompileStatic
 class DockerRegistryConfig {
     @Bean

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DockerRegistryProperties.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DockerRegistryProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "dockerRegistry")
+public class DockerRegistryProperties {
+    private boolean enabled;
+    private Integer itemUpperThreshold;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Integer getItemUpperThreshold() {
+        return itemUpperThreshold;
+    }
+
+    public void setItemUpperThreshold(Integer itemUpperThreshold) {
+        this.itemUpperThreshold = itemUpperThreshold;
+    }
+}


### PR DESCRIPTION
Make it possible to set an `itemUpperThreshold` property for the Docker Registry poller in Igor, that will function as a fallback value if the Docker registries retrieved from Clouddriver does not have this value set.

@robzienert PTAL