### PR TITLE
feat(jenkins): Support for overriding TrustStore used by Jenkins clients

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
@@ -22,6 +22,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.validation.annotation.Validated
 
 import javax.validation.Valid
+import java.security.KeyStore
+
 /**
  * Helper class to map masters in properties file into a validated property map
  */
@@ -53,5 +55,11 @@ class JenkinsProperties {
         String token
 
         Integer itemUpperThreshold;
+
+        String trustStore
+        String trustStoreType = KeyStore.getDefaultType()
+        String trustStorePassword
+
+        Boolean skipHostnameVerification = false
     }
 }


### PR DESCRIPTION
```
jenkins:
  masters:
    -
      address: "https://jenkins.com"
      name: spinnaker
      trustStore: "*"
```

or:

```
jenkins:
  masters:
    -
      address: "https://jenkins.com"
      name: spinnaker
      trustStore: /path/to/truststore.p12
      trustStoreType: PKCS12
      trustStorePassword: my_truststore_password
```
