### PR TITLE
feat(buildmasters): Permission support for build masters (CI's)

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -19,6 +19,7 @@ dependencies {
     spinnaker.group "bootWeb"
     spinnaker.group "jackson"
     spinnaker.group "retrofitDefault"
+    spinnaker.group "fiat"
 
     compile spinnaker.dependency("googleCloudBuild")
     compile spinnaker.dependency("kork")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.igor.config;
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -25,7 +26,7 @@ import java.util.List;
 
 @ConfigurationProperties(prefix = "gitlab-ci")
 @Validated
-public class GitlabCiProperties {
+public class GitlabCiProperties implements BuildServerProperties<GitlabCiProperties.GitlabCiHost> {
     private int cachedJobTTLDays = 60;
 
     @Valid
@@ -48,7 +49,7 @@ public class GitlabCiProperties {
         this.masters = masters;
     }
 
-    public static class GitlabCiHost {
+    public static class GitlabCiHost implements BuildServerProperties.Host {
         @NotEmpty
         private String name;
         @NotEmpty
@@ -57,6 +58,7 @@ public class GitlabCiProperties {
         private boolean limitByMembership = false;
         private boolean limitByOwnership = true;
         private Integer itemUpperThreshold;
+        private Permissions.Builder permissions = new Permissions.Builder();
 
         public String getName() {
             return name;
@@ -112,6 +114,14 @@ public class GitlabCiProperties {
 
         public void setItemUpperThreshold(Integer itemUpperThreshold) {
             this.itemUpperThreshold = itemUpperThreshold;
+        }
+
+        public Permissions.Builder getPermissions() {
+            return permissions;
+        }
+
+        public void setPermissions(Permissions.Builder permissions) {
+            this.permissions = permissions;
         }
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.igor.config
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions
 import groovy.transform.CompileStatic
 import org.hibernate.validator.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -30,11 +31,11 @@ import java.security.KeyStore
 @CompileStatic
 @ConfigurationProperties(prefix = 'jenkins')
 @Validated
-class JenkinsProperties {
+class JenkinsProperties implements BuildServerProperties<JenkinsProperties.JenkinsHost> {
     @Valid
     List<JenkinsHost> masters
 
-    static class JenkinsHost {
+    static class JenkinsHost implements BuildServerProperties.Host {
         @NotEmpty
         String name
 
@@ -61,5 +62,7 @@ class JenkinsProperties {
         String trustStorePassword
 
         Boolean skipHostnameVerification = false
+
+        Permissions.Builder permissions = new Permissions.Builder()
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/WerckerConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/WerckerConfig.groovy
@@ -38,7 +38,7 @@ import retrofit.client.OkClient
 @CompileStatic
 @ConditionalOnProperty("wercker.enabled")
 @EnableConfigurationProperties(WerckerProperties)
-public class WerckerConfig {
+class WerckerConfig {
     @Bean
     Map<String, WerckerService> werckerMasters(
         BuildServices buildServices,
@@ -46,10 +46,10 @@ public class WerckerConfig {
         IgorConfigurationProperties igorConfigurationProperties,
         @Valid WerckerProperties werckerProperties) {
         log.debug "creating werckerMasters"
-        Map<String, WerckerService> werckerMasters = ( werckerProperties?.masters?.collectEntries { WerckerProperties.WerckerHost host ->
+        Map<String, WerckerService> werckerMasters = werckerProperties?.masters?.collectEntries { WerckerHost host ->
             log.debug "bootstrapping Wercker ${host.address} as ${host.name}"
-            [(host.name): new WerckerService(host, cache, werckerClient(host, igorConfigurationProperties.getClient().timeout))]
-        })
+            [(host.name): new WerckerService(host, cache, werckerClient(host, igorConfigurationProperties.getClient().timeout), host.permissions.build())]
+        }
 
         buildServices.addServices(werckerMasters)
         werckerMasters

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/WerckerProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/WerckerProperties.groovy
@@ -8,22 +8,23 @@
  */
 package com.netflix.spinnaker.igor.config
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions
 import groovy.transform.CompileStatic
-
 import org.hibernate.validator.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 import javax.validation.Valid
+
 /**
  * Helper class to map masters in properties file into a validated property map
  */
 @CompileStatic
 @ConfigurationProperties(prefix = 'wercker')
-class WerckerProperties {
+class WerckerProperties implements BuildServerProperties<WerckerProperties.WerckerHost> {
     @Valid
     List<WerckerHost> masters
 
-    static class WerckerHost {
+    static class WerckerHost implements BuildServerProperties.Host {
         @NotEmpty
         String name
 
@@ -35,5 +36,7 @@ class WerckerProperties {
         String token
 
         Integer itemUpperThreshold
+
+        Permissions.Builder permissions = new Permissions.Builder()
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/filters/IgorCorsFilter.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/filters/IgorCorsFilter.groovy
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpServletResponse
  */
 @Component
 @CompileStatic
-class CorsFilter implements Filter {
+class IgorCorsFilter implements Filter {
 
     void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
         HttpServletResponse response = (HttpServletResponse) res

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.igor.gitlabci.service;
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.igor.build.model.GenericBuild;
 import com.netflix.spinnaker.igor.build.model.GenericGitRevision;
 import com.netflix.spinnaker.igor.gitlabci.client.GitlabCiClient;
@@ -22,28 +23,38 @@ import com.netflix.spinnaker.igor.gitlabci.client.model.Pipeline;
 import com.netflix.spinnaker.igor.gitlabci.client.model.PipelineSummary;
 import com.netflix.spinnaker.igor.gitlabci.client.model.Project;
 import com.netflix.spinnaker.igor.model.BuildServiceProvider;
-import com.netflix.spinnaker.igor.service.BuildService;
+import com.netflix.spinnaker.igor.service.BuildOperations;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class GitlabCiService implements BuildService {
-    private GitlabCiClient client;
-    private String address;
-    private boolean limitByMembership;
-    private boolean limitByOwnership;
+public class GitlabCiService implements BuildOperations {
+    private final String name;
+    private final GitlabCiClient client;
+    private final String address;
+    private final boolean limitByMembership;
+    private final boolean limitByOwnership;
+    private final Permissions permissions;
 
-    public GitlabCiService(GitlabCiClient client, String address, boolean limitByMembership, boolean limitByOwnership) {
+    public GitlabCiService(GitlabCiClient client, String name, String address, boolean limitByMembership,
+                           boolean limitByOwnership, Permissions permissions) {
         this.client = client;
+        this.name = name;
         this.address = address;
         this.limitByMembership = limitByMembership;
         this.limitByOwnership = limitByOwnership;
+        this.permissions = permissions;
     }
 
     @Override
-    public BuildServiceProvider buildServiceProvider() {
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public BuildServiceProvider getBuildServiceProvider() {
         return BuildServiceProvider.GITLAB_CI;
     }
 
@@ -65,6 +76,11 @@ public class GitlabCiService implements BuildService {
     @Override
     public int triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Permissions getPermissions() {
+        return permissions;
     }
 
     public List<Project> getProjects() {
@@ -97,7 +113,7 @@ public class GitlabCiService implements BuildService {
 
     private static void isValidPageSize(int perPage) {
         if (perPage > GitlabCiClient.MAX_PAGE_SIZE) {
-            throw new IllegalArgumentException("Gitlab API call page size should be less than " + String.valueOf(GitlabCiClient.MAX_PAGE_SIZE) + " but was " + String.valueOf(perPage));
+            throw new IllegalArgumentException("Gitlab API call page size should be less than " + GitlabCiClient.MAX_PAGE_SIZE + " but was " + perPage);
         }
     }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildOperations.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildOperations.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.service;
+
+import com.netflix.spinnaker.igor.build.model.GenericBuild;
+import com.netflix.spinnaker.igor.build.model.GenericGitRevision;
+
+import java.util.List;
+import java.util.Map;
+
+public interface BuildOperations extends BuildService {
+    List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber);
+    GenericBuild getGenericBuild(String job, int buildNumber);
+    int triggerBuildWithParameters(String job, Map<String, String> queryParameters);
+    List<?> getBuilds(String job);
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildOperations.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildOperations.java
@@ -23,9 +23,43 @@ import com.netflix.spinnaker.igor.build.model.GenericGitRevision;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Interface representing a Build Service (CI) host, the permissions needed to access it, and build operations on the
+ * host
+ */
 public interface BuildOperations extends BuildService {
-    List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber);
-    GenericBuild getGenericBuild(String job, int buildNumber);
-    int triggerBuildWithParameters(String job, Map<String, String> queryParameters);
-    List<?> getBuilds(String job);
+  /**
+   * Get a list of the Spinnaker representation of the Git commits relevant for the given build
+   *
+   * @param job The name of the job
+   * @param buildNumber The build number
+   * @return A list of git revisions relevant for the build
+   */
+  List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber);
+
+  /**
+   * Return all information of a given build
+   *
+   * @param job The name of the job
+   * @param buildNumber The build number
+   * @return A Spinnaker representation of a build
+   */
+  GenericBuild getGenericBuild(String job, int buildNumber);
+
+  /**
+   * Trigger a build of a given job on the build service host
+   *
+   * @param job The name of the job to be triggered
+   * @param queryParameters A key-value map of parameters to be injected into the build
+   * @return An id identifying the build; preferably the build number of the build
+   */
+  int triggerBuildWithParameters(String job, Map<String, String> queryParameters);
+
+  /**
+   * Returns all/relevant builds for the given job.
+   *
+   * @param job The name of the job
+   * @return A list of builds
+   */
+  List<?> getBuilds(String job);
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildProperties.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildProperties.java
@@ -16,8 +16,20 @@
 
 package com.netflix.spinnaker.igor.service;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
+/**
+ * Interface to be implemented by build service providers that supports a way of defining properties in a build that
+ * will be injected into the pipeline context of pipeline executions triggered by the given build
+ */
 public interface BuildProperties {
-    Map<String, ?> getBuildProperties(String job, int buildNumber, String fileName);
+    /**
+     * Get build properties defined in the given build
+     * @param job The name of the job
+     * @param buildNumber The build number
+     * @param fileName The file name containing the properties. Not all providers require this parameter.
+     * @return A map of properties
+     */
+    Map<String, ?> getBuildProperties(String job, int buildNumber, @Nullable String fileName);
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.java
@@ -19,42 +19,60 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.igor.model.BuildServiceProvider;
 
+/**
+ * Interface representing a Build Service host (CI) and the permissions needed to access it. Most implementations should
+ * implement the {@link BuildOperations} interface instead.
+ */
 public interface BuildService {
-    String getName();
+  /**
+   * Get the name of the build service host
+   * @return The name of the build service
+   */
+  String getName();
 
-    BuildServiceProvider getBuildServiceProvider();
+  /**
+   * Get the type of the build service
+   * @return The type of the build service
+   */
+  BuildServiceProvider getBuildServiceProvider();
 
-    Permissions getPermissions();
+  /**
+   * Get the permissions of the build service. Read permissions are needed to be able to interact with the build service
+   * host and use it as a trigger in Spinnaker. Write permissions are needed to trigger CI builds/jobs from a Spinnaker
+   * pipeline.
+   * @return The permissions needed to access this build service host
+   */
+  Permissions getPermissions();
 
-    @JsonIgnore
-    default BuildServiceView getView() {
-        return new BuildServiceView(this);
+  @JsonIgnore
+  default BuildServiceView getView() {
+    return new BuildServiceView(this);
+  }
+
+  class BuildServiceView implements BuildService {
+    final String name;
+    final BuildServiceProvider buildServiceProvider;
+    final Permissions permissions;
+
+    private BuildServiceView(BuildService buildService) {
+      this.name = buildService.getName();
+      this.buildServiceProvider = buildService.getBuildServiceProvider();
+      this.permissions = buildService.getPermissions();
     }
 
-    class BuildServiceView implements BuildService {
-        final String name;
-        final BuildServiceProvider buildServiceProvider;
-        final Permissions permissions;
-
-        private BuildServiceView(BuildService buildService) {
-            this.name = buildService.getName();
-            this.buildServiceProvider = buildService.getBuildServiceProvider();
-            this.permissions = buildService.getPermissions();
-        }
-
-        @Override
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public BuildServiceProvider getBuildServiceProvider() {
-            return buildServiceProvider;
-        }
-
-        @Override
-        public Permissions getPermissions() {
-            return permissions;
-        }
+    @Override
+    public String getName() {
+      return name;
     }
+
+    @Override
+    public BuildServiceProvider getBuildServiceProvider() {
+      return buildServiceProvider;
+    }
+
+    @Override
+    public Permissions getPermissions() {
+      return permissions;
+    }
+  }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildService.java
@@ -15,21 +15,46 @@
  */
 package com.netflix.spinnaker.igor.service;
 
-import com.netflix.spinnaker.igor.build.model.GenericBuild;
-import com.netflix.spinnaker.igor.build.model.GenericGitRevision;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.igor.model.BuildServiceProvider;
 
-import java.util.List;
-import java.util.Map;
-
 public interface BuildService {
-    BuildServiceProvider buildServiceProvider();
+    String getName();
 
-    List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber);
+    BuildServiceProvider getBuildServiceProvider();
 
-    GenericBuild getGenericBuild(String job, int buildNumber);
+    Permissions getPermissions();
 
-    int triggerBuildWithParameters(String job, Map<String, String> queryParameters);
+    @JsonIgnore
+    default BuildServiceView getView() {
+        return new BuildServiceView(this);
+    }
 
-    List<?> getBuilds(String job);
+    class BuildServiceView implements BuildService {
+        final String name;
+        final BuildServiceProvider buildServiceProvider;
+        final Permissions permissions;
+
+        private BuildServiceView(BuildService buildService) {
+            this.name = buildService.getName();
+            this.buildServiceProvider = buildService.getBuildServiceProvider();
+            this.permissions = buildService.getPermissions();
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public BuildServiceProvider getBuildServiceProvider() {
+            return buildServiceProvider;
+        }
+
+        @Override
+        public Permissions getPermissions() {
+            return permissions;
+        }
+    }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildServices.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildServices.java
@@ -24,13 +24,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class BuildServices {
-    private final Map<String, BuildService> buildServices = new HashMap<>();
+    private final Map<String, BuildOperations> buildServices = new HashMap<>();
 
-    public void addServices(Map<String, ? extends BuildService> services) {
+    public void addServices(Map<String, ? extends BuildOperations> services) {
         buildServices.putAll(services);
     }
 
-    public BuildService getService(String name) {
+    public BuildOperations getService(String name) {
         return buildServices.get(name);
     }
 
@@ -41,9 +41,15 @@ public class BuildServices {
     public List<String> getServiceNames(BuildServiceProvider buildServiceProvider) {
         return buildServices.entrySet().stream()
             .filter(e -> e.getValue() != null)
-            .filter(e -> e.getValue().buildServiceProvider() == buildServiceProvider)
+            .filter(e -> e.getValue().getBuildServiceProvider() == buildServiceProvider)
             .map(Map.Entry::getKey)
             .sorted()
+            .collect(Collectors.toList());
+    }
+
+    public List<BuildService> getAllBuildServices() {
+        return buildServices.values().stream()
+            .map(BuildOperations::getView)
             .collect(Collectors.toList());
     }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/BuildServerProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/BuildServerProperties.java
@@ -21,12 +21,76 @@ import com.netflix.spinnaker.fiat.model.resources.Permissions;
 
 import java.util.List;
 
+/**
+ * Interface for representing the properties of a Build Service (CI) provider in Spinnaker.
+ * An example configuration file could look like this:
+ *
+ * <pre>{@code
+ * someProvider:
+ *   masters:
+ *   - name: someProvider-host1
+ *     address: https://foo.com/api
+ *     permissions:
+ *       READ:
+ *       - foo
+ *       - bar
+ *       WRITE:
+ *       - bar
+ *   - name: someProvider-host2
+ *     address: https://bar.com/api}</pre>
+ *
+ * @param <T> The implementation type of each host
+ */
 public interface BuildServerProperties<T extends BuildServerProperties.Host> {
-    List<T> getMasters();
 
-    interface Host {
-        String getName();
-        String getAddress();
-        Permissions.Builder getPermissions();
-    }
+  /**
+   * Returns a list of the build service hosts configured with this provider
+   * @return The build service hosts
+   */
+  List<T> getMasters();
+
+  /**
+   * Interface for representing the properties of a specific build service host
+   */
+  interface Host {
+    /**
+     * Get the name of the build service host
+     * @return The name of the build service host
+     */
+    String getName();
+
+    /**
+     * Get the address of the build service host
+     * @return The address of the build service host
+     */
+    String getAddress();
+
+    /**
+     * Get the permissions needed to access this build service host. Read permissions are needed to trigger Spinnaker
+     * pipelines on successful builds on the build service host (if set, users without the correct permissions won't see
+     * the host in Spinnaker), while write permissions are needed to trigger jobs/builds on the build service host from
+     * Spinnaker. Can be left blank; If so, the host will not be protected. An example configuration should look like
+     * this:
+     * <pre>{@code
+     * someProvider:
+     *   masters:
+     *   - name: someProvider-host1
+     *     address: https://foo.com/api
+     *     permissions:
+     *       READ:
+     *       - foo
+     *       - bar
+     *       WRITE:
+     *       - bar
+     *   - name: someProvider-host2
+     *     address: https://bar.com/api}</pre>
+     * In the example above, users with the foo or bar roles will be able to see <code>someProvider-host1</code> and use
+     * it as a trigger, users with the bar role will additionally be able to trigger builds on the CI host. Users
+     * without these roles will not see <code>someProvider-host1</code> in Spinnaker at all. All users will be able to
+     * access <code>someProvider-host2</code> without limitations.
+     *
+     * @return The permissions needed to access this build service host
+     */
+    Permissions.Builder getPermissions();
+  }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/BuildServerProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/BuildServerProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+
+import java.util.List;
+
+public interface BuildServerProperties<T extends BuildServerProperties.Host> {
+    List<T> getMasters();
+
+    interface Host {
+        String getName();
+        String getAddress();
+        Permissions.Builder getPermissions();
+    }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ConcourseProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ConcourseProperties.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.igor.config;
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -55,5 +56,7 @@ public class ConcourseProperties {
      * this number of recent builds.
      */
     private Integer buildLookbackLimit = 200;
+
+    private Permissions.Builder permissions = new Permissions.Builder();
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisConfig.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.igor.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.igor.IgorConfigurationProperties;
 import com.netflix.spinnaker.igor.service.ArtifactDecorator;
 import com.netflix.spinnaker.igor.service.BuildServices;
@@ -65,7 +66,7 @@ public class TravisConfig {
                 log.info("bootstrapping {} as {}", host.getAddress(), travisName);
 
                 TravisClient client = travisClient(host.getAddress(), igorConfigurationProperties.getClient().getTimeout(), objectMapper);
-                return travisService(travisName, host.getBaseUrl(), host.getGithubToken(), host.getNumberOfRepositories(), client, travisCache, artifactDecorator, (travisProperties == null ? null : travisProperties.getRegexes()));
+                return travisService(travisName, host.getBaseUrl(), host.getGithubToken(), host.getNumberOfRepositories(), client, travisCache, artifactDecorator, (travisProperties == null ? null : travisProperties.getRegexes()), host.getPermissions().build());
             })
             .collect(Collectors.toMap(TravisService::getGroupKey, Function.identity()));
 
@@ -73,8 +74,8 @@ public class TravisConfig {
         return travisMasters;
     }
 
-    public static TravisService travisService(String travisHostId, String baseUrl, String githubToken, int numberOfRepositories, TravisClient travisClient, TravisCache travisCache, Optional<ArtifactDecorator> artifactDecorator, Collection<String> artifactRexeges) {
-        return new TravisService(travisHostId, baseUrl, githubToken, numberOfRepositories, travisClient, travisCache, artifactDecorator, artifactRexeges);
+    private static TravisService travisService(String travisHostId, String baseUrl, String githubToken, int numberOfRepositories, TravisClient travisClient, TravisCache travisCache, Optional<ArtifactDecorator> artifactDecorator, Collection<String> artifactRexeges, Permissions permissions) {
+        return new TravisService(travisHostId, baseUrl, githubToken, numberOfRepositories, travisClient, travisCache, artifactDecorator, artifactRexeges, permissions);
     }
 
     public static TravisClient travisClient(String address, int timeout, ObjectMapper objectMapper) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.igor.config;
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -24,7 +25,7 @@ import javax.validation.Valid;
 import java.util.List;
 
 @ConfigurationProperties(prefix = "travis")
-public class TravisProperties {
+public class TravisProperties implements BuildServerProperties<TravisProperties.TravisHost> {
     private long newBuildGracePeriodSeconds = 10;
     private boolean repositorySyncEnabled = false;
     private int cachedJobTTLDays = 60;
@@ -77,7 +78,7 @@ public class TravisProperties {
         this.newBuildGracePeriodSeconds = newBuildGracePeriodSeconds;
     }
 
-    public static class TravisHost {
+    public static class TravisHost implements BuildServerProperties.Host {
         @NotEmpty
         private String name;
         @NotEmpty
@@ -88,6 +89,7 @@ public class TravisProperties {
         private String githubToken;
         private int numberOfRepositories = 25;
         private Integer itemUpperThreshold;
+        private Permissions.Builder permissions = new Permissions.Builder();
 
         public String getName() {
             return name;
@@ -137,5 +139,12 @@ public class TravisProperties {
             this.itemUpperThreshold = itemUpperThreshold;
         }
 
+        public Permissions.Builder getPermissions() {
+            return permissions;
+        }
+
+        public void setPermissions(Permissions.Builder permissions) {
+            this.permissions = permissions;
+        }
     }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -16,17 +16,21 @@
 
 package com.netflix.spinnaker.igor.build
 
-import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.config.JenkinsConfig
-import com.netflix.spinnaker.igor.jenkins.client.model.*
+import com.netflix.spinnaker.igor.jenkins.client.model.Build
+import com.netflix.spinnaker.igor.jenkins.client.model.BuildArtifact
+import com.netflix.spinnaker.igor.jenkins.client.model.JobConfig
+import com.netflix.spinnaker.igor.jenkins.client.model.ParameterDefinition
+import com.netflix.spinnaker.igor.jenkins.client.model.QueuedJob
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
+import com.netflix.spinnaker.igor.service.BuildOperations
 import com.netflix.spinnaker.igor.service.BuildServices
-import com.netflix.spinnaker.igor.service.BuildService
 import com.netflix.spinnaker.igor.travis.service.TravisService
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.squareup.okhttp.mockwebserver.MockWebServer
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -37,10 +41,10 @@ import retrofit.client.Header
 import retrofit.client.Response
 import spock.lang.Shared
 import spock.lang.Specification
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-
 /**
  * Tests for BuildController
  */
@@ -51,9 +55,9 @@ class BuildControllerSpec extends Specification {
     BuildServices buildServices
     BuildCache cache
     JenkinsService jenkinsService
-    BuildService service
+    BuildOperations service
     TravisService travisService
-    Map<String, BuildService> serviceList
+    Map<String, BuildOperations> serviceList
     def retrySupport = Spy(RetrySupport) {
         _ * sleep(_) >> { /* do nothing */ }
     }
@@ -76,11 +80,11 @@ class BuildControllerSpec extends Specification {
     }
 
     void setup() {
-        service = Mock(BuildService)
+        service = Mock(BuildOperations)
         jenkinsService = Mock(JenkinsService)
-        jenkinsService.buildServiceProvider() >> BuildServiceProvider.JENKINS
+        jenkinsService.getBuildServiceProvider() >> BuildServiceProvider.JENKINS
         travisService = Mock(TravisService)
-        travisService.buildServiceProvider() >> BuildServiceProvider.TRAVIS
+        travisService.getBuildServiceProvider() >> BuildServiceProvider.TRAVIS
         buildServices = new BuildServices()
         buildServices.addServices([
             (SERVICE) : service,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -16,13 +16,15 @@
 
 package com.netflix.spinnaker.igor.build
 
+import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.igor.config.GitlabCiProperties
 import com.netflix.spinnaker.igor.config.JenkinsConfig
 import com.netflix.spinnaker.igor.config.JenkinsProperties
 import com.netflix.spinnaker.igor.config.TravisProperties
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
-import com.netflix.spinnaker.igor.service.BuildService
+import com.netflix.spinnaker.igor.service.BuildOperations
 import com.netflix.spinnaker.igor.service.BuildServices
 import com.netflix.spinnaker.igor.travis.service.TravisService
 import com.netflix.spinnaker.igor.wercker.WerckerService
@@ -38,7 +40,6 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-
 /**
  * tests for the info controller
  */
@@ -69,7 +70,7 @@ class InfoControllerSpec extends Specification {
         server = new MockWebServer()
     }
 
-    void createMocks(Map<String, BuildService> buildServices) {
+    void createMocks(Map<String, BuildOperations> buildServices) {
         cache = Mock(BuildCache)
         this.buildServices = new BuildServices()
         this.buildServices.addServices(buildServices)
@@ -97,24 +98,69 @@ class InfoControllerSpec extends Specification {
         response.contentAsString == '["build.buildServices.blah","master1","master2"]'
     }
 
-    void 'is able to get a list of buildMasters with urls'() {
+    void 'is able to get a list of buildServices with permissions'() {
         given:
-        createMocks([:])
+        JenkinsService jenkinsService1 = new JenkinsService('jenkins-foo', null, false, Permissions.EMPTY)
+        JenkinsService jenkinsService2 = new JenkinsService('jenkins-bar', null, false,
+            new Permissions.Builder()
+                .add(Authorization.READ, ['group-1', 'group-2'])
+                .add(Authorization.WRITE, 'group-2').build())
+        TravisService travisService = new TravisService('travis-baz', null, null, 100, null, null, Optional.empty(), [],
+            new Permissions.Builder()
+                .add(Authorization.READ, ['group-3', 'group-4'])
+                .add(Authorization.WRITE, 'group-3').build())
+        createMocks([
+            'jenkins-foo': jenkinsService1,
+            'jenkins-bar': jenkinsService2,
+            'travis-baz': travisService
+        ])
 
         when:
-        MockHttpServletResponse response = mockMvc.perform(get('/masters')
-            .param("showUrl", "true")
+        MockHttpServletResponse response = mockMvc.perform(get('/buildServices')
             .accept(MediaType.APPLICATION_JSON))
             .andReturn()
             .response
 
         then:
-        1 * jenkinsProperties.masters >> [['name': 'jenkins-foo', 'address': 'http://jenkins-bar']]
-        1 * travisProperties.masters >> [['name': 'travis-foo', 'address': 'http://travis-bar']]
-        1 * gitlabCiProperties.masters >> [['name': 'gitlab-foo', 'address': 'http://gitlab-bar']]
-        response.getContentAsString() == '[{"name":"jenkins-foo","address":"http://jenkins-bar"},' +
-            '{"name":"travis-foo","address":"http://travis-bar"},' +
-            '{"name":"gitlab-foo","address":"http://gitlab-bar"}]'
+        def jsonResponse = new JsonSlurper().parseText(response.getContentAsString())
+        jsonResponse == new JsonSlurper().parseText(
+            """
+            [
+                {
+                    "name": "jenkins-foo",
+                    "buildServiceProvider": "JENKINS",
+                    "permissions": {}
+                },
+                {
+                    "name": "jenkins-bar",
+                    "buildServiceProvider": "JENKINS",
+                    "permissions": {
+                        "READ": [
+                            "group-1",
+                            "group-2"
+                        ],
+                        "WRITE": [
+                            "group-2"
+                        ]
+                    }
+                },
+                {
+                    "name": "travis-baz",
+                    "buildServiceProvider": "TRAVIS",
+                    "permissions": {
+                        "READ": [
+                            "group-3",
+                            "group-4"
+                        ],
+                        "WRITE": [
+                            "group-3"
+                        ]
+                    }
+                }
+            ]
+
+            """.stripMargin()
+        )
     }
 
     void 'is able to get jobs for a jenkins master'() {
@@ -145,7 +191,7 @@ class InfoControllerSpec extends Specification {
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
-        jenkinsService.buildServiceProvider() >> BuildServiceProvider.JENKINS
+        jenkinsService.getBuildServiceProvider() >> BuildServiceProvider.JENKINS
         jenkinsService.getJobs() >> ['list': [
             ['name': 'folder', 'list': [
                 ['name': 'job1'],
@@ -166,7 +212,7 @@ class InfoControllerSpec extends Specification {
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
-        travisService.buildServiceProvider() >> BuildServiceProvider.TRAVIS
+        travisService.getBuildServiceProvider() >> BuildServiceProvider.TRAVIS
         1 * cache.getJobNames('travis-master1') >> ["some-job"]
         response.contentAsString == '["some-job"]'
 
@@ -183,7 +229,7 @@ class InfoControllerSpec extends Specification {
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
-        werckerService.buildServiceProvider() >> BuildServiceProvider.WERCKER
+        werckerService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
         werckerService.getJobs() >> [werckerJob]
         response.contentAsString == '["' + werckerJob + '"]'
 
@@ -200,7 +246,7 @@ class InfoControllerSpec extends Specification {
             address: server.getUrl('/').toString(),
             username: 'username',
             password: 'password')
-        service = new JenkinsConfig().jenkinsService("jenkins", new JenkinsConfig().jenkinsClient(host), false)
+        service = new JenkinsConfig().jenkinsService("jenkins", new JenkinsConfig().jenkinsClient(host), false, Permissions.EMPTY)
     }
 
     @Unroll

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiServiceSpec.groovy
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.igor.gitlabci.service
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.igor.gitlabci.client.GitlabCiClient
 import com.netflix.spinnaker.igor.gitlabci.client.model.Pipeline
 import com.netflix.spinnaker.igor.gitlabci.client.model.PipelineSummary
@@ -31,7 +32,7 @@ class GitlabCiServiceSpec extends Specification {
 
     void setup() {
         client = Mock(GitlabCiClient)
-        service = new GitlabCiService(client, null, false, false)
+        service = new GitlabCiService(client, "gitlab", null, false, false, Permissions.EMPTY)
     }
 
     def "verify project pagination"() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
@@ -61,7 +61,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
             new JenkinsProperties()
         )
         monitor.worker = scheduler.createWorker()
-        jenkinsService.buildServiceProvider() >> BuildServiceProvider.JENKINS
+        jenkinsService.getBuildServiceProvider() >> BuildServiceProvider.JENKINS
 
         when:
         monitor.onApplicationEvent(Mock(RemoteStatusChangedEvent))
@@ -111,7 +111,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
             new JenkinsProperties()
         )
         monitor.worker = scheduler.createWorker()
-        jenkinsService.buildServiceProvider() >> BuildServiceProvider.JENKINS
+        jenkinsService.getBuildServiceProvider() >> BuildServiceProvider.JENKINS
 
         when:
         monitor.onApplicationEvent(Mock(RemoteStatusChangedEvent))

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.igor.jenkins.service
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.igor.build.model.GenericGitRevision
 import com.netflix.spinnaker.igor.config.JenkinsConfig
 import com.netflix.spinnaker.igor.config.JenkinsProperties
@@ -48,8 +49,8 @@ class JenkinsServiceSpec extends Specification {
 
     void setup() {
         client = Mock(JenkinsClient)
-        service = new JenkinsService('http://my.jenkins.net', client, false)
-        csrfService = new JenkinsService('http://my.jenkins.net', client, true)
+        service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
+        csrfService = new JenkinsService('http://my.jenkins.net', client, true, Permissions.EMPTY)
     }
 
     @Unroll
@@ -157,7 +158,7 @@ class JenkinsServiceSpec extends Specification {
             username: 'username',
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
-        service = new JenkinsService('http://my.jenkins.net', client, true)
+        service = new JenkinsService('http://my.jenkins.net', client, true, Permissions.EMPTY)
 
         when:
         String crumb = service.getCrumb()
@@ -183,7 +184,7 @@ class JenkinsServiceSpec extends Specification {
             username: 'username',
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
-        service = new JenkinsService('http://my.jenkins.net', client, false)
+        service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
 
         when:
         List<Project> projects = service.projects.list
@@ -277,7 +278,7 @@ class JenkinsServiceSpec extends Specification {
             username: 'username',
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
-        service = new JenkinsService('http://my.jenkins.net', client, false)
+        service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
 
         when:
         List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
@@ -330,7 +331,7 @@ class JenkinsServiceSpec extends Specification {
             username: 'username',
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
-        service = new JenkinsService('http://my.jenkins.net', client, false)
+        service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
 
         when:
         List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
@@ -383,7 +384,7 @@ class JenkinsServiceSpec extends Specification {
             username: 'username',
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
-        service = new JenkinsService('http://my.jenkins.net', client, false)
+        service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
 
         when:
         List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
@@ -442,7 +443,7 @@ class JenkinsServiceSpec extends Specification {
             username: 'username',
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
-        service = new JenkinsService('http://my.jenkins.net', client, false)
+        service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
 
         when:
         List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
@@ -504,7 +505,7 @@ class JenkinsServiceSpec extends Specification {
             username: 'username',
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
-        service = new JenkinsService('http://my.jenkins.net', client, false)
+        service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
 
         when:
         List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
@@ -566,7 +567,7 @@ class JenkinsServiceSpec extends Specification {
             username: 'username',
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
-        service = new JenkinsService('http://my.jenkins.net', client, false)
+        service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
 
         when:
         List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
@@ -618,7 +619,7 @@ class JenkinsServiceSpec extends Specification {
             username: 'username',
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
-        service = new JenkinsService('http://my.jenkins.net', client, false)
+        service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
 
         expect:
         service.getBuildProperties("PropertiesTest", 1, "props$extension") == testCase.result

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.igor.travis.service
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.igor.build.artifact.decorator.DebDetailsDecorator
 import com.netflix.spinnaker.igor.build.artifact.decorator.RpmDetailsDecorator
 import com.netflix.spinnaker.igor.build.model.GenericBuild
@@ -47,7 +48,7 @@ class TravisServiceSpec extends Specification{
     void setup() {
         client = Mock(TravisClient)
         artifactDecorator = Optional.of(new ArtifactDecorator([new DebDetailsDecorator(), new RpmDetailsDecorator()], null))
-        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', 25, client, null, artifactDecorator, [])
+        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', 25, client, null, artifactDecorator, [], Permissions.EMPTY)
 
         AccessToken accessToken = new AccessToken()
         accessToken.accessToken = "someToken"

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSchedulingSpec.groovy
@@ -52,7 +52,7 @@ class WerckerBuildMonitorSchedulingSpec extends Specification {
                 new WerckerProperties()
                 )
         monitor.worker = scheduler.createWorker()
-        werckerService.buildServiceProvider() >> BuildServiceProvider.WERCKER
+        werckerService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
 
         when:
         monitor.onApplicationEvent(Mock(RemoteStatusChangedEvent))

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSpec.groovy
@@ -9,6 +9,7 @@
 package com.netflix.spinnaker.igor.wercker
 
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.igor.IgorConfigurationProperties
 import com.netflix.spinnaker.igor.config.WerckerProperties
 import com.netflix.spinnaker.igor.config.WerckerProperties.WerckerHost
@@ -40,7 +41,7 @@ class WerckerBuildMonitorSpec extends Specification {
     void setup() {
         client = Mock(WerckerClient)
         werckerService = new WerckerService(
-                new WerckerHost(name: master, address: werckerDev), cache, client)
+                new WerckerHost(name: master, address: werckerDev), cache, client, Permissions.EMPTY)
     }
 
     final MASTER = 'MASTER'
@@ -68,7 +69,7 @@ class WerckerBuildMonitorSpec extends Specification {
         monitor.worker = scheduler.createWorker()
         mockService.getRunsSince(_) >> [pipeline: runs1]
         cache.getBuildNumber(*_) >> 1
-        mockService.buildServiceProvider() >> BuildServiceProvider.WERCKER
+        mockService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
 
         when:
         monitor.onApplicationEvent(Mock(RemoteStatusChangedEvent))
@@ -95,7 +96,7 @@ class WerckerBuildMonitorSpec extends Specification {
         monitor.worker = scheduler.createWorker()
         mockService.getRunsSince(_) >> [pipeline: runs1]
         cache.getBuildNumber(*_) >> 1
-        mockService.buildServiceProvider() >> BuildServiceProvider.WERCKER
+        mockService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
 
         when:
         monitor.onApplicationEvent(Mock(RemoteStatusChangedEvent))
@@ -115,7 +116,7 @@ class WerckerBuildMonitorSpec extends Specification {
         monitor.worker = scheduler.createWorker()
         mockService.getRunsSince(_) >> [:]
         cache.getBuildNumber(*_) >> 1
-        mockService.buildServiceProvider() >> BuildServiceProvider.WERCKER
+        mockService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
 
         when:
         monitor.onApplicationEvent(Mock(RemoteStatusChangedEvent))
@@ -158,7 +159,7 @@ class WerckerBuildMonitorSpec extends Specification {
         monitor.worker = scheduler.createWorker()
         cache.getBuildNumber(*_) >> 1
         client.getRunsSince(_, _, _, _, _) >> []
-        mockService.buildServiceProvider() >> BuildServiceProvider.WERCKER
+        mockService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
 
         when:
         monitor.onApplicationEvent(Mock(RemoteStatusChangedEvent))

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerServiceSpec.groovy
@@ -9,6 +9,7 @@
 
 package com.netflix.spinnaker.igor.wercker
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.igor.config.WerckerProperties.WerckerHost
 import com.netflix.spinnaker.igor.wercker.model.*
 
@@ -30,7 +31,7 @@ class WerckerServiceSpec extends Specification {
     void setup() {
         client = Mock(WerckerClient)
         service = new WerckerService(
-                new WerckerHost(name: master, address: werckerDev), cache, client)
+                new WerckerHost(name: master, address: werckerDev), cache, client, Permissions.EMPTY)
     }
 
     void 'get pipelines as jobs'() {


### PR DESCRIPTION
New feature to let build masters be restricted to people with certain roles.

Read permission is required to see the build master at all, and thus to use triggers.
Write permission is only required to be able to trigger a build with the build master.

Adds a permissions field to the config in Igor:
```
travis:
  repositorySyncEnabled: true
  masters:
  - name: travis
    address: https://travis.com/api
    baseUrl: https://travis.com
    githubToken: xxxxxxx
    numberOfRepositories: 100
    permissions:
      READ:
      - foo
      - bar
      WRITE:
      - bar
```

In the example above, users with the `foo` or `bar` roles will be able to see the build master and use it as a trigger, users with the `bar` role will additionally be able to trigger builds. Users without these roles will not see the build master in Deck at all.

This feature is useful for big Spinnaker installations where companies and/or teams want to bring their own CI's into Spinnaker.

https://github.com/spinnaker/echo/pull/467, https://github.com/spinnaker/orca/pull/2673 and https://github.com/spinnaker/fiat/pull/355 is also a part of this feature and depends on this PR. Halyard support in https://github.com/spinnaker/halyard/pull/1224.