### PR TITLE
fix(travis): Make artifact decorator optional

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisConfig.java
@@ -41,6 +41,7 @@ import javax.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -55,7 +56,7 @@ public class TravisConfig {
     private Logger log = LoggerFactory.getLogger(getClass());
 
     @Bean
-    public Map<String, TravisService> travisMasters(BuildMasters buildMasters, TravisCache travisCache, IgorConfigurationProperties igorConfigurationProperties, @Valid TravisProperties travisProperties, ObjectMapper objectMapper, ArtifactDecorator artifactDecorator) {
+    public Map<String, TravisService> travisMasters(BuildMasters buildMasters, TravisCache travisCache, IgorConfigurationProperties igorConfigurationProperties, @Valid TravisProperties travisProperties, ObjectMapper objectMapper, Optional<ArtifactDecorator> artifactDecorator) {
         log.info("creating travisMasters");
 
         Map<String, TravisService> travisMasters = (travisProperties == null ? new ArrayList<TravisProperties.TravisHost>() : travisProperties.getMasters()).stream()
@@ -72,7 +73,7 @@ public class TravisConfig {
         return travisMasters;
     }
 
-    public static TravisService travisService(String travisHostId, String baseUrl, String githubToken, int numberOfRepositories, TravisClient travisClient, TravisCache travisCache, ArtifactDecorator artifactDecorator, Collection<String> artifactRexeges) {
+    public static TravisService travisService(String travisHostId, String baseUrl, String githubToken, int numberOfRepositories, TravisClient travisClient, TravisCache travisCache, Optional<ArtifactDecorator> artifactDecorator, Collection<String> artifactRexeges) {
         return new TravisService(travisHostId, baseUrl, githubToken, numberOfRepositories, travisClient, travisCache, artifactDecorator, artifactRexeges);
     }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
@@ -66,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -81,11 +82,11 @@ public class TravisService implements BuildService {
     private final TravisClient travisClient;
     private final TravisCache travisCache;
     private final Collection<String> artifactRegexes;
-    private final ArtifactDecorator artifactDecorator;
+    private final Optional<ArtifactDecorator> artifactDecorator;
     protected AccessToken accessToken;
     private Accounts accounts;
 
-    public TravisService(String travisHostId, String baseUrl, String githubToken, int numberOfRepositories, TravisClient travisClient, TravisCache travisCache, @Nullable ArtifactDecorator artifactDecorator, Collection<String> artifactRegexes) {
+    public TravisService(String travisHostId, String baseUrl, String githubToken, int numberOfRepositories, TravisClient travisClient, TravisCache travisCache, Optional<ArtifactDecorator> artifactDecorator, Collection<String> artifactRegexes) {
         this.numberOfRepositories = numberOfRepositories;
         this.groupKey = travisHostId;
         this.gitHubAuth = new GithubAuth(githubToken);
@@ -471,10 +472,7 @@ public class TravisService implements BuildService {
 
     private void parseAndDecorateArtifacts(String log, GenericBuild genericBuild) {
         genericBuild.setArtifacts(ArtifactParser.getArtifactsFromLog(log, artifactRegexes));
-        if (artifactDecorator != null) {
-            artifactDecorator.decorate(genericBuild);
-        }
-
+        artifactDecorator.ifPresent(decorator -> decorator.decorate(genericBuild));
     }
 
     public final String getBaseUrl() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -42,11 +42,11 @@ class TravisServiceSpec extends Specification{
     TravisService service
 
     @Shared
-    ArtifactDecorator artifactDecorator
+    Optional<ArtifactDecorator> artifactDecorator
 
     void setup() {
         client = Mock(TravisClient)
-        artifactDecorator = new ArtifactDecorator([new DebDetailsDecorator(), new RpmDetailsDecorator()], null)
+        artifactDecorator = Optional.of(new ArtifactDecorator([new DebDetailsDecorator(), new RpmDetailsDecorator()], null))
         service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', 25, client, null, artifactDecorator, [])
 
         AccessToken accessToken = new AccessToken()


### PR DESCRIPTION
Igor fails to start when the artifact decorator is not enabled. This change makes the decorator optional.

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 5 of method travisMasters in com.netflix.spinnaker.igor.config.TravisConfig required a bean of type 'com.netflix.spinnaker.igor.service.ArtifactDecorator' that could not be found.
```