### PR TITLE
fix(concourse): Detect Concourse token expiry

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/ConcourseClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/ConcourseClient.java
@@ -54,6 +54,9 @@ public class ConcourseClient {
   @Getter
   private PipelineService pipelineService;
 
+  @Getter
+  private SkyService skyService;
+
   private volatile ZonedDateTime tokenExpiration = ZonedDateTime.now();
   private volatile Token token;
 
@@ -94,6 +97,7 @@ public class ConcourseClient {
     this.jobService = createService(JobService.class);
     this.teamService = createService(TeamService.class);
     this.pipelineService = createService(PipelineService.class);
+    this.skyService = createService(SkyService.class);
     this.eventService = new EventService(host, this::refreshToken, mapper);
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/SkyService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/SkyService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.concourse.client;
+
+import retrofit.client.Response;
+import retrofit.http.GET;
+
+public interface SkyService {
+  @GET("/sky/userinfo")
+  Response userInfo();
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
@@ -70,18 +70,21 @@ public class ConcourseService implements BuildService, BuildProperties {
   }
 
   public Collection<Team> teams() {
+    refreshTokenIfNecessary();
     return client.getTeamService().teams().stream()
       .filter(team -> host.getTeams() == null || host.getTeams().contains(team.getName()))
       .collect(toList());
   }
 
   public Collection<Pipeline> pipelines() {
+    refreshTokenIfNecessary();
     return client.getPipelineService().pipelines().stream()
       .filter(pipeline -> host.getTeams() == null || host.getTeams().contains(pipeline.getTeamName()))
       .collect(toList());
   }
 
   public Collection<Job> getJobs() {
+    refreshTokenIfNecessary();
     return client.getJobService().jobs().stream()
       .filter(job -> host.getTeams() == null || host.getTeams().contains(job.getTeamName()))
       .collect(toList());
@@ -253,5 +256,13 @@ public class ConcourseService implements BuildService, BuildProperties {
     job.setName(jobParts[2]);
 
     return job;
+  }
+
+  /**
+   * This is necessary until this is resolved: https://github.com/concourse/concourse/issues/3558
+   */
+  private void refreshTokenIfNecessary() {
+    // returns a 401 on expired/invalid token, which because of retry logic causes the token to be refreshed.
+    client.getSkyService().userInfo();
   }
 }

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitorTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitorTest.java
@@ -19,22 +19,17 @@ package com.netflix.spinnaker.igor.concourse;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spinnaker.igor.IgorConfigurationProperties;
-import com.netflix.spinnaker.igor.concourse.client.OkHttpClientBuilder;
 import com.netflix.spinnaker.igor.concourse.service.ConcourseService;
 import com.netflix.spinnaker.igor.config.ConcourseProperties;
 import com.netflix.spinnaker.igor.history.EchoService;
 import com.netflix.spinnaker.igor.service.BuildServices;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
-import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import retrofit.http.GET;
-import retrofit.http.Path;
 import rx.schedulers.Schedulers;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
See https://github.com/concourse/concourse/issues/3558.

Concourse does not correctly produce a 401 when a token is invalid/expires when executing commands to retrieve teams and pipelines.

Calls to `/sky/userinfo` do return a 401 on invalid/expired token, so as a workaround we preface calls to resource listings with a call to `/sky/userinfo`.