### PR TITLE
fix(docker): Fix igor startup with dockerRegistry enabled

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -30,14 +30,14 @@ import com.netflix.spinnaker.igor.polling.DeltaItem
 import com.netflix.spinnaker.igor.polling.PollContext
 import com.netflix.spinnaker.igor.polling.PollingDelta
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 
 import static net.logstash.logback.argument.StructuredArguments.kv
 
 @Service
 @SuppressWarnings('CatchException')
-@ConditionalOnBean(DockerRegistryAccounts)
+@ConditionalOnProperty(['services.clouddriver.baseUrl', 'dockerRegistry.enabled'])
 class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta> {
 
     private final DockerRegistryCache cache


### PR DESCRIPTION
#257 (that was supposed to fix a regression in #255) caused the Docker Monitor to never initialize.
Revert to using `ConditionalOnProperty` instead.

@ezimanyi @robzienert PTAL