### PR TITLE
fix(docker): Redis key migration: Only migrate V1 keys

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -94,7 +94,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
         Boolean trackDigests = ctx.context.trackDigests ?: false
 
         log.debug("Checking new tags for {}", account)
-        List<String> cachedImages = cache.getImages(account)
+        Set<String> cachedImages = cache.getImages(account)
 
         long startTime = System.currentTimeMillis()
         List<TaggedImage> images = dockerRegistryAccounts.service.getImagesByAccount(account)
@@ -113,7 +113,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
         return new DockerPollingDelta(items: delta, cachedImages: cachedImages)
     }
 
-    private boolean shouldUpdateCache(List<String> cachedImages, String imageId, TaggedImage image, boolean trackDigests) {
+    private boolean shouldUpdateCache(Set<String> cachedImages, String imageId, TaggedImage image, boolean trackDigests) {
         boolean updateCache = false
         if (imageId in cachedImages) {
             if (trackDigests) {
@@ -155,7 +155,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
         "dockerTagMonitor"
     }
 
-    void postEvent(List<String> cachedImagesForAccount, TaggedImage image, String imageId) {
+    void postEvent(Set<String> cachedImagesForAccount, TaggedImage image, String imageId) {
         if (!echoService.isPresent()) {
             log.warn("Cannot send tagged image notification: Echo is not enabled")
             registry.counter(missedNotificationId.withTags("monitor", getClass().simpleName, "reason", "echoDisabled")).increment()
@@ -190,7 +190,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
 
     private static class DockerPollingDelta implements PollingDelta<ImageDelta> {
         List<ImageDelta> items
-        List<String> cachedImages
+        Set<String> cachedImages
     }
 
     private static class ImageDelta implements DeltaItem {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCache.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCache.java
@@ -20,9 +20,9 @@ import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static java.lang.String.format;
 
@@ -44,9 +44,9 @@ public class DockerRegistryCache {
         this.igorConfigurationProperties = igorConfigurationProperties;
     }
 
-    public List<String> getImages(String account) {
+    public Set<String> getImages(String account) {
         return redisClientDelegate.withMultiClient(c -> {
-            return new ArrayList<>(c.keys(makeIndexPattern(prefix(), account)));
+            return c.keys(makeIndexPattern(prefix(), account));
         });
     }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigration.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigration.java
@@ -139,6 +139,7 @@ public class DockerRegistryCacheV2KeysMigration {
     private Function<List<String>, Integer> oldKeysCallback =
         (keys) -> {
             List<DockerRegistryV1Key> v1Keys = keys.stream()
+                .filter(key -> !DockerRegistryV2Key.isV2Key(key))
                 .map(this::readV1Key)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV2Key.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryV2Key.java
@@ -15,8 +15,12 @@
  */
 package com.netflix.spinnaker.igor.docker;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class DockerRegistryV2Key {
     private static final String VERSION = "v2";
+    private static Pattern V2_PATTERN = Pattern.compile("^.*?:.*?:v2:.*?:.*?:.*$");
     private final String prefix;
     private final String id;
     private final String account;
@@ -57,6 +61,14 @@ public class DockerRegistryV2Key {
 
     public String toString() {
         return String.format("%s:%s:v2:%s:%s:%s", prefix, id, account, registry, tag);
+    }
+
+    public static boolean isV2Key(String key) {
+        if (key == null) {
+            return false;
+        }
+        Matcher matcher = V2_PATTERN.matcher(key);
+        return matcher.matches();
     }
 
     @Override

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -64,16 +64,16 @@ class DockerMonitorSpec extends Specification {
 
         when: "should short circuit if `echoService` is not available"
         new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.empty(), Optional.empty(), dockerRegistryProperties)
-            .postEvent(["imageId"], taggedImage, "imageId")
+            .postEvent(["imageId"] as Set, taggedImage, "imageId")
 
         then:
         notThrown(NullPointerException)
 
         where:
-        cachedImages || echoServiceCallCount
-        null         || 0
-        []           || 0
-        ["job1"]     || 1
+        cachedImages    || echoServiceCallCount
+        null            || 0
+        [] as Set       || 0
+        ["job1"] as Set || 1
 
     }
 
@@ -89,7 +89,7 @@ class DockerMonitorSpec extends Specification {
 
         when:
         new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.empty(), dockerRegistryProperties)
-            .postEvent(["job1"], taggedImage, "imageId")
+            .postEvent(["job1"] as Set, taggedImage, "imageId")
 
         then:
         1 * echoService.postEvent({ DockerEvent event ->
@@ -107,7 +107,7 @@ class DockerMonitorSpec extends Specification {
     void "should update cache if image is not already cached"() {
         given:
         def subject = createSubject()
-        List<String> cachedImages = [
+        Set<String> cachedImages = [
             'prefix:dockerRegistry:v2:account:registry:tag',
             'prefix:dockerRegistry:v2:account:anotherregistry:tag',
         ]

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigrationSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerRegistryCacheV2KeysMigrationSpec.groovy
@@ -27,6 +27,20 @@ import spock.lang.Subject
 
 class DockerRegistryCacheV2KeysMigrationSpec extends Specification {
 
+    private static final V1_KEYS = [
+        new DockerRegistryV1Key("igor", "dockerRegistry", "acct", "registry", "netflix.com", "tag"),
+        new DockerRegistryV1Key("igor", "dockerRegistry", "acct", "registry", "http://netflix.com", "tag"),
+        new DockerRegistryV1Key("igor", "dockerRegistry", "acct", "registry", "netflix.com:1111", "tag"),
+    ]
+    private static final V2_KEYS = [
+        new DockerRegistryV2Key("igor", "dockerRegistry", "acct", "registry", "tag"),
+        new DockerRegistryV2Key("igor", "dockerRegistry", "acct", "registry", "tag")
+    ]
+    private static final INVALID_KEYS = [
+        new DockerRegistryV2Key("igor", "totalInvalid", "acct", "registry", "tag")
+    ]
+    private static final ALL_KEYS = [V1_KEYS, V2_KEYS, INVALID_KEYS].flatten()
+
     EmbeddedRedis embeddedRedis
     Jedis jedis
     RedisClientDelegate redisClientDelegate
@@ -52,37 +66,38 @@ class DockerRegistryCacheV2KeysMigrationSpec extends Specification {
 
     def "migrates all v1 keys to v2 format"() {
         given:
-        def v1Keys = [
-            new DockerRegistryV1Key("igor", "dockerRegistry", "acct", "registry", "netflix.com", "tag"),
-            new DockerRegistryV1Key("igor", "dockerRegistry", "acct", "registry", "http://netflix.com", "tag"),
-            new DockerRegistryV1Key("igor", "dockerRegistry", "acct", "registry", "netflix.com:1111", "tag"),
-        ]
-        def v2Keys = [
-            new DockerRegistryV2Key("igor", "dockerRegistry", "acct", "registry", "tag"),
-            new DockerRegistryV2Key("igor", "dockerRegistry", "acct", "registry", "tag")
-        ]
-        def invalidKeys = [
-            new DockerRegistryV2Key("igor", "totalInvalid", "acct", "registry", "tag")
-
-        ]
-        def allKeys = [v1Keys, v2Keys, invalidKeys].flatten()
-        allKeys.each { jedis.hmset(it.toString(), [foo: "bar"]) }
+        ALL_KEYS.each { jedis.hmset(it.toString(), [foo: "bar"]) }
 
         expect:
         jedis.keys("igor:*").size() == 5
-        jedis.keys("igor:*:v2:*").size() == v2Keys.size()
+        jedis.keys("igor:*:v2:*").size() == V2_KEYS.size()
 
         when:
         subject.run()
 
         then:
         noExceptionThrown()
-        [v1Keys.collect { keyFactory.convert(it) }, v2Keys].flatten().unique().each {
+        [V1_KEYS.collect { keyFactory.convert(it) }, V2_KEYS].flatten().unique().each {
             assert jedis.exists(it.toString()), "${it} was not created"
             assert jedis.hgetAll(it.toString()) == [foo: "bar"], "${it} did not get correct contents"
         }
-        [v1Keys.each {
+        [V1_KEYS.each {
             assert jedis.ttl(it.toString()) != null, "${it} did not get an expiration"
         }]
+    }
+
+    def "should not migrate v2 keys twice"() {
+        given:
+        ALL_KEYS.each { jedis.hmset(it.toString(), [foo: "bar"]) }
+
+        when:
+        subject.run()
+
+        then:
+        noExceptionThrown()
+        assert jedis.keys("igor:*:v2:*") == [
+            "igor:totalInvalid:v2:acct:registry:tag",
+            "igor:dockerRegistry:v2:acct:registry:tag"
+        ] as Set
     }
 }


### PR DESCRIPTION
The migrator was happily converting V2 keys as well, reading `account` as `v2` and then constructing a new key like `prefix:id:v2:v2:registry:tag`

Proof in the form of a failing test:

```
22:07:51.730 [main] DEBUG com.netflix.spinnaker.igor.docker.DockerRegistryCacheV2KeysMigration - Starting migration
22:07:51.733 [main] INFO com.netflix.spinnaker.igor.docker.DockerRegistryCacheV2KeysMigration - Migrated 4 v1 keys in 3ms

Condition not satisfied:

jedis.keys("igor:*:v2:*") == [ "igor:totalInvalid:v2:acct:registry:tag", "igor:dockerRegistry:v2:acct:registry:tag" ] as Set
|     |                   |
|     |                   false
|     [igor:dockerRegistry:v2:v2:acct:tag, igor:totalInvalid:v2:acct:registry:tag, igor:dockerRegistry:v2:acct:registry:tag]
redis.clients.jedis.Jedis@49b2a47d
 <Click to see difference>

	at com.netflix.spinnaker.igor.docker.DockerRegistryCacheV2KeysMigrationSpec.should not migrate v2 keys twice(DockerRegistryCacheV2KeysMigrationSpec.groovy:98)
```
@robzienert PTAL