### PR TITLE
fix(travis): grace period before triggering with new travis builds

### DIFF
--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -35,6 +35,10 @@ spring.jackson.serialization.write_dates_as_timestamps: false
 #  This makes new repos with builds in travis the github user has access to tracked by spinnaker.
 #  repositorySyncEnabled: true
 #
+#  This grace period gives travis some time to make the logs available. If a build just finished when we try to fetch
+#  logs, parts of the logs might not be present. Increase this timeout if artifacts are randomly missing.
+#  newBuildGracePeriod: 10
+#
 #  Travis names are prefixed with travis- inside igor.
 #  masters:
 #    - name: ci # This will show as travis-ci inside spinnaker.

--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -37,7 +37,7 @@ spring.jackson.serialization.write_dates_as_timestamps: false
 #
 #  This grace period gives travis some time to make the logs available. If a build just finished when we try to fetch
 #  logs, parts of the logs might not be present. Increase this timeout if artifacts are randomly missing.
-#  newBuildGracePeriod: 10
+#  newBuildGracePeriodSeconds: 10
 #
 #  Travis names are prefixed with travis- inside igor.
 #  masters:

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 @ConfigurationProperties(prefix = "travis")
 public class TravisProperties {
+    private long newBuildGracePeriod = 10;
     private boolean repositorySyncEnabled = false;
     private int cachedJobTTLDays = 60;
     @Valid
@@ -66,6 +67,14 @@ public class TravisProperties {
 
     public void setRegexes(List<String> regexes) {
         this.regexes = regexes;
+    }
+
+    public long getNewBuildGracePeriod() {
+        return newBuildGracePeriod;
+    }
+
+    public void setNewBuildGracePeriod(long newBuildGracePeriod) {
+        this.newBuildGracePeriod = newBuildGracePeriod;
     }
 
     public static class TravisHost {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 @ConfigurationProperties(prefix = "travis")
 public class TravisProperties {
-    private long newBuildGracePeriod = 10;
+    private long newBuildGracePeriodSeconds = 10;
     private boolean repositorySyncEnabled = false;
     private int cachedJobTTLDays = 60;
     @Valid
@@ -69,12 +69,12 @@ public class TravisProperties {
         this.regexes = regexes;
     }
 
-    public long getNewBuildGracePeriod() {
-        return newBuildGracePeriod;
+    public long getNewBuildGracePeriodSeconds() {
+        return newBuildGracePeriodSeconds;
     }
 
-    public void setNewBuildGracePeriod(long newBuildGracePeriod) {
-        this.newBuildGracePeriod = newBuildGracePeriod;
+    public void setNewBuildGracePeriodSeconds(long newBuildGracePeriodSeconds) {
+        this.newBuildGracePeriodSeconds = newBuildGracePeriodSeconds;
     }
 
     public static class TravisHost {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -254,10 +254,10 @@ public class TravisBuildMonitor extends CommonPollingMonitor<TravisBuildMonitor.
 
     private Predicate<V3Build> filterNewBuildsPredicate() {
         /*
-        NEW_BUILD_GRACE_PERIOD is here because the travis API needs some time in order to fully represent the build in
-        the api.
+        NewBuildGracePeriod is here because the travis API needs some time in order to fully represent the build in
+        the api. This can be overridden by travis.newBuildGracePeriod.
         */
-        Instant threshold = Instant.now().minus(30L, ChronoUnit.SECONDS);
+        Instant threshold = Instant.now().minus(travisProperties.getNewBuildGracePeriod(), ChronoUnit.SECONDS);
         return build -> !build.getState().isRunning() || (build.getFinishedAt() != null && build.getFinishedAt().isBefore(threshold));
     }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -173,7 +174,9 @@ public class TravisBuildMonitor extends CommonPollingMonitor<TravisBuildMonitor.
 
     private List<BuildDelta> processBuilds(List<V3Build> builds, String master, TravisService travisService) {
         List<BuildDelta> results = new ArrayList<>();
-        builds.forEach(build -> {
+        builds.stream()
+            .filter(filterNewBuildsPredicate())
+            .forEach(build -> {
             String branchedRepoSlug = build.branchedRepoSlug();
             int cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug, build.getState().isRunning());
             GenericBuild genericBuild = TravisBuildConverter.genericBuild(build, travisService.getBaseUrl());
@@ -247,6 +250,15 @@ public class TravisBuildMonitor extends CommonPollingMonitor<TravisBuildMonitor.
 
     private int buildCacheJobTTLSeconds() {
         return (int) TimeUnit.DAYS.toSeconds(travisProperties.getCachedJobTTLDays());
+    }
+
+    private Predicate<V3Build> filterNewBuildsPredicate() {
+        /*
+        NEW_BUILD_GRACE_PERIOD is here because the travis API needs some time in order to fully represent the build in
+        the api.
+        */
+        Instant threshold = Instant.now().minus(30L, ChronoUnit.SECONDS);
+        return build -> !build.getState().isRunning() || (build.getFinishedAt() != null && build.getFinishedAt().isBefore(threshold));
     }
 
     private List<Repo> filterOutOldBuilds(List<Repo> repos) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -254,10 +254,10 @@ public class TravisBuildMonitor extends CommonPollingMonitor<TravisBuildMonitor.
 
     private Predicate<V3Build> filterNewBuildsPredicate() {
         /*
-        NewBuildGracePeriod is here because the travis API needs some time in order to fully represent the build in
+        NewBuildGracePeriodSeconds is here because the travis API needs some time in order to fully represent the build in
         the api. This can be overridden by travis.newBuildGracePeriod.
         */
-        Instant threshold = Instant.now().minus(travisProperties.getNewBuildGracePeriod(), ChronoUnit.SECONDS);
+        Instant threshold = Instant.now().minus(travisProperties.getNewBuildGracePeriodSeconds(), ChronoUnit.SECONDS);
         return build -> !build.getState().isRunning() || (build.getFinishedAt() != null && build.getFinishedAt().isBefore(threshold));
     }
 


### PR DESCRIPTION
The travis api needs some time after a build is finished in order to have
the build data present in the apis.

This is configurable through `travis.newBuildGracePeriod`