### PR TITLE
feat(jenkins/queue): add ready flag to queue response

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/QueuedJob.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/QueuedJob.groovy
@@ -29,6 +29,11 @@ class QueuedJob {
     Integer getNumber() {
         return executable?.number
     }
+
+    @XmlElement(name = 'ready')
+    boolean getReady() {
+        executable?.number ? true : false
+    }
 }
 
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -116,7 +116,7 @@ class BuildControllerSpec extends Specification {
         then:
         1 * buildMasters.filteredMap(BuildServiceProvider.JENKINS) >> [(MASTER): jenkinsService]
         1 * buildMasters.map >> [(MASTER): jenkinsService]
-        response.contentAsString == "{\"executable\":{\"number\":${QUEUED_JOB_NUMBER}},\"number\":${QUEUED_JOB_NUMBER}}"
+        response.contentAsString == "{\"executable\":{\"number\":${QUEUED_JOB_NUMBER}},\"ready\":true,\"number\":${QUEUED_JOB_NUMBER}}"
     }
 
     void 'deserialize a queue response'() {
@@ -159,6 +159,7 @@ class BuildControllerSpec extends Specification {
 
         then:
         queuedJob.number == null
+        !queuedJob.ready
     }
 
     void 'get a list of builds for a job'() {


### PR DESCRIPTION
Currently one has to check for a null to know if a build number is set
or not. Setting a ready Boolean will make it more clear that jenkins is
spending some time setting a build number for a queued item.
