### PR TITLE
fix(concourse): Tweak return type to support manual execution build listing

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericBuild.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericBuild.groovy
@@ -28,7 +28,12 @@ class GenericBuild {
     String name
     int number
     Integer duration
+
+    /**
+     * String representation of time in nanoseconds since Unix epoch
+     */
     String timestamp
+
     Result result
     List<GenericArtifact> artifacts
     List<TestResults> testResults

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
@@ -105,7 +105,7 @@ public class ConcourseService implements BuildService, BuildProperties {
   @Nullable
   @Override
   public GenericBuild getGenericBuild(String jobPath, int buildNumber) {
-    return getBuilds(jobPath).stream()
+    return getBuilds(jobPath, null).stream()
       .filter(build -> build.getNumber() == buildNumber)
       .findAny()
       .map(build -> getGenericBuild(jobPath, build, true))
@@ -124,6 +124,7 @@ public class ConcourseService implements BuildService, BuildProperties {
     build.setFullDisplayName(job.getTeamName() + "/" + job.getPipelineName() + "/" + job.getName());
     build.setUrl(host.getUrl() + "/teams/" + job.getTeamName() + "/pipelines/" + job.getPipelineName() + "/jobs/" +
       job.getName() + "/builds/" + b.getNumber());
+    build.setTimestamp(Long.toString(b.getStartTime() * 1000));
 
     if (!fetchResources) {
       return build;
@@ -226,8 +227,10 @@ public class ConcourseService implements BuildService, BuildProperties {
   }
 
   @Override
-  public List<Build> getBuilds(String jobPath) {
-    return getBuilds(jobPath, null);
+  public List<GenericBuild> getBuilds(String jobPath) {
+    return getBuilds(jobPath, null).stream()
+      .map(build -> getGenericBuild(jobPath, build, false))
+      .collect(Collectors.toList());
   }
 
   public List<Build> getBuilds(String jobPath, @Nullable Long since) {


### PR DESCRIPTION
Returning a `GenericBuild` now which properly supports listing builds available for manual execution:

![image](https://user-images.githubusercontent.com/1697736/54789693-510d1180-4c01-11e9-8610-07fa243beb7e.png)
