### PR TITLE
fix(jenkins) return multiple scms when jenkins has multiple scms and remoteUrl calls

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.groovy
@@ -29,11 +29,19 @@ class GenericGitRevision {
     String compareUrl
     String message
     Instant timestamp
+    String remoteUrl
 
     GenericGitRevision(String name, String branch, String sha1) {
         this.name = name
         this.branch = branch
         this.sha1 = sha1
+    }
+
+    GenericGitRevision(String name, String branch, String sha1, String remoteUrl) {
+        this.name = name
+        this.branch = branch
+        this.sha1 = sha1
+        this.remoteUrl = remoteUrl
     }
 
     GenericGitRevision(String name, String branch, String sha1, String committer, String compareUrl, String message, Instant timestamp) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -50,7 +50,7 @@ interface JenkinsClient {
     @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(totalCount)]&tree=actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url,fullDisplayName,artifacts[displayPath,fileName,relativePath]')
     Build getBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
 
-    @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(lastBuiltRevision)]&tree=actions[remoteUrl,lastBuiltRevision[branch[name,SHA1]]]')
+    @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(lastBuiltRevision)]&tree=actions[remoteUrls,lastBuiltRevision[branch[name,SHA1]]]')
     ScmDetails getGitDetails(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
 
     @GET('/job/{jobName}/lastCompletedBuild/api/xml')

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.groovy
@@ -196,9 +196,7 @@ class JenkinsService implements BuildService{
     @Override
     List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber) {
         ScmDetails scmDetails = getGitDetails(job, buildNumber)
-        if (scmDetails?.action?.lastBuiltRevision?.branch?.name) {
-            return scmDetails.genericGitRevisions()
-        }
-        return null
+        return scmDetails.genericGitRevisions()
+
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/ScmDetails.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/ScmDetails.groovy
@@ -30,21 +30,31 @@ import org.simpleframework.xml.Root
 @CompileStatic
 @Root(strict = false)
 class ScmDetails {
-    @Element(required = false)
-    Action action
+    @ElementList(inline = true, required = false, name = "action")
+    ArrayList<Action> actions
+
 
     List<GenericGitRevision> genericGitRevisions() {
-        if (action?.lastBuiltRevision?.branch?.name) {
-            return action.lastBuiltRevision.branch.collect() { Branch branch ->
-                new GenericGitRevision(branch.name, branch.name.split('/').last(), branch.sha1)
+        List<GenericGitRevision> genericGitRevisions = new ArrayList<GenericGitRevision>()
+
+        if (actions == null) {
+            return null
+        }
+
+        for (Action action : actions) {
+            if (action?.lastBuiltRevision?.branch?.name) {
+                genericGitRevisions.addAll(action.lastBuiltRevision.branch.collect() { Branch branch ->
+                    new GenericGitRevision(branch.name, branch.name.split('/').last(), branch.sha1, action.remoteUrl)
+                })
             }
         }
-        return null
+
+        return genericGitRevisions
     }
 }
 
-@Root(strict=false)
-class Action{
+@Root(strict = false)
+class Action {
     @Element(required = false)
     LastBuiltRevision lastBuiltRevision
 
@@ -52,17 +62,17 @@ class Action{
     String remoteUrl
 }
 
-@Root(strict=false)
-class LastBuiltRevision{
+@Root(strict = false)
+class LastBuiltRevision {
     @ElementList(inline = true, name = "branch")
     List<Branch> branch
 }
 
-@Root(strict=false)
-class Branch{
+@Root(strict = false)
+class Branch {
     @Element(required = false)
     String name
 
-    @Element(required = false, name="SHA1")
+    @Element(required = false, name = "SHA1")
     String sha1
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/ScmDetails.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/ScmDetails.groovy
@@ -47,6 +47,9 @@ class ScmDetails {
 class Action{
     @Element(required = false)
     LastBuiltRevision lastBuiltRevision
+
+    @Element(required = false)
+    String remoteUrl
 }
 
 @Root(strict=false)


### PR DESCRIPTION
- Some jenkins jobs will trigger with multiple scms, this however caused igor to break and not return any scm information
- Jenkins XML api requires remoteUrl to be pluralized