### PR TITLE
fix(web): Log an error when commits cannot be fetched from stash

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/stash/CommitController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/stash/CommitController.groovy
@@ -43,15 +43,19 @@ class CommitController extends AbstractCommitController {
         try {
             commitsResponse = stashMaster.stashClient.getCompareCommits(projectKey, repositorySlug, requestParams)
         } catch (RetrofitError e) {
-            if(e.getKind() == RetrofitError.Kind.NETWORK) {
+            if (e.getKind() == RetrofitError.Kind.NETWORK) {
                 throw new RuntimeException("Could not find the server ${stashMaster.baseUrl}")
-            } else if(e.response.status == 404) {
+            } else if (e.response.status == 404) {
                 return getNotFoundCommitsResponse(projectKey, repositorySlug, requestParams.to, requestParams.from, stashMaster.baseUrl)
             }
+            log.error(
+                "Failed to fetch commits for {}/{}, reason: {}",
+                projectKey, repositorySlug, e.message
+            )
         }
 
         List result = []
-        commitsResponse.values.each {
+        commitsResponse?.values?.each {
             result << [displayId: it?.displayId, id: it?.id, authorDisplayName: it?.author?.displayName,
                        timestamp: it?.authorTimestamp, message : it?.message, commitUrl:
                            "${stashMaster.baseUrl}/projects/${projectKey}/repos/${repositorySlug}/commits/${it.id}".toString()]


### PR DESCRIPTION
Previously we would swallow the exception and NPE.

Now we report an error and return an empty list.
