### PR TITLE
feat(*): Adding locking support to build monitors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
     sourceSets.main.groovy.srcDirs += ["src/main/java"]
 
     ext {
-        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.155.1'
+        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.154.0-SNAPSHOT'
     }
 
     def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/LockManagerConfig.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/LockManagerConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import com.netflix.spinnaker.kork.jedis.lock.RedisLockManager;
+import com.netflix.spinnaker.kork.lock.LockManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+@ConditionalOnProperty("locking.enabled")
+public class LockManagerConfig {
+
+    @Bean
+    LockManager redisLockManager(Clock clock,
+                                 Registry registry,
+                                 ObjectMapper mapper,
+                                 RedisClientDelegate redisClientDelegate) {
+        return new RedisLockManager("igor", clock, registry, mapper, redisClientDelegate);
+    }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.igor.polling.CommonPollingMonitor
 import com.netflix.spinnaker.igor.polling.DeltaItem
 import com.netflix.spinnaker.igor.polling.PollContext
 import com.netflix.spinnaker.igor.polling.PollingDelta
+import com.netflix.spinnaker.kork.lock.LockManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
@@ -50,12 +51,13 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
     DockerMonitor(IgorConfigurationProperties properties,
                   Registry registry,
                   Optional<DiscoveryClient> discoveryClient,
+                  Optional<LockManager> lockManager,
                   DockerRegistryCache cache,
                   DockerRegistryAccounts dockerRegistryAccounts,
                   Optional<EchoService> echoService,
                   Optional<DockerRegistryCacheV2KeysMigration> keysMigration,
                   DockerRegistryProperties dockerRegistryProperties) {
-        super(properties, registry, discoveryClient)
+        super(properties, registry, discoveryClient, lockManager)
         this.cache = cache
         this.dockerRegistryAccounts = dockerRegistryAccounts
         this.echoService = echoService

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.igor.polling.DeltaItem;
 import com.netflix.spinnaker.igor.polling.PollContext;
 import com.netflix.spinnaker.igor.polling.PollingDelta;
 import com.netflix.spinnaker.igor.service.BuildMasters;
+import com.netflix.spinnaker.kork.lock.LockManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
@@ -63,11 +64,12 @@ public class GitlabCiBuildMonitor extends CommonPollingMonitor<GitlabCiBuildMoni
     public GitlabCiBuildMonitor(IgorConfigurationProperties properties,
                                 Registry registry,
                                 Optional<DiscoveryClient> discoveryClient,
+                                Optional<LockManager> lockManager,
                                 BuildCache buildCache,
                                 BuildMasters buildMasters,
                                 GitlabCiProperties gitlabCiProperties,
                                 Optional<EchoService> echoService) {
-        super(properties, registry, discoveryClient);
+        super(properties, registry, discoveryClient, lockManager);
         this.buildCache = buildCache;
         this.buildMasters = buildMasters;
         this.gitlabCiProperties = gitlabCiProperties;

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.igor.polling.DeltaItem
 import com.netflix.spinnaker.igor.polling.PollContext
 import com.netflix.spinnaker.igor.polling.PollingDelta
 import com.netflix.spinnaker.igor.service.BuildMasters
+import com.netflix.spinnaker.kork.lock.LockManager
 import groovy.time.TimeCategory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -61,12 +62,13 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
     JenkinsBuildMonitor(IgorConfigurationProperties properties,
                         Registry registry,
                         Optional<DiscoveryClient> discoveryClient,
+                        Optional<LockManager> lockManager,
                         JenkinsCache cache,
                         BuildMasters buildMasters,
                         @Value('${jenkins.polling.enabled:true}') boolean pollingEnabled,
                         Optional<EchoService> echoService,
                         JenkinsProperties jenkinsProperties) {
-        super(properties, registry, discoveryClient)
+        super(properties, registry, discoveryClient, lockManager)
         this.cache = cache
         this.buildMasters = buildMasters
         this.pollingEnabled = pollingEnabled

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
@@ -21,16 +21,20 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.igor.IgorConfigurationProperties;
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent;
+import com.netflix.spinnaker.kork.lock.LockManager;
+import com.netflix.spinnaker.kork.lock.LockManager.LockOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
 
 import javax.annotation.Nullable;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
 public abstract class CommonPollingMonitor<I extends DeltaItem, T extends PollingDelta<I>> implements PollingMonitor, PollAccess {
@@ -50,19 +54,24 @@ public abstract class CommonPollingMonitor<I extends DeltaItem, T extends Pollin
     private final Id pollCycleFailedId;
     protected final Id missedNotificationId;
 
+    private final Optional<LockManager> lockManager;
+
     public CommonPollingMonitor(IgorConfigurationProperties igorProperties,
                                 Registry registry,
-                                Optional<DiscoveryClient> discoveryClient) {
-        this(igorProperties, registry, discoveryClient, Schedulers.io());
+                                Optional<DiscoveryClient> discoveryClient,
+                                Optional<LockManager> lockManager) {
+        this(igorProperties, registry, discoveryClient, lockManager, Schedulers.io());
     }
 
     public CommonPollingMonitor(IgorConfigurationProperties igorProperties,
                                 Registry registry,
                                 Optional<DiscoveryClient> discoveryClient,
+                                Optional<LockManager> lockManager,
                                 Scheduler scheduler) {
         this.igorProperties = igorProperties;
         this.registry = registry;
         this.discoveryClient = discoveryClient;
+        this.lockManager = lockManager;
         this.worker = scheduler.createWorker();
 
         itemsCachedId = registry.createId("pollingMonitor.newItems");
@@ -106,6 +115,23 @@ public abstract class CommonPollingMonitor<I extends DeltaItem, T extends Pollin
 
     @Override
     public void pollSingle(PollContext ctx) {
+        if (lockManager.isPresent()) {
+            // Lock duration of the full poll interval; if the work is completed ahead of that time, it'll be released.
+            // If anything, this will mean builds are polled more often, rather than less.
+            LockOptions lockOptions = new LockOptions()
+                .withLockName(format("%s.%s", getName(), ctx.partitionName))
+                .withLeaseDuration(Duration.ofMillis(getPollInterval()));
+
+            lockManager.get().acquireLock(lockOptions, () -> {
+                internalPollSingle(ctx);
+                return null;
+            });
+        } else {
+            internalPollSingle(ctx);
+        }
+    }
+
+    protected void internalPollSingle(PollContext ctx) {
         String monitorName = getClass().getSimpleName();
 
         try {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -32,6 +32,7 @@ class DockerMonitorSpec extends Specification {
     def properties = new IgorConfigurationProperties()
     def registry = new NoopRegistry()
     def discoveryClient = Optional.empty()
+    def lockManager = Optional.empty()
     def dockerRegistryCache = Mock(DockerRegistryCache)
     def dockerRegistryAccounts = Mock(DockerRegistryAccounts)
     def echoService = Mock(EchoService)
@@ -49,7 +50,7 @@ class DockerMonitorSpec extends Specification {
         )
 
         when:
-        new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.empty(), dockerRegistryProperties)
+        new DockerMonitor(properties, registry, discoveryClient, lockManager, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.empty(), dockerRegistryProperties)
             .postEvent(cachedImages, taggedImage, "imageId")
 
         then:
@@ -63,7 +64,7 @@ class DockerMonitorSpec extends Specification {
         })
 
         when: "should short circuit if `echoService` is not available"
-        new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.empty(), Optional.empty(), dockerRegistryProperties)
+        new DockerMonitor(properties, registry, discoveryClient, lockManager, dockerRegistryCache, dockerRegistryAccounts, Optional.empty(), Optional.empty(), dockerRegistryProperties)
             .postEvent(["imageId"] as Set, taggedImage, "imageId")
 
         then:
@@ -88,7 +89,7 @@ class DockerMonitorSpec extends Specification {
         )
 
         when:
-        new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.empty(), dockerRegistryProperties)
+        new DockerMonitor(properties, registry, discoveryClient, lockManager, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.empty(), dockerRegistryProperties)
             .postEvent(["job1"] as Set, taggedImage, "imageId")
 
         then:
@@ -154,7 +155,7 @@ class DockerMonitorSpec extends Specification {
     }
 
     private DockerMonitor createSubject(Optional<EchoService> echoService) {
-        return new DockerMonitor(properties, registry, discoveryClient, dockerRegistryCache, dockerRegistryAccounts, echoService, Optional.empty(), dockerRegistryProperties)
+        return new DockerMonitor(properties, registry, discoveryClient, lockManager, dockerRegistryCache, dockerRegistryAccounts, echoService, Optional.empty(), dockerRegistryProperties)
     }
 
     private static String keyFromTaggedImage(TaggedImage taggedImage) {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitorSpec.groovy
@@ -45,6 +45,7 @@ class GitlabCiBuildMonitorSpec extends Specification {
             new IgorConfigurationProperties(),
             new NoopRegistry(),
             Optional.empty(),
+            Optional.empty(),
             buildCache,
             new BuildMasters(map: [MASTER: service]),
             properties,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
@@ -52,6 +52,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
             cfg,
             new NoopRegistry(),
             Optional.empty(),
+            Optional.empty(),
             cache,
             buildMasters,
             true,
@@ -105,6 +106,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
         monitor = new JenkinsBuildMonitor(
             cfg,
             new NoopRegistry(),
+            Optional.empty(),
             Optional.empty(),
             cache,
             buildMasters,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSpec.groovy
@@ -51,6 +51,7 @@ class JenkinsBuildMonitorSpec extends Specification {
             igorConfigurationProperties,
             new NoopRegistry(),
             Optional.empty(),
+            Optional.empty(),
             cache,
             new BuildMasters(map: [MASTER: jenkinsService]),
             true,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -48,6 +48,7 @@ class TravisBuildMonitorSpec extends Specification {
             new IgorConfigurationProperties(),
             new NoopRegistry(),
             Optional.empty(),
+            Optional.empty(),
             buildCache,
             new BuildMasters(map: [MASTER : travisService]),
             travisProperties,


### PR DESCRIPTION
Depends on https://github.com/spinnaker/kork/pull/150.

This will allow us to run more than one igor. Since this is new functionality, the LockManager defaults to completely disabled.