### PR TITLE
feat(jenkins): Expected artifact matchable Jenkins artifacts

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericArtifact.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericArtifact.groovy
@@ -30,7 +30,7 @@ class GenericArtifact {
     String type
     String version
 
-    Map<String, String> metadata;
+    Map<String, String> metadata
 
     GenericArtifact(String fileName, String displayPath, String relativePath) {
         this.fileName = fileName

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/Build.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/Build.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.igor.jenkins.client.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
+import com.netflix.spinnaker.igor.build.model.GenericArtifact
 import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.Result
 import groovy.transform.CompileStatic
@@ -64,7 +65,12 @@ class Build {
     GenericBuild genericBuild(String jobName) {
         GenericBuild genericBuild = new GenericBuild(building: building, number: number.intValue(), duration: duration.intValue(), result: result as Result, name: jobName, url: url, timestamp: timestamp, fullDisplayName: fullDisplayName)
         if (artifacts) {
-            genericBuild.artifacts = artifacts*.getGenericArtifact()
+            genericBuild.artifacts = artifacts.collect { buildArtifact ->
+                GenericArtifact artifact = buildArtifact.getGenericArtifact()
+                artifact.name = jobName
+                artifact.version = number
+                artifact
+            }
         }
         if (testResults) {
             genericBuild.testResults = testResults
@@ -72,6 +78,3 @@ class Build {
         return genericBuild
     }
 }
-
-
-

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/BuildArtifact.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/BuildArtifact.groovy
@@ -41,6 +41,9 @@ class BuildArtifact {
     String relativePath
 
     GenericArtifact getGenericArtifact() {
-        return new GenericArtifact(fileName, displayPath, relativePath)
+        GenericArtifact artifact = new GenericArtifact(fileName, displayPath, relativePath)
+        artifact.type = 'jenkins/file'
+        artifact.reference = relativePath
+        return artifact
     }
 }


### PR DESCRIPTION
This is an alternative to the original PR adding support for expected artifact matchable Jenkins artifacts reverted in https://github.com/spinnaker/igor/pull/398.

This approach defers the addition of additional fields to Jenkins artifacts to the point where echo retrieves additional build details. Since it doesn't involve any changes to API access to Jenkins, there should be no performance implications for large Jenkins masters.

Like the original PR, the additional data elements on Jenkins artifacts are strictly additive, so should have no impact on existing code referring to `displayName`, `relativePath`, etc.

cc / @robzienert @eleftherias @Jammy-Louie