### PR TITLE
fix(build): Fix spring warnings about validated classes

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/ArtifactDecorationProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/ArtifactDecorationProperties.groovy
@@ -20,12 +20,14 @@ import groovy.transform.CompileStatic
 import org.hibernate.validator.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
+import org.springframework.validation.annotation.Validated
 
 import javax.validation.Valid
 
 @Configuration
 @CompileStatic
 @ConfigurationProperties(prefix = 'artifact.decorator')
+@Validated
 class ArtifactDecorationProperties {
     boolean enabled = false
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.config
 import groovy.transform.CompileStatic
 import org.hibernate.validator.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
 
 import javax.validation.Valid
 /**
@@ -26,6 +27,7 @@ import javax.validation.Valid
  */
 @CompileStatic
 @ConfigurationProperties(prefix = 'jenkins')
+@Validated
 class JenkinsProperties {
     @Valid
     List<JenkinsHost> masters


### PR DESCRIPTION
As of Spring Boot 1.5, `@ConfigurationProperties` classes that use constraint annotations should also be annotated with `@Validated`; this is currently throwing warnings but may actually break in the future.