### PR TITLE
chore(build): Add debug flag to igor build

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,14 @@ dockerRegistry:
 Igor requires redis server to be up and running.
 
 Start Igor via `./gradlew bootRun`. Or by following the instructions using the [Spinnaker installation scripts](https://www.github.com/spinnaker/spinnaker).
+
+### Debugging
+
+To start the JVM in debug mode, set the Java system property `DEBUG=true`:
+```
+./gradlew -DDEBUG=true
+```
+
+The JVM will then listen for a debugger to be attached on port 8188.  The JVM will _not_ wait for
+the debugger to be attached before starting Igor; the relevant JVM arguments can be seen and
+modified as needed in `build.gradle`.

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,12 @@ allprojects {
       }
     }
 
+    tasks.withType(JavaExec) {
+      if (System.getProperty('DEBUG', 'false') == 'true') {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8188'
+      }
+    }
+
     group = "com.netflix.spinnaker.igor"
 }
 


### PR DESCRIPTION
Starting igor with ./gradlew -DDEBUG=true now causes the JVM to listen on port 8188 for a remote debugger.