### PR TITLE
fix(jenkins): guard against NPE on parameter definitions

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/ParameterDefinition.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/ParameterDefinition.java
@@ -31,11 +31,17 @@ public class ParameterDefinition {
 
     @XmlElement(name = "defaultValue")
     public String getDefaultValue() {
+        if (defaultParameterValue == null) {
+            return null;
+        }
         return defaultParameterValue.getValue();
     }
 
     @XmlElement(name = "defaultName")
     public String getDefaultName() {
+        if (defaultParameterValue == null) {
+            return null;
+        }
         return defaultParameterValue.getName();
     }
 }


### PR DESCRIPTION
Some Jenkins parameter types (e.g. git parameters, it's a thing, promise) do not have the `<defaultParameterValue>`, so these defaults blow up.