### PR TITLE
feat(artifactory): Add Artifactory artifact monitor

### DIFF
--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -17,7 +17,7 @@ endpoints.health.sensitive: false
 
 spring.jackson.serialization.write_dates_as_timestamps: false
 
-
+server.port: 8088
 
 #artifact:
 #  This is a feature toggle for decoration of artifacts.

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -10,6 +10,10 @@ run {
 
 mainClassName = 'com.netflix.spinnaker.igor.Main'
 
+test {
+  useJUnitPlatform()
+}
+
 dependencies {
     spinnaker.group "test"
     spinnaker.group "bootWeb"
@@ -30,14 +34,21 @@ dependencies {
     compile spinnaker.dependency("korkHystrix")
     compile spinnaker.dependency("okHttp")
     compile spinnaker.dependency('logstashEncoder')
+    compile spinnaker.dependency("lombok")
+    compile spinnaker.dependency('korkArtifacts')
 
     compile 'org.yaml:snakeyaml:1.15'
     compile 'com.squareup.retrofit:converter-simplexml:1.9.0'
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.6'
     compile 'com.google.code.gson:gson:2.8.2'
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.0'
+    compile 'org.jfrog.artifactory.client:artifactory-java-client-services:2.8.1'
 
+    testCompile 'com.squareup.okhttp:mockwebserver:2.7.0'
     testCompile spinnaker.dependency("korkJedisTest")
+    testCompile spinnaker.dependency("junitJupiterApi")
+    testCompile spinnaker.dependency("assertj")
+
+    testRuntime spinnaker.dependency("junitJupiterEngine")
 }
 
 configurations.all {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/IgorConfigurationProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/IgorConfigurationProperties.groovy
@@ -34,7 +34,7 @@ class IgorConfigurationProperties {
 
         @Canonical
         static class BuildProperties {
-            int pollInterval = 60
+            int pollInterval = 60 /* seconds */
             int lookBackWindowMins = 10
             boolean handleFirstBuilds = true
             boolean processBuildsOlderThanLookBackWindow = true

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/ArtifactoryEvent.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/ArtifactoryEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.history.model;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@EqualsAndHashCode(callSuper = true)
+@RequiredArgsConstructor
+@Data
+public class ArtifactoryEvent extends Event {
+  private final Map<String, String> details = ImmutableMap.<String, String>builder()
+    .put("type", "artifactory")
+    .put("source", "igor")
+    .build();
+
+  private final Artifact artifact;
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.artifactory;
+
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.igor.IgorConfigurationProperties;
+import com.netflix.spinnaker.igor.artifactory.model.ArtifactoryArtifact;
+import com.netflix.spinnaker.igor.artifactory.model.ArtifactoryRepositoryType;
+import com.netflix.spinnaker.igor.artifactory.model.ArtifactorySearch;
+import com.netflix.spinnaker.igor.config.ArtifactoryProperties;
+import com.netflix.spinnaker.igor.history.EchoService;
+import com.netflix.spinnaker.igor.history.model.ArtifactoryEvent;
+import com.netflix.spinnaker.igor.polling.*;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.jfrog.artifactory.client.Artifactory;
+import org.jfrog.artifactory.client.ArtifactoryClientBuilder;
+import org.jfrog.artifactory.client.ArtifactoryRequest;
+import org.jfrog.artifactory.client.ArtifactoryResponse;
+import org.jfrog.artifactory.client.impl.ArtifactoryRequestImpl;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+
+@Service
+@ConditionalOnProperty("artifactory.enabled")
+@Slf4j
+public class ArtifactoryBuildMonitor extends CommonPollingMonitor<ArtifactoryBuildMonitor.ArtifactDelta, ArtifactoryBuildMonitor.ArtifactPollingDelta> {
+  private final ArtifactoryCache cache;
+  private final ArtifactoryProperties artifactoryProperties;
+  private final Optional<EchoService> echoService;
+
+  public ArtifactoryBuildMonitor(IgorConfigurationProperties properties,
+                                 Registry registry,
+                                 Optional<DiscoveryClient> discoveryClient,
+                                 Optional<LockService> lockService,
+                                 Optional<EchoService> echoService,
+                                 ArtifactoryCache cache,
+                                 ArtifactoryProperties artifactoryProperties) {
+    super(properties, registry, discoveryClient, lockService);
+    this.cache = cache;
+    this.artifactoryProperties = artifactoryProperties;
+    this.echoService = echoService;
+  }
+
+  @Override
+  public String getName() {
+    return "artifactoryPublishingMonitor";
+  }
+
+  @Override
+  protected void initialize() {
+  }
+
+  @Override
+  public void poll(boolean sendEvents) {
+    for (ArtifactorySearch search : artifactoryProperties.getSearches()) {
+      pollSingle(new PollContext(search.getPartitionName(), sendEvents));
+    }
+  }
+
+  @Override
+  protected ArtifactPollingDelta generateDelta(PollContext ctx) {
+    return artifactoryProperties.getSearches().stream()
+      .filter(host -> host.getPartitionName().equals(ctx.partitionName))
+      .findAny()
+      .map(search -> {
+        Artifactory client = ArtifactoryClientBuilder.create()
+          .setUsername(search.getUsername())
+          .setPassword(search.getPassword())
+          .setAccessToken(search.getAccessToken())
+          .setUrl(search.getBaseUrl())
+          .setIgnoreSSLIssues(search.isIgnoreSslIssues())
+          .build();
+
+        int lookBackWindowMins = igorProperties.getSpinnaker().getBuild().getLookBackWindowMins();
+        long lookbackFromCurrent = System.currentTimeMillis() - (getPollInterval() * 1000 + (lookBackWindowMins * 60 * 1000));
+        String modified = "\"modified\":{\"$last\":\"" + lookBackWindowMins + "minutes\"}";
+
+        Long cursor = cache.getLastPollCycleTimestamp(search);
+        if (cursor == null) {
+          cache.setLastPollCycleTimestamp(search, System.currentTimeMillis());
+          if (!igorProperties.getSpinnaker().getBuild().isHandleFirstBuilds()) {
+            return ArtifactPollingDelta.EMPTY;
+          }
+        } else if (cursor > lookbackFromCurrent || igorProperties.getSpinnaker().getBuild().isProcessBuildsOlderThanLookBackWindow()) {
+          modified = "\"modified\":{\"$gt\":\"" + Instant.ofEpochMilli(cursor) + "\"}";
+        }
+
+        String aqlQuery = "items.find({" +
+          "\"repo\":\"libs-demo-local\"," +
+          modified + "," +
+          "\"name\":{\"$match\":\"" +
+            (search.getGroupId() == null ? "" : search.getGroupId().replace('.', '/') + "/") +
+            "*.pom\"}" +
+          "}).include(\"path\",\"repo\",\"name\")";
+
+        ArtifactoryRequest aqlRequest = new ArtifactoryRequestImpl()
+          .method(ArtifactoryRequest.Method.POST)
+          .apiUrl("/api/search/aql")
+          .requestType(ArtifactoryRequest.ContentType.TEXT)
+          .responseType(ArtifactoryRequest.ContentType.JSON)
+          .requestBody(aqlQuery);
+
+        try {
+          ArtifactoryResponse aqlResponse = client.restCall(aqlRequest);
+          if (aqlResponse.isSuccessResponse()) {
+            List<ArtifactoryArtifact> results = aqlResponse.parseBody(ArtifactoryQueryResults.class).getResults();
+            return new ArtifactPollingDelta(search.getPartitionName(), Collections.singletonList(
+              new ArtifactDelta(System.currentTimeMillis(), search.getRepoType(), results)));
+          }
+
+          log.warn("Unable to query Artifactory for artifacts (HTTP {}): {}", aqlResponse.getStatusLine().getStatusCode(),
+            aqlResponse.getRawBody());
+        } catch (IOException e) {
+          log.warn("Unable to query Artifactory for artifacts", e);
+        }
+        return ArtifactPollingDelta.EMPTY;
+      })
+      .orElse(ArtifactPollingDelta.EMPTY);
+  }
+
+  @Override
+  protected void commitDelta(ArtifactPollingDelta delta, boolean sendEvents) {
+    for (ArtifactDelta artifactDelta : delta.items) {
+      if (sendEvents) {
+        for (ArtifactoryArtifact artifact : artifactDelta.getArtifacts()) {
+          postEvent(artifactDelta.getType(), artifact);
+          log.debug("{} event posted", artifact);
+        }
+      }
+    }
+  }
+
+  private void postEvent(ArtifactoryRepositoryType repoType, ArtifactoryArtifact artifact) {
+    if (!echoService.isPresent()) {
+      log.warn("Cannot send build notification: Echo is not configured");
+      registry.counter(missedNotificationId.withTag("monitor", ArtifactoryBuildMonitor.class.getSimpleName())).increment();
+    } else {
+      Artifact matchableArtifact = artifact.toMatchableArtifact(repoType);
+      if(matchableArtifact != null) {
+        echoService.get().postEvent(new ArtifactoryEvent(matchableArtifact));
+      }
+    }
+  }
+
+  @Data
+  static class ArtifactPollingDelta implements PollingDelta<ArtifactDelta> {
+    public static ArtifactPollingDelta EMPTY = new ArtifactPollingDelta(null, emptyList());
+
+    @Nullable
+    private final String repo;
+
+    private final List<ArtifactDelta> items;
+  }
+
+  @Data
+  static class ArtifactDelta implements DeltaItem {
+    private final long searchTimestamp;
+    private final ArtifactoryRepositoryType type;
+    private final List<ArtifactoryArtifact> artifacts;
+  }
+
+  @Data
+  private static class ArtifactoryQueryResults {
+    List<ArtifactoryArtifact> results;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryCache.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryCache.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.artifactory;
+
+import com.netflix.spinnaker.igor.IgorConfigurationProperties;
+import com.netflix.spinnaker.igor.artifactory.model.ArtifactorySearch;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ArtifactoryCache {
+  private final static String ID = "artifactory:publish:queue";
+
+  private static final String POLL_STAMP = "lastPollCycleTimestamp";
+
+  private final RedisClientDelegate redisClientDelegate;
+  private final IgorConfigurationProperties igorConfigurationProperties;
+
+  public void setLastPollCycleTimestamp(ArtifactorySearch search, long timestamp) {
+    String key = makeKey(search);
+    redisClientDelegate.withCommandsClient(c -> {
+      c.hset(key, POLL_STAMP, Long.toString(timestamp));
+    });
+  }
+
+  public Long getLastPollCycleTimestamp(ArtifactorySearch search) {
+    return redisClientDelegate.withCommandsClient(c -> {
+      String ts = c.hget(makeKey(search), POLL_STAMP);
+      return ts == null ? null : Long.parseLong(ts);
+    });
+  }
+
+  private String makeKey(ArtifactorySearch search) {
+    return prefix() + ":" + search.getPartitionName() + ":" + search.getGroupId();
+  }
+
+  private String prefix() {
+    return igorConfigurationProperties.getSpinnaker().getJedis().getPrefix() + ":" + ID;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryArtifact.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryArtifact.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.artifactory.model;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import lombok.Data;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+
+@Data
+public class ArtifactoryArtifact {
+  private String repo;
+  private String path;
+
+  @Nullable
+  public Artifact toMatchableArtifact(ArtifactoryRepositoryType repoType) {
+    switch(repoType) {
+      case Maven:
+        String[] pathParts = path.split("/");
+        String version = pathParts[pathParts.length - 1];
+        String artifactId = pathParts[pathParts.length - 2];
+
+        String[] groupParts = Arrays.copyOfRange(pathParts, 0, pathParts.length - 2);
+        String group = String.join(".", groupParts);
+
+        return Artifact.builder().type("maven/file")
+          .reference(group + ":" + artifactId + ":" + version)
+          .name(group + ":" + artifactId)
+          .version(version)
+          .provenance(repo)
+          .build();
+    }
+    return null;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryRepositoryType.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryRepositoryType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.artifactory.model;
+
+public enum ArtifactoryRepositoryType {
+  Maven,
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactorySearch.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactorySearch.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.artifactory.model;
+
+import lombok.Data;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class ArtifactorySearch {
+  private ArtifactoryRepositoryType repoType = ArtifactoryRepositoryType.Maven;
+  private String baseUrl;
+  private List<String> repos = Arrays.asList("libs-releases-local", "libs-snapshot-local");
+
+  /**
+   * One of username/password or an access token is required.
+   */
+  @Nullable
+  private String username;
+
+  @Nullable
+  private String password;
+
+  /**
+   * One of username/password or an access token is required.
+   */
+  @Nullable
+  private String accessToken;
+
+  private boolean ignoreSslIssues = false;
+
+  /**
+   * Filter published artifact searches to just this group id.
+   */
+  @Nullable
+  private String groupId;
+
+  public String getPartitionName() {
+    return baseUrl + "/" + repos.stream()
+      .collect(Collectors.joining(",", "[", "]"));
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ArtifactoryConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ArtifactoryConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty("artifactory.enabled")
+@EnableConfigurationProperties(ArtifactoryProperties.class)
+public class ArtifactoryConfig {
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ArtifactoryProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ArtifactoryProperties.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config;
+
+import com.netflix.spinnaker.igor.artifactory.model.ArtifactorySearch;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Data
+@ConfigurationProperties(prefix = "artifactory")
+public class ArtifactoryProperties {
+  private List<ArtifactorySearch> searches;
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitorSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.artifactory
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.igor.artifactory.model.ArtifactorySearch
+import com.netflix.spinnaker.igor.config.ArtifactoryProperties
+import com.netflix.spinnaker.igor.history.EchoService
+import com.squareup.okhttp.mockwebserver.MockResponse
+import com.squareup.okhttp.mockwebserver.MockWebServer
+import rx.schedulers.Schedulers
+import spock.lang.Specification
+
+class ArtifactoryBuildMonitorSpec extends Specification {
+  ArtifactoryCache cache = Mock(ArtifactoryCache)
+  EchoService echoService = Mock()
+  IgorConfigurationProperties igorConfigurationProperties = new IgorConfigurationProperties()
+  ArtifactoryBuildMonitor monitor
+
+  MockWebServer mockArtifactory = new MockWebServer()
+
+  void setup() {
+    monitor = new ArtifactoryBuildMonitor(
+      igorConfigurationProperties,
+      new NoopRegistry(),
+      Optional.empty(),
+      Optional.empty(),
+      Optional.of(echoService),
+      cache,
+      new ArtifactoryProperties(searches: [
+        new ArtifactorySearch(
+          baseUrl: mockArtifactory.url('/'),
+          repos: ['libs-releases-local'],
+        )
+      ])
+    )
+
+    monitor.worker = Schedulers.immediate().createWorker()
+  }
+
+  def 'should handle any failure to talk to artifactory graciously' () {
+    given:
+    mockArtifactory.enqueue(new MockResponse().setResponseCode(400))
+
+    when:
+    monitor.poll(false)
+
+    then:
+    notThrown(Exception)
+  }
+}

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryArtifactTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryArtifactTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.artifactory.model;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArtifactoryArtifactTest {
+  @Test
+  void toMatchableArtifact() {
+    ArtifactoryArtifact artifact = new ArtifactoryArtifact();
+    artifact.setPath("io/pivotal/spinnaker/demo/0.1.0-dev.20+d9a14fb");
+    artifact.setRepo("libs-demo-local");
+
+    Artifact matchableArtifact = artifact.toMatchableArtifact(ArtifactoryRepositoryType.Maven);
+    assertThat(matchableArtifact).isNotNull();
+    assertThat(matchableArtifact.getType()).isEqualTo("maven/file");
+    assertThat(matchableArtifact.getReference()).isEqualTo("io.pivotal.spinnaker:demo:0.1.0-dev.20+d9a14fb");
+    assertThat(matchableArtifact.getVersion()).isEqualTo("0.1.0-dev.20+d9a14fb");
+    assertThat(matchableArtifact.getName()).isEqualTo("io.pivotal.spinnaker:demo");
+  }
+}


### PR DESCRIPTION
Adding a new monitor for Artifactory that uses [AQL](https://www.jfrog.com/confluence/display/RTF/Artifactory+Query+Language#ArtifactoryQueryLanguage-SpecifyingOutputFields) to artifacts modified since the last poll.

This monitor initially only publishes events for artifacts published to Maven repositories, because it constructs an event containing `kork-artifacts` Artifacts with a `maven/file` type. This requires special knowledge of how an artifact path correlates to a Maven GAV coordinate. Similar treatment for other repository types can be added as needed.