### PR TITLE
fix(artifacts): fixed parsing of version

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifacts/ArtifactController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifacts/ArtifactController.java
@@ -50,7 +50,7 @@ public class ArtifactController {
     return artifactService.getArtifactVersions(name);
   }
 
-  @GetMapping("/{provider}/{name}/{version}")
+  @GetMapping("/{provider}/{name}/{version:.+}")
   public Artifact getVersions(
     @PathVariable("provider") String provider,
     @PathVariable("name") String name,


### PR DESCRIPTION
This allows version to be something like `1.4.0-h40.5222222` and for that whole string to come through.