### PR TITLE
feat(gcb): Add support for triggering GCB builds

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -20,6 +20,7 @@ dependencies {
     spinnaker.group "jackson"
     spinnaker.group "retrofitDefault"
 
+    compile spinnaker.dependency("googleCloudBuild")
     compile spinnaker.dependency("kork")
     compile spinnaker.dependency("korkArtifacts")
     compile spinnaker.dependency("korkStackdriver")
@@ -47,7 +48,6 @@ dependencies {
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.6'
     compile 'com.google.code.gson:gson:2.8.2'
     compile 'org.jfrog.artifactory.client:artifactory-java-client-services:2.8.1'
-    compile 'com.google.apis:google-api-services-cloudbuild:v1-rev836-1.25.0'
 
     testCompile 'com.squareup.okhttp:mockwebserver:2.7.0'
     testCompile 'org.springframework.boot:spring-boot-starter-test'

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -48,13 +48,19 @@ dependencies {
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.6'
     compile 'com.google.code.gson:gson:2.8.2'
     compile 'org.jfrog.artifactory.client:artifactory-java-client-services:2.8.1'
+    compile 'com.google.apis:google-api-services-cloudbuild:v1-rev836-1.25.0'
 
     testCompile 'com.squareup.okhttp:mockwebserver:2.7.0'
+    testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile spinnaker.dependency("korkJedisTest")
     testCompile spinnaker.dependency("junitJupiterApi")
     testCompile spinnaker.dependency("assertj")
 
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${spinnaker.version('jupiter')}"
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.2.0'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.2.0'
+    testCompile 'com.github.tomakehurst:wiremock-jre8:2.22.0'
+    testCompile 'org.mockito:mockito-core:2.6.8'
 }
 
 configurations.all {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.netflix.spinnaker.igor.gcb.GoogleCloudBuildAccount;
+import com.netflix.spinnaker.igor.gcb.GoogleCloudBuildAccountFactory;
+import com.netflix.spinnaker.igor.gcb.GoogleCloudBuildAccountRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+@Configuration
+@ComponentScan("com.netflix.spinnaker.igor.gcb")
+@ConditionalOnProperty("gcb.enabled")
+@EnableConfigurationProperties(GoogleCloudBuildProperties.class)
+public class GoogleCloudBuildConfig {
+    @Bean
+    HttpTransport httpTransport() throws IOException, GeneralSecurityException {
+      return GoogleNetHttpTransport.newTrustedTransport();
+    }
+
+    @Bean
+    GoogleCloudBuildAccountRepository googleCloudBuildAccountRepository(
+        GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory,
+        GoogleCloudBuildProperties googleCloudBuildProperties
+    ) {
+        GoogleCloudBuildAccountRepository credentials = new GoogleCloudBuildAccountRepository();
+        googleCloudBuildProperties.getAccounts().forEach(a -> {
+            GoogleCloudBuildAccount account = googleCloudBuildAccountFactory.build(a);
+            credentials.registerAccount(a.getName(), account);
+        });
+        return credentials;
+    }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "gcb")
+@Data
+public class GoogleCloudBuildProperties {
+    private List<Account> accounts;
+
+    @Data
+    public static class Account {
+        private String name;
+        private String project;
+        private String jsonKey;
+    }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
@@ -24,12 +24,14 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.cloudbuild.v1.CloudBuild;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 /**
  * Factory for calling CloudBuild client library code to create CloudBuild objects
  */
 @Component
+@ConditionalOnProperty("gcb.enabled")
 @RequiredArgsConstructor
 public class CloudBuildFactory {
   private final int connectTimeoutSec = 10;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.cloudbuild.v1.CloudBuild;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Factory for calling CloudBuild client library code to create CloudBuild objects
+ */
+@Component
+@RequiredArgsConstructor
+public class CloudBuildFactory {
+  private final int connectTimeoutSec = 10;
+  private final int readTimeoutSec = 10;
+
+  private final JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+  private final HttpTransport httpTransport;
+
+  // Override the base URL for all requests to the cloud build API; primarily for testing.
+  private final String overrideRootUrl;
+
+  @Autowired
+  public CloudBuildFactory(HttpTransport httpTransport) {
+    this(httpTransport, null);
+  }
+
+  public CloudBuild getCloudBuild(GoogleCredential credential, String applicationName) {
+    HttpRequestInitializer requestInitializer = getRequestInitializer(credential);
+    CloudBuild.Builder builder = new CloudBuild.Builder(httpTransport, jsonFactory, requestInitializer)
+      .setApplicationName(applicationName);
+
+    if (overrideRootUrl != null) {
+      builder.setRootUrl(overrideRootUrl);
+    }
+    return  builder.build();
+  }
+
+  private HttpRequestInitializer getRequestInitializer(GoogleCredential credential) {
+    return request -> {
+      credential.initialize(request);
+      request.setConnectTimeout(connectTimeoutSec * 1000);
+      request.setReadTimeout(readTimeoutSec * 1000);
+    };
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.services.cloudbuild.v1.CloudBuild;
+import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.Operation;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Generates authenticated requests to the Google Cloud Build API for a single configured account, delegating to
+ * GoogleCloudBuildExecutor to execute these requests.
+ */
+@RequiredArgsConstructor
+public class GoogleCloudBuildAccount {
+  private final String projectId;
+  private final CloudBuild cloudBuild;
+  private final GoogleCloudBuildExecutor executor;
+
+  public Operation createBuild(Build build) {
+    return executor.execute(() -> cloudBuild.projects().builds().create(projectId, build));
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.cloudbuild.v1.CloudBuild;
+import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Creates GoogleCloudBuildAccounts
+ */
+@Component
+@RequiredArgsConstructor
+public class GoogleCloudBuildAccountFactory {
+  private final GoogleCredentialService credentialService;
+  private final CloudBuildFactory cloudBuildFactory;
+  private final GoogleCloudBuildExecutor googleCloudBuildExecutor;
+
+  public GoogleCloudBuildAccount build(GoogleCloudBuildProperties.Account account) {
+    GoogleCredential credential = getCredential(account);
+    String applicationName = getApplicationName();
+    CloudBuild cloudBuild = cloudBuildFactory.getCloudBuild(credential, applicationName);
+
+    return new GoogleCloudBuildAccount(account.getProject(), cloudBuild, googleCloudBuildExecutor);
+  }
+
+  private String getApplicationName() {
+    return Optional.ofNullable(getClass().getPackage().getImplementationVersion()).orElse("Unknown");
+  }
+
+  private GoogleCredential getCredential(GoogleCloudBuildProperties.Account account) {
+    String jsonKey = account.getJsonKey();
+    if (StringUtils.isEmpty(jsonKey)) {
+      return credentialService.getApplicationDefault();
+    } else {
+      return credentialService.getFromKey(jsonKey);
+    }
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -34,6 +35,7 @@ import java.util.Optional;
  * Creates GoogleCloudBuildAccounts
  */
 @Component
+@ConditionalOnProperty("gcb.enabled")
 @RequiredArgsConstructor
 public class GoogleCloudBuildAccountFactory {
   private final GoogleCredentialService credentialService;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepository.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepository.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Keeps track of all registered instances of GoogleCloudBuildAccount and returns the appropriate account when
+ * it is requested by name.
+ */
+public class GoogleCloudBuildAccountRepository {
+  private final Map<String, GoogleCloudBuildAccount> accounts = new HashMap<>();
+
+  public void registerAccount(String name, GoogleCloudBuildAccount account) {
+    accounts.put(name, account);
+  }
+
+  public GoogleCloudBuildAccount getGoogleCloudBuild(String name) {
+    GoogleCloudBuildAccount account = accounts.get(name);
+    if (account == null) {
+      throw new NotFoundException(String.format("No Google Cloud Build account with name %s is configured", name));
+    }
+    return account;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+@ConditionalOnProperty("gcb.enabled")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/gcb")
+public class GoogleCloudBuildController {
+  private final GoogleCloudBuildAccountRepository googleCloudBuildAccountRepository;
+
+  @RequestMapping(value = "/builds/create/{account}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+  Operation createBuild(@PathVariable String account, @RequestBody Build build) {
+    return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).createBuild(build);
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 @Component
 @ConditionalOnProperty("gcb.enabled")
 public class GoogleCloudBuildExecutor {
+  //TODO(ezimanyi): Consider adding retry logic here
   public <T> T execute(RequestFactory<T> requestFactory) {
     try {
       CloudBuildRequest<T> request = requestFactory.get();

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
@@ -20,6 +20,7 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.cloudbuild.v1.CloudBuildRequest;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import org.apache.http.client.HttpResponseException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -29,6 +30,7 @@ import java.io.IOException;
  * into appropriate exceptions.
  */
 @Component
+@ConditionalOnProperty("gcb.enabled")
 public class GoogleCloudBuildExecutor {
   public <T> T execute(RequestFactory<T> requestFactory) {
     try {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.cloudbuild.v1.CloudBuildRequest;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
+import org.apache.http.client.HttpResponseException;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Executes requests to the Google Cloud Build API, catching appropriate error conditions and translating them
+ * into appropriate exceptions.
+ */
+@Component
+public class GoogleCloudBuildExecutor {
+  public <T> T execute(RequestFactory<T> requestFactory) {
+    try {
+      CloudBuildRequest<T> request = requestFactory.get();
+      return request.execute();
+    } catch (HttpResponseException e) {
+      if (e.getStatusCode() == 400) {
+        throw new InvalidRequestException(e.getMessage());
+      }
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  interface RequestFactory<T> {
+    CloudBuildRequest<T> get() throws IOException;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCredentialService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCredentialService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.services.cloudbuild.v1.CloudBuildScopes;
+import org.springframework.stereotype.Component;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Factory for calling Google API code to create a GoogleCredential, either from application default credentials or
+ * from a supplied path to a JSON key.
+ */
+@Component
+public class GoogleCredentialService {
+  GoogleCredential getFromKey(String jsonPath) {
+    try {
+      InputStream stream = getCredentialAsStream(jsonPath);
+      return loadCredential(stream);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  GoogleCredential getApplicationDefault() {
+    try {
+      return GoogleCredential.getApplicationDefault();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private InputStream getCredentialAsStream(String jsonPath) {
+    try {
+      return new FileInputStream(jsonPath);
+    } catch (IOException e) {
+      throw new IllegalArgumentException(String.format("Unable to read credential file: %s", jsonPath), e);
+    }
+  }
+
+  private GoogleCredential loadCredential(InputStream stream) throws IOException {
+    return GoogleCredential.fromStream(stream).createScoped(CloudBuildScopes.all());
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCredentialService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCredentialService.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.services.cloudbuild.v1.CloudBuildScopes;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.io.FileInputStream;
@@ -29,6 +30,7 @@ import java.io.InputStream;
  * from a supplied path to a JSON key.
  */
 @Component
+@ConditionalOnProperty("gcb.enabled")
 public class GoogleCredentialService {
   GoogleCredential getFromKey(String jsonPath) {
     try {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.services.cloudbuild.v1.CloudBuild;
+import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoogleCloudBuildAccountFactoryTest {
+  private GoogleCredentialService googleCredentialService = mock(GoogleCredentialService.class);
+  private CloudBuildFactory cloudBuildFactory = mock(CloudBuildFactory.class);
+  private GoogleCloudBuildExecutor executor = mock(GoogleCloudBuildExecutor.class);
+
+  private GoogleCredential googleCredential = mock(GoogleCredential.class);
+  private CloudBuild cloudBuild = mock(CloudBuild.class);
+
+  private GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory = new GoogleCloudBuildAccountFactory(googleCredentialService, cloudBuildFactory, executor);
+
+  @Test
+  public void applicationDefaultCredentials() {
+    GoogleCloudBuildProperties.Account accountConfig = getBaseAccount();
+    accountConfig.setJsonKey("");
+
+    when(googleCredentialService.getApplicationDefault()).thenReturn(googleCredential);
+    when(cloudBuildFactory.getCloudBuild(eq(googleCredential), any(String.class))).thenReturn(cloudBuild);
+
+    GoogleCloudBuildAccount account = googleCloudBuildAccountFactory.build(accountConfig);
+
+    verify(googleCredentialService).getApplicationDefault();
+    verify(googleCredentialService, never()).getFromKey(any());
+    verify(cloudBuildFactory).getCloudBuild(eq(googleCredential), any(String.class));
+  }
+
+  @Test
+  public void jsonCredentials() {
+    GoogleCloudBuildProperties.Account accountConfig = getBaseAccount();
+    accountConfig.setJsonKey("/path/to/file");
+
+    when(googleCredentialService.getFromKey("/path/to/file")).thenReturn(googleCredential);
+    when(cloudBuildFactory.getCloudBuild(eq(googleCredential), any(String.class))).thenReturn(cloudBuild);
+
+    GoogleCloudBuildAccount account = googleCloudBuildAccountFactory.build(accountConfig);
+
+    verify(googleCredentialService, never()).getApplicationDefault();
+    verify(googleCredentialService).getFromKey("/path/to/file");
+    verify(cloudBuildFactory).getCloudBuild(eq(googleCredential), any(String.class));
+  }
+
+  private GoogleCloudBuildProperties.Account getBaseAccount() {
+    GoogleCloudBuildProperties.Account accountConfig = new GoogleCloudBuildProperties.Account();
+    accountConfig.setName("test-account");
+    accountConfig.setProject("test-project");
+    return accountConfig;
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepositoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepositoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoogleCloudBuildAccountRepositoryTest {
+
+  @Test(expected = NotFoundException.class)
+  public void emptyRepository() {
+    GoogleCloudBuildAccountRepository repository = new GoogleCloudBuildAccountRepository();
+    repository.getGoogleCloudBuild("missing");
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void missingAccount() {
+    GoogleCloudBuildAccountRepository repository = new GoogleCloudBuildAccountRepository();
+
+    GoogleCloudBuildAccount presentAccount = mock(GoogleCloudBuildAccount.class);
+    repository.registerAccount("present", presentAccount);
+
+    repository.getGoogleCloudBuild("missing");
+  }
+
+  public void presentAccount() {
+    GoogleCloudBuildAccountRepository repository = new GoogleCloudBuildAccountRepository();
+
+    GoogleCloudBuildAccount presentAccount = mock(GoogleCloudBuildAccount.class);
+    repository.registerAccount("present", presentAccount);
+
+    GoogleCloudBuildAccount retrievedAccount = repository.getGoogleCloudBuild("present");
+    assertSame(presentAccount, retrievedAccount);
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutorTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.services.cloudbuild.v1.CloudBuildRequest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoogleCloudBuildExecutorTest {
+  private GoogleCloudBuildExecutor executor = new GoogleCloudBuildExecutor();
+  private CloudBuildRequest<GenericJson> request = (CloudBuildRequest<GenericJson>) mock(CloudBuildRequest.class);
+
+  @Test
+  public void executesRequest() throws Exception {
+    GenericJson mockResult = mock(GenericJson.class);
+    when(request.execute()).thenReturn(mockResult);
+
+    GenericJson result = executor.execute(() -> request);
+    assertSame(mockResult, result);
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.BuildStep;
+import com.google.api.services.cloudbuild.v1.model.Operation;
+import com.netflix.spinnaker.igor.config.GoogleCloudBuildConfig;
+import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import java.util.*;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@RunWith(SpringRunner.class)
+@AutoConfigureMockMvc(secure = false)
+@EnableWebMvc
+@SpringBootTest(classes = {
+  GoogleCloudBuildConfig.class,
+  GoogleCloudBuildController.class,
+  GenericExceptionHandlers.class,
+  WireMockConfig.class
+})
+@TestPropertySource(properties = {"spring.config.location=classpath:gcb/gcb-test.yml"})
+public class GoogleCloudBuildTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  @Qualifier("stubCloudBuildService")
+  private WireMockServer stubCloudBuildService;
+
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void missingAccountTest() throws Exception {
+    String testBuild = objectMapper.writeValueAsString(buildRequest());
+    mockMvc.perform(
+      post("/gcb/builds/create/missing-account")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(testBuild)
+    ).andExpect(status().is(404));
+  }
+
+  @Test
+  public void presentAccountTest() throws Exception {
+    String buildRequest = objectMapper.writeValueAsString(buildRequest());
+    String buildResponse = objectMapper.writeValueAsString(buildResponse());
+    stubCloudBuildService.stubFor(
+      WireMock
+        .post(urlEqualTo("/v1/projects/spinnaker-gcb-test/builds"))
+        .withHeader("Authorization", equalTo("Bearer test-token"))
+        .withRequestBody(equalToJson(buildRequest))
+        .willReturn(aResponse().withStatus(200).withBody(buildResponse))
+    );
+
+    mockMvc.perform(
+      post("/gcb/builds/create/gcb-account")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(buildRequest)
+    ).andExpect(status().is(200))
+      .andExpect(content().json(buildResponse));
+
+    assertThat(stubCloudBuildService.findUnmatchedRequests().getRequests()).isEmpty();
+  }
+
+  private Build buildRequest() {
+    List<String> args = new ArrayList<>();
+    args.add("echo");
+    args.add("Hello, world!");
+
+    BuildStep buildStep = new BuildStep().setArgs(args).setName("hello");
+    return new Build().setSteps(Collections.singletonList(buildStep));
+  }
+
+  private Operation buildResponse() {
+    Build build = buildRequest();
+    build.setId("9f7a39db-b605-437f-aac1-f1ec3b798105");
+    build.setStatus("QUEUED");
+    build.setProjectId("spinnaker-gcb-test");
+    build.setCreateTime("2019-03-26T16:00:08.659446379Z");
+
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("@type", "type.googleapis.com/google.devtools.cloudbuild.v1.BuildOperationMetadata");
+    metadata.put("build", build);
+
+    Operation operation = new Operation();
+    operation.setName("operations/build/spinnaker-gcb-test/operationid");
+    operation.setMetadata(metadata);
+    return operation;
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/WireMockConfig.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/WireMockConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.testing.auth.oauth2.MockTokenServerTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.cloudbuild.v1.CloudBuildScopes;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+public class WireMockConfig {
+  @Bean(name = "stubCloudBuildService")
+  WireMockServer stubCloudBuildService() {
+    WireMockServer server = new WireMockServer(options().dynamicPort());
+    server.start();
+    return server;
+  }
+
+  @Bean
+  @Primary
+  CloudBuildFactory cloudBuildFactory(
+    HttpTransport httpTransport,
+    @Qualifier("stubCloudBuildService") WireMockServer wireMockServer
+  ) {
+    return new CloudBuildFactory(httpTransport, wireMockServer.baseUrl());
+  }
+
+  @Bean
+  @Primary
+  GoogleCredentialService googleCredentialService() {
+    return new GoogleCredentialService() {
+      @Override
+      GoogleCredential getFromKey(String jsonPath) {
+        if (!jsonPath.equals("/path/to/some/file")) {
+          return null;
+        }
+        // Create a mock credential whose bearer token is always "test-token"
+        try {
+          InputStream is = GoogleCloudBuildAccountFactory.class.getResourceAsStream("/gcb/gcb-test-account.json");
+          MockTokenServerTransport mockTransport = new MockTokenServerTransport("https://accounts.google.com/o/oauth2/auth");
+          mockTransport.addServiceAccount("test-account@spinnaker-gcb-test.iam.gserviceaccount.com", "test-token");
+          return GoogleCredential
+            .fromStream(is, mockTransport, JacksonFactory.getDefaultInstance())
+            .createScoped(CloudBuildScopes.all());
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
+}

--- a/igor-web/src/test/resources/gcb/gcb-test-account.json
+++ b/igor-web/src/test/resources/gcb/gcb-test-account.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "spinnaker-gcb-test",
+  "private_key_id": "8b362792857a0ea43501eceb138c0402425cc90a",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDYegEWFgg0hNpe\nRQB/Gj4LDbZeq1czRT1cntIZ5lC1KMSLsg+fbh5/qCD5jvcf8DWK1N3oAzmq7jCg\nEiYVde73eBx6JrpquZRXjq+4BN/RgWQszGLnp1tT6ZfKdw9liyucsYv5Nw/VsMb/\noDhBPrq4R1Tl5rbVT9+5BY9Zos3AMInN7Lvi9BYTUwnSaYx9BU1sFUV48RtX7JfJ\ny9A717Zy9vUR7gWV7/ctfLKQmMjA8FtOQCefVZlaq808KFqqo8L2L50lLwCyz/dG\nNe/d25WCaqywXi6RVB9SYYCkm7ho0txjAjr+fX9NQizoFamp9HK7JPqo1m6oU6ZE\n04+JXzPrAgMBAAECggEBAJvGb7Gs+QqR73GWxdywzaS2oV1OftluIdHcl+P7UGiM\nhaLg500auOez3Ma4kixxdpYIyAaFC6Js9KC7bpxS2TtLO3LLG6phENZQ3zHUkBr6\nuVNjYGjCjX28wnX3ZyTzGNcRDGCxtrtXElwwt0p8EXE6I2WsuDSX3a4OyjD+boC1\nGXaAuH4MXkPwVtL8v/s9xxO6eLBwAEVk/HkGtqHl9vGQEX5eRtIMeD2KE52tQYjZ\ns+wsAXSed3dKkvbJq1bVbhCwvr8YdAxAzgGdEgIJz5q3i+LYTWnXXOYVMaoibjKp\n3T26vwjDdDQR8RinXTqlv0HlxJp1ogDpt5PHf5ldjkECgYEA+usg0PV4e1FzBa1r\njMpjlVGYkzYBaBpcvR/1X6BYWIt0Eevgl3DIDA4JBDz3n3VYq8EoJD+DXJj+fcpQ\nZJjS07BkKEcfYOQk9OwgG4LfKqsRDjBioCDnLuFKQgK4aPjU4aGaaBRBIUm7GWjS\nL5PLmJgnYxlVVadmYSoqy8U/0KUCgYEA3NxQavTAiuep715W4IR7OwbOcdgPRHko\nfRb+sr4rorz1YwFQlUVRNGqGIYnzlt73BlQ/rLD8bQQFlZ1gF5ecA7F/z3TMmZJd\nkTZfM2vQl0kWywrs1VfdEtl6IOOG2msgw8eSfIU2QrN1gPYpx6K3Jpznwa7jvR7q\nGN2xeaHUvU8CgYAn0WhDwLB94U7/d6W5keR7rZcoxUkz2/sbiBbINgnPA1JIBcZ+\nQcd9Ij0MDyC8jUKk/uH/3pRZ/W1lSNW5IQdT0IoUWjUAizPSKiZuNzZy7vKl7ce4\n4X/OULIYB5Z8EgC2TY7TNWOghLLMNXYlVq7YaEzXzQ1dqlL02FwyOfsGgQKBgQCv\n0uBeVVxW+JhLTDIjaLRlyERfUx7MZxu5ga3gBA7e7kj3uVs6ikVcUhVX6+e0yumi\n6z0JsJgz/Uio0/FktrhoJE1YjWY4N9IvQTbGy+TyGyh/GcJzERCY6fMU7a00gqZB\n1cYjRTVuIknAEbgvCrV9ktnZUe5RZ6P7ibm42AFxdwKBgQDghX7NulRF/BpRJ8ls\n4sK93dFPIS7dp5LFrhR4f8GLzIBJ7w5B5iEC3GqdrfGesJTRVIJs5CRC36Bi7nhR\nUaME//wmnr+LX2ToElBel25sLnkAmcK7BSby2ConQEYvc4zMp8vmYAMe4rvN+dgs\nqmlvJiSZWW2lD76tH43J3xmXHw==\n-----END PRIVATE KEY-----\n",
+  "client_email": "test-account@spinnaker-gcb-test.iam.gserviceaccount.com",
+  "client_id": "1",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/auth",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-account%40spinnaker-gcb-test.iam.gserviceaccount.com"
+}

--- a/igor-web/src/test/resources/gcb/gcb-test.yml
+++ b/igor-web/src/test/resources/gcb/gcb-test.yml
@@ -1,0 +1,6 @@
+gcb:
+  enabled: true
+  accounts:
+  - name: gcb-account
+    project: spinnaker-gcb-test
+    jsonKey: /path/to/some/file


### PR DESCRIPTION
This PR adds the groundwork necessary for configuring GCB accounts, and adds an endpoint for triggering a GCB build using a specified account. Functionality to look up the status of a build and get build results will come later.