### PR TITLE
feat(travis): Customize the Travis build message on triggered builds

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisConfig.java
@@ -66,7 +66,7 @@ public class TravisConfig {
                 log.info("bootstrapping {} as {}", host.getAddress(), travisName);
 
                 TravisClient client = travisClient(host.getAddress(), igorConfigurationProperties.getClient().getTimeout(), objectMapper);
-                return travisService(travisName, host.getBaseUrl(), host.getGithubToken(), host.getNumberOfRepositories(), client, travisCache, artifactDecorator, (travisProperties == null ? null : travisProperties.getRegexes()), host.getPermissions().build());
+                return travisService(travisName, host.getBaseUrl(), host.getGithubToken(), host.getNumberOfRepositories(), client, travisCache, artifactDecorator, (travisProperties == null ? null : travisProperties.getRegexes()), travisProperties.getBuildMessageKey(), host.getPermissions().build());
             })
             .collect(Collectors.toMap(TravisService::getGroupKey, Function.identity()));
 
@@ -74,8 +74,8 @@ public class TravisConfig {
         return travisMasters;
     }
 
-    private static TravisService travisService(String travisHostId, String baseUrl, String githubToken, int numberOfRepositories, TravisClient travisClient, TravisCache travisCache, Optional<ArtifactDecorator> artifactDecorator, Collection<String> artifactRexeges, Permissions permissions) {
-        return new TravisService(travisHostId, baseUrl, githubToken, numberOfRepositories, travisClient, travisCache, artifactDecorator, artifactRexeges, permissions);
+    private static TravisService travisService(String travisHostId, String baseUrl, String githubToken, int numberOfRepositories, TravisClient travisClient, TravisCache travisCache, Optional<ArtifactDecorator> artifactDecorator, Collection<String> artifactRexeges, String buildMessageKey, Permissions permissions) {
+        return new TravisService(travisHostId, baseUrl, githubToken, numberOfRepositories, travisClient, travisCache, artifactDecorator, artifactRexeges, buildMessageKey, permissions);
     }
 
     public static TravisClient travisClient(String address, int timeout, ObjectMapper objectMapper) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
@@ -33,6 +33,13 @@ public class TravisProperties implements BuildServerProperties<TravisProperties.
     private List<TravisHost> masters;
     @Valid
     private List<String> regexes;
+    /**
+     * Lets you customize the build message used when Spinnaker triggers builds in Travis. If you set a custom parameter
+     * in the Travis stage in Spinnaker with the value of this property as the key (e.g
+     * <code>travis.buildMessage=My customized message</code>, the build message in Travis will be
+     * <em>Triggered from Spinnaker: My customized message</em>. The first part of this message is not customizable.
+     */
+    private String buildMessageKey = "travis.buildMessage";
 
     public boolean getRepositorySyncEnabled() {
         return repositorySyncEnabled;
@@ -70,7 +77,15 @@ public class TravisProperties implements BuildServerProperties<TravisProperties.
         this.regexes = regexes;
     }
 
-    public long getNewBuildGracePeriodSeconds() {
+    public String getBuildMessageKey() {
+      return buildMessageKey;
+    }
+
+    public void setBuildMessageKey(String buildMessageKey) {
+      this.buildMessageKey = buildMessageKey;
+    }
+
+  public long getNewBuildGracePeriodSeconds() {
         return newBuildGracePeriodSeconds;
     }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/RepoRequest.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/RepoRequest.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 @JsonRootName("request")
 public class RepoRequest {
     private String branch;
-    private String message = "Triggered from spinnaker";
+    private String message = "Triggered from Spinnaker";
     private Config config;
 
     public RepoRequest(String branch) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.java
@@ -76,7 +76,9 @@ public class V3Build {
     }
 
     public boolean spinnakerTriggered() {
-        return ("api".equals(eventType) && commit != null && "Triggered from spinnaker".equals(commit.getMessage()));
+        return ("api".equals(eventType) && commit != null && commit.getMessage() != null
+            && (commit.getMessage().startsWith("Triggered from spinnaker")
+            || commit.getMessage().startsWith("Triggered from Spinnaker")));
     }
 
     public String toString() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -105,7 +105,7 @@ class InfoControllerSpec extends Specification {
             new Permissions.Builder()
                 .add(Authorization.READ, ['group-1', 'group-2'])
                 .add(Authorization.WRITE, 'group-2').build())
-        TravisService travisService = new TravisService('travis-baz', null, null, 100, null, null, Optional.empty(), [],
+        TravisService travisService = new TravisService('travis-baz', null, null, 100, null, null, Optional.empty(), [], null,
             new Permissions.Builder()
                 .add(Authorization.READ, ['group-3', 'group-4'])
                 .add(Authorization.WRITE, 'group-3').build())


### PR DESCRIPTION
Lets you customize the build message used when Spinnaker triggers builds in Travis. If you set a custom parameter in the Travis stage in Spinnaker with the key `travis.buildMessage` (customizable) (e.g `travis.buildMessage=My customized message`, the build message in Travis will be _Triggered from Spinnaker: My customized message_. The first part of this message is not possible to change.
![image](https://user-images.githubusercontent.com/155558/55166178-eb73d480-516e-11e9-94cb-11e5d5c7433b.png)
![image](https://user-images.githubusercontent.com/155558/55166113-d303ba00-516e-11e9-8efe-f28bd24193c5.png)
