### PR TITLE
fix(jenkins): don't mistake the queue id for the job number

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/QueuedJob.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/QueuedJob.groovy
@@ -25,16 +25,9 @@ class QueuedJob {
     @XmlElement
     QueuedExecutable executable
 
-    @XmlElement
-    Integer id
-
     @XmlElement(name = 'number')
     Integer getNumber() {
-        if (executable != null) {
-            return executable.number
-        }
-
-        return id ?: null
+        return executable?.number
     }
 }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -121,7 +121,7 @@ class BuildControllerSpec extends Specification {
         then:
         1 * buildMasters.filteredMap(BuildServiceProvider.JENKINS) >> [MASTER: jenkinsService]
         1 * buildMasters.map >> [MASTER: jenkinsService]
-        response.contentAsString == "{\"executable\":{\"number\":${QUEUED_JOB_NUMBER}},\"id\":null,\"number\":${QUEUED_JOB_NUMBER}}"
+        response.contentAsString == "{\"executable\":{\"number\":${QUEUED_JOB_NUMBER}},\"number\":${QUEUED_JOB_NUMBER}}"
     }
 
     void 'deserialize a queue response'() {
@@ -163,7 +163,7 @@ class BuildControllerSpec extends Specification {
             "</buildableItem>", QueuedJob.class)
 
         then:
-        queuedJob.number == QUEUED_JOB_NUMBER
+        queuedJob.number == null
     }
 
     void 'get a list of builds for a job'() {


### PR DESCRIPTION
Orca runs MonitorQueuedJenkinsJobTask until the number is not null and
then uses that in MonitorJenkinsJobTask. Returning the id in QueuedJob
results in the wrong number stored in the context and MonitorJenkinsJobTask
then gets 404s back from Jenkins.
