### PR TITLE
fix(jenkins): Use new location for revision information

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.groovy
@@ -17,9 +17,11 @@
 package com.netflix.spinnaker.igor.build.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import groovy.transform.EqualsAndHashCode
 
 import java.time.Instant
 
+@EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 class GenericGitRevision {
     String name

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -50,7 +50,11 @@ interface JenkinsClient {
     @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(totalCount)]&tree=actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url,fullDisplayName,artifacts[displayPath,fileName,relativePath]')
     Build getBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
 
-    @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(lastBuiltRevision)]&tree=actions[remoteUrls,lastBuiltRevision[branch[name,SHA1]]]')
+    // The location of the SCM details in the build xml changed in version 4.0.0 of the jenkins-git plugin; see the
+    // header comment in com.netflix.spinnaker.igor.jenkins.client.model.ScmDetails for more information.
+    // The exclude and tree parameters to this call must continue to support both formats to remain compatible with
+    // all versions of the plugin.
+    @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(build|lastBuiltRevision)]&tree=actions[remoteUrls,lastBuiltRevision[branch[name,SHA1]],build[revision[branch[name,SHA1]]]]')
     ScmDetails getGitDetails(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
 
     @GET('/job/{jobName}/lastCompletedBuild/api/xml')

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/ScmDetails.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/ScmDetails.groovy
@@ -21,9 +21,39 @@ import com.netflix.spinnaker.igor.build.model.GenericGitRevision
 import groovy.transform.CompileStatic
 
 import javax.xml.bind.annotation.XmlElement
+import java.util.stream.Collectors
 
 /**
  * Represents git details
+ *
+ * The serialization of these details in the Jenkins build XML changed in version 4.0.0 of the jenkins-git plugin.
+ *
+ * Prior to 4.0.0, the format was:
+ * <action _class="hudson.plugins.git.util.BuildData">
+ *   <lastBuiltRevision>
+ *     <branch>
+ *       <SHA1>943a702d06f34599aee1f8da8ef9f7296031d699</SHA1>
+ *       <name>refs/remotes/origin/master</name>
+ *     </branch>
+ *   </lastBuiltRevision>
+ *   <remoteUrl>some-url</remoteUrl>
+ * </action>
+ *
+ * As of version 4.0.0, the format is:
+ * <action _class="hudson.plugins.git.util.BuildDetails">
+ *   <build>
+ *     <revision>
+ *       <branch>
+ *         <SHA1>943a702d06f34599aee1f8da8ef9f7296031d699</SHA1>
+ *         <name>refs/remotes/origin/master</name>
+ *       </branch>
+ *     </revision>
+ *     <remoteUrl>some-url</remoteUrl>
+ *   </build>
+ * </action>
+ *
+ * The code in this module should remain compatible with both formats to ensure that SCM info is populated in Spinnaker
+ * regardless of which version of the jenkins-git plugin is being used.
  */
 @CompileStatic
 class ScmDetails {
@@ -39,26 +69,36 @@ class ScmDetails {
         }
 
         for (Action action : actions) {
-            if (action?.lastBuiltRevision?.branch?.name) {
-                genericGitRevisions.addAll(action.lastBuiltRevision.branch.collect() { Branch branch ->
+            Revision revision = action?.lastBuiltRevision ?: action?.build?.revision
+            if (revision?.branch?.name) {
+                genericGitRevisions.addAll(revision.branch.collect() { Branch branch ->
                     new GenericGitRevision(branch.name, branch.name.split('/').last(), branch.sha1, action.remoteUrl)
                 })
             }
         }
 
-        return genericGitRevisions
+        // If the same revision appears in both the old and the new location in the XML, we only want to return it once
+        return genericGitRevisions.stream().distinct().collect(Collectors.toList())
     }
 }
 
 class Action {
     @XmlElement(required = false)
-    LastBuiltRevision lastBuiltRevision
+    Revision lastBuiltRevision
+
+    @XmlElement(required = false)
+    ScmBuild build
 
     @XmlElement(required = false)
     String remoteUrl
 }
 
-class LastBuiltRevision {
+class ScmBuild {
+    @XmlElement(required = false)
+    Revision revision
+}
+
+class Revision {
     @JacksonXmlElementWrapper(useWrapping = false)
     @XmlElement(name = "branch")
     List<Branch> branch


### PR DESCRIPTION
The jenkins-git plugin is removing the BuildData structure from the results of the build as of version 4.0.0 of the plugin. Spinnaker uses that data to populate the 'scm' information for the build, so users who have upgraded their jenkins-git plugin are not getting any SCM information in Spinnaker.

The replacement for BuildData is a new structure BuildDetails. All of the information we were fetching from BuildData is available in BuildDetails.

Update igor to look for the SCM information in BuildDetails if nothing is found in BuildData. This change is backwards-compatible as the new BuildDetails location is only queried if there is nothing in the old BuildData location.

Closes spinnaker/spinnaker#3927