### PR TITLE
 fix(docker): Update cache when a null tag becomes non-null

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -111,7 +111,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
             String imageId = new DockerRegistryV2Key(igorProperties.spinnaker.jedis.prefix, DockerRegistryCache.ID, account, image.repository, image.tag)
             UpdateType updateType = getUpdateType(cachedImages, imageId, image, trackDigests)
             if (updateType.updateCache) {
-                delta.add(new ImageDelta(imageId: imageId, image: image))
+                delta.add(new ImageDelta(imageId: imageId, image: image, sendEvent: updateType.sendEvent))
             }
         }
 
@@ -121,21 +121,25 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
     }
 
     private UpdateType getUpdateType(Set<String> cachedImages, String imageId, TaggedImage image, boolean trackDigests) {
-        UpdateType updateType = UpdateType.none()
-        if (imageId in cachedImages) {
-            if (trackDigests) {
-                String lastDigest = cache.getLastDigest(image.account, image.repository, image.tag)
-
-                if (lastDigest != image.digest) {
-                    log.info("Updated tagged image: {}: {}. Digest changed from [$lastDigest] -> [$image.digest].", kv("account", image.account), kv("image", imageId))
-                    // If either is null, there was an error retrieving the manifest in this or the previous cache cycle.
-                    updateType = image.digest != null && lastDigest != null ? UpdateType.full() : UpdateType.none()
-                }
-            }
-        } else {
-            updateType = UpdateType.full()
+        if (!cachedImages.contains(imageId)) {
+            // We have not seen this tag before; do a full update
+            return UpdateType.full()
         }
-        return updateType
+
+        if (!trackDigests) {
+            // We have seen this tag before and are not tracking digests, so there is nothing to update
+            return UpdateType.none()
+        }
+
+        String lastDigest = cache.getLastDigest(image.account, image.repository, image.tag)
+        if (lastDigest == image.digest || image.digest == null) {
+            return UpdateType.none();
+        }
+
+        log.info("Updated tagged image: {}: {}. Digest changed from [$lastDigest] -> [$image.digest].", kv("account", image.account), kv("image", imageId))
+        // If the last digest was null, update the cache but don't send events as we don't actually know if the digest
+        // changed. This is to prevent triggering multiple pipelines when trackDigests is initially turned on.
+        return lastDigest == null ? UpdateType.cacheOnly() : UpdateType.full()
     }
 
     /**
@@ -148,7 +152,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
             if (item != null) {
                 cache.setLastDigest(item.image.account, item.image.repository, item.image.tag, item.image.digest)
                 log.info("New tagged image: {}, {}. Digest is now [$item.image.digest].", kv("account", item.image.account), kv("image", item.imageId))
-                if (sendEvents) {
+                if (sendEvents && item.sendEvent) {
                     postEvent(delta.cachedImages, item.image, item.imageId)
                 } else {
                     registry.counter(missedNotificationId.withTags("monitor", getClass().simpleName, "reason", "fastForward")).increment()
@@ -203,6 +207,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
     private static class ImageDelta implements DeltaItem {
         String imageId
         TaggedImage image
+        boolean sendEvent = true
     }
 
     private static class UpdateType {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -116,23 +116,24 @@ class DockerMonitorSpec extends Specification {
 
         when:
         def taggedImage = new TaggedImage(tag: tag, account: "account", registry: "registry", repository: "repository", digest: digest)
-        def result = subject.shouldUpdateCache(cachedImages, keyFromTaggedImage(taggedImage), taggedImage, trackDigest)
+        def result = subject.getUpdateType(cachedImages, keyFromTaggedImage(taggedImage), taggedImage, trackDigest)
 
         then:
         dockerRegistryCache.getLastDigest(_, _, _) >> cachedDigest
-        assert result == updateCache
+        assert result.updateCache == updateCache
+        assert result.sendEvent == sendEvent
 
         where:
-        tag   | digest    | cachedDigest | trackDigest || updateCache
-        "tag" | "digest"  | "digest"     | false       || false
-        "new" | "digest"  | "digest"     | false       || true
-        "tag" | "digest2" | "digest"     | true        || true
-        "tag" | null      | "digest"     | true        || false
-        "tag" | "digest"  | null         | true        || false
-        "tag" | null      | null         | true        || false
-        "tag" | null      | "digest"     | false       || false
-        "tag" | "digest"  | null         | false       || false
-        "tag" | null      | null         | false       || false
+        tag   | digest    | cachedDigest | trackDigest || updateCache | sendEvent
+        "tag" | "digest"  | "digest"     | false       || false       | false
+        "new" | "digest"  | "digest"     | false       || true        | true
+        "tag" | "digest2" | "digest"     | true        || true        | true
+        "tag" | null      | "digest"     | true        || false       | false
+        "tag" | "digest"  | null         | true        || false       | false
+        "tag" | null      | null         | true        || false       | false
+        "tag" | null      | "digest"     | false       || false       | false
+        "tag" | "digest"  | null         | false       || false       | false
+        "tag" | null      | null         | false       || false       | false
     }
 
     @Unroll

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -129,7 +129,7 @@ class DockerMonitorSpec extends Specification {
         "new" | "digest"  | "digest"     | false       || true        | true
         "tag" | "digest2" | "digest"     | true        || true        | true
         "tag" | null      | "digest"     | true        || false       | false
-        "tag" | "digest"  | null         | true        || false       | false
+        "tag" | "digest"  | null         | true        || true        | false
         "tag" | null      | null         | true        || false       | false
         "tag" | null      | "digest"     | false       || false       | false
         "tag" | "digest"  | null         | false       || false       | false

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.igor.docker
 
+import com.netflix.discovery.DiscoveryClient
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.igor.IgorConfigurationProperties
 import com.netflix.spinnaker.igor.config.DockerRegistryProperties
@@ -24,6 +25,7 @@ import com.netflix.spinnaker.igor.docker.model.DockerRegistryAccounts
 import com.netflix.spinnaker.igor.docker.service.TaggedImage
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.history.model.DockerEvent
+import com.netflix.spinnaker.igor.polling.LockService
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -31,11 +33,12 @@ class DockerMonitorSpec extends Specification {
 
     def properties = new IgorConfigurationProperties()
     def registry = new NoopRegistry()
-    def discoveryClient = Optional.empty()
-    def lockService = Optional.empty()
+    Optional<DiscoveryClient> discoveryClient = Optional.empty()
+    Optional<LockService> lockService = Optional.empty()
     def dockerRegistryCache = Mock(DockerRegistryCache)
     def dockerRegistryAccounts = Mock(DockerRegistryAccounts)
     def echoService = Mock(EchoService)
+    Optional<DockerRegistryCacheV2KeysMigration> keysMigration = Optional.empty()
     def dockerRegistryProperties = new DockerRegistryProperties(enabled: true, itemUpperThreshold: 5)
 
     @Unroll
@@ -64,8 +67,7 @@ class DockerMonitorSpec extends Specification {
         })
 
         when: "should short circuit if `echoService` is not available"
-        new DockerMonitor(properties, registry, discoveryClient, lockService, dockerRegistryCache, dockerRegistryAccounts, Optional.empty(), Optional.empty(), dockerRegistryProperties)
-            .postEvent(["imageId"] as Set, taggedImage, "imageId")
+        createSubject().postEvent(["imageId"] as Set, taggedImage, "imageId")
 
         then:
         notThrown(NullPointerException)
@@ -89,8 +91,7 @@ class DockerMonitorSpec extends Specification {
         )
 
         when:
-        new DockerMonitor(properties, registry, discoveryClient, lockService, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.empty(), dockerRegistryProperties)
-            .postEvent(["job1"] as Set, taggedImage, "imageId")
+        createSubject().postEvent(["job1"] as Set, taggedImage, "imageId")
 
         then:
         1 * echoService.postEvent({ DockerEvent event ->
@@ -114,17 +115,24 @@ class DockerMonitorSpec extends Specification {
         ]
 
         when:
+        def taggedImage = new TaggedImage(tag: tag, account: "account", registry: "registry", repository: "repository", digest: digest)
         def result = subject.shouldUpdateCache(cachedImages, keyFromTaggedImage(taggedImage), taggedImage, trackDigest)
 
         then:
-        dockerRegistryCache.getLastDigest(_, _, _) >> { "digest" }
+        dockerRegistryCache.getLastDigest(_, _, _) >> cachedDigest
         assert result == updateCache
 
         where:
-        taggedImage                                                                                                        | trackDigest || updateCache
-        new TaggedImage(tag: "tag", account: "account", registry: "registry", repository: "repository", digest: "digest")  | false       || false
-        new TaggedImage(tag: "new", account: "account", registry: "registry", repository: "repository", digest: "digest")  | false       || true
-        new TaggedImage(tag: "tag", account: "account", registry: "registry", repository: "repository", digest: "digest2") | true        || true
+        tag   | digest    | cachedDigest | trackDigest || updateCache
+        "tag" | "digest"  | "digest"     | false       || false
+        "new" | "digest"  | "digest"     | false       || true
+        "tag" | "digest2" | "digest"     | true        || true
+        "tag" | null      | "digest"     | true        || false
+        "tag" | "digest"  | null         | true        || false
+        "tag" | null      | null         | true        || false
+        "tag" | null      | "digest"     | false       || false
+        "tag" | "digest"  | null         | false       || false
+        "tag" | null      | null         | false       || false
     }
 
     @Unroll
@@ -154,8 +162,8 @@ class DockerMonitorSpec extends Specification {
         'partition4' | null              || null
     }
 
-    private DockerMonitor createSubject(Optional<EchoService> echoService) {
-        return new DockerMonitor(properties, registry, discoveryClient, lockService, dockerRegistryCache, dockerRegistryAccounts, echoService, Optional.empty(), dockerRegistryProperties)
+    private DockerMonitor createSubject() {
+        return new DockerMonitor(properties, registry, discoveryClient, lockService, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), keysMigration, dockerRegistryProperties)
     }
 
     private static String keyFromTaggedImage(TaggedImage taggedImage) {


### PR DESCRIPTION
We currently don't update the docker image cache when either the prior or the current digest is null. This means that any tag that was present before trackDigests was enabled will always have its digest set to null. Change this so we do set the digest any time the new one is not null.

In order to avoid triggering multiple pipelines when turning trackDigests on, we won't send an event to echo when updating from a null to non-null digest (as we don't actually know if it was updated), we'll only update the cache.