### PR TITLE
fix(tests): Use JUnit vintage engine so Spock tests still run

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -54,7 +54,7 @@ dependencies {
     testCompile spinnaker.dependency("junitJupiterApi")
     testCompile spinnaker.dependency("assertj")
 
-    testRuntime spinnaker.dependency("junitJupiterEngine")
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${spinnaker.version('jupiter')}"
 }
 
 configurations.all {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
@@ -41,7 +41,7 @@ public abstract class CommonPollingMonitor<I extends DeltaItem, T extends Pollin
     protected Logger log = LoggerFactory.getLogger(getClass());
 
     private final Optional<DiscoveryClient> discoveryClient;
-    private Scheduler.Worker worker;
+    protected Scheduler.Worker worker;
 
     protected final IgorConfigurationProperties igorProperties;
     protected final Registry registry;


### PR DESCRIPTION
* Also rolled back a visibility change to CommonPollingMonitor.worker so it is accessible in Spock tests that assign it as a property