### PR TITLE
feat(gcb): Add endpoint for listing accounts

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepository.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepository.java
@@ -19,7 +19,9 @@ package com.netflix.spinnaker.igor.gcb;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Keeps track of all registered instances of GoogleCloudBuildAccount and returns the appropriate account when
@@ -30,6 +32,10 @@ public class GoogleCloudBuildAccountRepository {
 
   public void registerAccount(String name, GoogleCloudBuildAccount account) {
     accounts.put(name, account);
+  }
+
+  public List<String> getAccounts() {
+    return accounts.keySet().stream().sorted().collect(Collectors.toList());
   }
 
   public GoogleCloudBuildAccount getGoogleCloudBuild(String name) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -23,12 +23,19 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @ConditionalOnProperty("gcb.enabled")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/gcb")
 public class GoogleCloudBuildController {
   private final GoogleCloudBuildAccountRepository googleCloudBuildAccountRepository;
+
+  @RequestMapping(value = "/accounts", method = RequestMethod.GET)
+  List<String> getAccounts() {
+    return googleCloudBuildAccountRepository.getAccounts();
+  }
 
   @RequestMapping(value = "/builds/create/{account}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
   Operation createBuild(@PathVariable String account, @RequestBody Build build) {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepositoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepositoryTest.java
@@ -21,7 +21,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -43,6 +46,7 @@ public class GoogleCloudBuildAccountRepositoryTest {
     repository.getGoogleCloudBuild("missing");
   }
 
+  @Test
   public void presentAccount() {
     GoogleCloudBuildAccountRepository repository = new GoogleCloudBuildAccountRepository();
 
@@ -52,4 +56,20 @@ public class GoogleCloudBuildAccountRepositoryTest {
     GoogleCloudBuildAccount retrievedAccount = repository.getGoogleCloudBuild("present");
     assertSame(presentAccount, retrievedAccount);
   }
+
+  @Test
+  public void getAccounts() {
+    GoogleCloudBuildAccountRepository repository = new GoogleCloudBuildAccountRepository();
+
+    GoogleCloudBuildAccount presentAccount = mock(GoogleCloudBuildAccount.class);
+
+    List<String> accountsBefore = repository.getAccounts();
+    assertTrue(accountsBefore.isEmpty());
+
+    repository.registerAccount("present", presentAccount);
+
+    List<String> accountsAfter = repository.getAccounts();
+    assertEquals(accountsAfter, Collections.singletonList("present"));
+  }
+
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
@@ -40,6 +40,7 @@ import java.util.*;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -94,6 +95,20 @@ public class GoogleCloudBuildTest {
         .content(buildRequest)
     ).andExpect(status().is(200))
       .andExpect(content().json(buildResponse));
+
+    assertThat(stubCloudBuildService.findUnmatchedRequests().getRequests()).isEmpty();
+  }
+
+  @Test
+  public void listAccountTest() throws Exception {
+    List<String> expectedAccounts = Collections.singletonList("gcb-account");
+    String expectedResponse = objectMapper.writeValueAsString(expectedAccounts);
+
+    mockMvc.perform(
+      get("/gcb/accounts")
+        .accept(MediaType.APPLICATION_JSON)
+    ).andExpect(status().is(200))
+      .andExpect(content().json(expectedResponse));
 
     assertThat(stubCloudBuildService.findUnmatchedRequests().getRequests()).isEmpty();
   }


### PR DESCRIPTION
The UI for the GCB stage should provide a drop-down that lists available accounts, so we need to support this operation on the back-end.

This is similar to the '/masters' endpoint that lists the available build services for other services. I didn't have GCB implement BuildService because the types of operations it supports are different, which means that we don't get the '/masters' functionality for free.

As I develop this functionality further I'll see whether there's a more general interface that emerges that this and other build services can implement, at which point we may be able to add these into the general
'/masters/ endpoint.  But for now, adding a separate '/gcb/accounts' endpoint that will list GCB accounts.