### PR TITLE
fix(travis/packagecloud): Fix escaping in the packagecloud regex

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/logparser/ArtifactParser.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/logparser/ArtifactParser.java
@@ -35,7 +35,7 @@ public class ArtifactParser {
 
     private static final List<String> DEFAULT_REGEXES = Collections.unmodifiableList(Arrays.asList(
         "Uploading artifact: https?:\\/\\/.+\\/(.+\\.(deb|rpm)).*$",
-        "Successfully pushed (.+\\\\.(deb|rpm)) to .*"));
+        "Successfully pushed (.+\\.(deb|rpm)) to .*"));
 
     /**
      * Parse the build log using the given regular expressions.  If they are

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/logparser/ArtifactParserTest.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/logparser/ArtifactParserTest.groovy
@@ -61,8 +61,11 @@ class ArtifactParserTest extends Specification {
 
     @Unroll
     def "get single deb or rpm from log using default regexes"() {
-        expect:
+        when:
         List<GenericArtifact> artifacts = ArtifactParser.getArtifactsFromLog(buildLog, Collections.emptyList())
+
+        then:
+        artifacts.first().fileName == packageName
 
         where:
         buildLog                     || packageName


### PR DESCRIPTION
The test that covers packagecloud did not actually validate that the artifact was identified.
This fixes both the test and the regex.
