### PR TITLE
fix(artifacts/rpm): the generated version should be complete

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/RpmDetailsDecorator.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/RpmDetailsDecorator.groovy
@@ -51,8 +51,8 @@ class RpmDetailsDecorator implements ArtifactDetailsDecorator {
 
     String extractVersion(String file) {
         List<String> parts = file.tokenize(versionDelimiter)
-        parts.pop()
-        return parts.pop()
+        String suffix = parts.pop().replaceAll(".rpm", '')
+        return parts.pop() + versionDelimiter + suffix
     }
 
     String extractName(String file) {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/RpmDetailsDecoratorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/artifact/decorator/RpmDetailsDecoratorSpec.groovy
@@ -37,9 +37,9 @@ class RpmDetailsDecoratorSpec extends Specification {
 
         where:
         file                                        || version
-        "api-4.11.4h-1.x86_64.rpm"                  || "4.11.4h"
-        "alsa-lib-1.0.17-1.el5.i386.rpm"            || "1.0.17"
-        "openmotif22-libs-2.2.4-192.1.3.x86_64.rpm" || "2.2.4"
+        "api-4.11.4h-1.x86_64.rpm"                  || "4.11.4h-1.x86_64"
+        "alsa-lib-1.0.17-1.el5.i386.rpm"            || "1.0.17-1.el5.i386"
+        "openmotif22-libs-2.2.4-192.1.3.x86_64.rpm" || "2.2.4-192.1.3.x86_64"
     }
 
     @Unroll

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/service/ArtifactDecoratorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/service/ArtifactDecoratorSpec.groovy
@@ -51,13 +51,13 @@ class ArtifactDecoratorSpec extends Specification {
         genericArtifact.type    == type
 
         where:
-        reference                                   || name               | version            | type
-        "openmotif22-libs-2.2.4-192.1.3.x86_64.rpm" || "openmotif22-libs" | "2.2.4"            | "rpm"
-        "api_1.1.1-h01.sha123_all.deb"              || "api"              | "1.1.1-h01.sha123" | "deb"
-        "test-2.13.jar"                             || "test"             | "2.13"             | "jar"
-        "wara-2.13.war"                             || "wara"             | "2.13"             | "war"
-        "unknown-3.2.1.apk"                         || null               | null               | null
-        null                                        || null               | null               | null
+        reference                                   || name               | version                | type
+        "openmotif22-libs-2.2.4-192.1.3.x86_64.rpm" || "openmotif22-libs" | "2.2.4-192.1.3.x86_64" | "rpm"
+        "api_1.1.1-h01.sha123_all.deb"              || "api"              | "1.1.1-h01.sha123"     | "deb"
+        "test-2.13.jar"                             || "test"             | "2.13"                 | "jar"
+        "wara-2.13.war"                             || "wara"             | "2.13"                 | "war"
+        "unknown-3.2.1.apk"                         || null               | null                   | null
+        null                                        || null               | null                   | null
     }
 
     @Unroll


### PR DESCRIPTION
Make the rpm decorator produce the proper version for rpms.