### PR TITLE
fix(jenkins): don't error out on queue item responses with missing field

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/QueuedJob.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/QueuedJob.groovy
@@ -25,9 +25,16 @@ class QueuedJob {
     @XmlElement
     QueuedExecutable executable
 
+    @XmlElement
+    Integer id
+
     @XmlElement(name = 'number')
     Integer getNumber() {
-        return executable.number
+        if (executable != null) {
+            return executable.number
+        }
+
+        return id ?: null
     }
 }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -135,6 +135,37 @@ class BuildControllerSpec extends Specification {
         queuedJob.number == QUEUED_JOB_NUMBER
     }
 
+    void 'deserialize a more realistic queue response'() {
+        given:
+        def objectMapper = JenkinsConfig.getObjectMapper()
+
+        when:
+        def queuedJob = objectMapper.readValue(
+            "<buildableItem _class=\"hudson.model.Queue\$BuildableItem\">\n" +
+            "    <action _class=\"hudson.model.ParametersAction\">\n" +
+            "        <parameter _class=\"hudson.model.StringParameterValue\">\n" +
+            "            <name>CLUSTER_NAME</name>\n" +
+            "            <value>aspera-ingestqc</value>\n" +
+            "        </parameter>\n" +
+            "    </action>\n" +
+            "    <action _class=\"hudson.model.CauseAction\">\n" +
+            "        <cause _class=\"hudson.model.Cause\$UserIdCause\">\n" +
+            "            <shortDescription>Started by user buildtest</shortDescription>\n" +
+            "            <userId>buildtest</userId>\n" +
+            "            <userName>buildtest</userName>\n" +
+            "        </cause>\n" +
+            "    </action>\n" +
+            "    <blocked>false</blocked>\n" +
+            "    <buildable>true</buildable>\n" +
+            "    <id>${QUEUED_JOB_NUMBER}</id>" +
+            "    <stuck>true</stuck>" +
+            "    <pending>false</pending>" +
+            "</buildableItem>", QueuedJob.class)
+
+        then:
+        queuedJob.number == QUEUED_JOB_NUMBER
+    }
+
     void 'get a list of builds for a job'() {
         given:
         1 * jenkinsService.getBuilds(JOB_NAME) >> new BuildsList(list: [new Build(number: 111), new Build(number: 222)])

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -121,7 +121,7 @@ class BuildControllerSpec extends Specification {
         then:
         1 * buildMasters.filteredMap(BuildServiceProvider.JENKINS) >> [MASTER: jenkinsService]
         1 * buildMasters.map >> [MASTER: jenkinsService]
-        response.contentAsString == "{\"executable\":{\"number\":${QUEUED_JOB_NUMBER}},\"number\":${QUEUED_JOB_NUMBER}}"
+        response.contentAsString == "{\"executable\":{\"number\":${QUEUED_JOB_NUMBER}},\"id\":null,\"number\":${QUEUED_JOB_NUMBER}}"
     }
 
     void 'deserialize a queue response'() {


### PR DESCRIPTION
We don't want to throw an NPE if there is no `executable` element in the
response. I noticed this element now seems to correspond to `id` so use
that as a fallback if we can.
