### PR TITLE
fix(travis): Check that logs are complete before parsing them

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.igor.service.BuildServices;
 import com.netflix.spinnaker.igor.travis.client.model.Repo;
 import com.netflix.spinnaker.igor.travis.client.model.v3.TravisBuildState;
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build;
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Job;
 import com.netflix.spinnaker.igor.travis.service.TravisBuildConverter;
 import com.netflix.spinnaker.igor.travis.service.TravisService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -178,10 +179,11 @@ public class TravisBuildMonitor extends CommonPollingMonitor<TravisBuildMonitor.
             .map(build -> setTracking(build, master))
             .filter(filterNewBuildsPredicate())
             .forEach(build -> {
-            String branchedRepoSlug = build.branchedRepoSlug();
-            int cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug, build.getState().isRunning());
-            GenericBuild genericBuild = TravisBuildConverter.genericBuild(build, travisService.getBaseUrl());
-            if (build.getNumber() > cachedBuild && !build.spinnakerTriggered()) {
+                String branchedRepoSlug = build.branchedRepoSlug();
+                int cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug, build.getState().isRunning());
+                GenericBuild genericBuild = TravisBuildConverter.genericBuild(build, travisService.getBaseUrl());
+                List<Integer> jobIds = build.getJobs().stream().map(V3Job::getId).collect(Collectors.toList());
+                if (build.getNumber() > cachedBuild && !build.spinnakerTriggered() && travisService.isLogReady(jobIds)) {
                 BuildDelta delta = new BuildDelta()
                     .setBranchedRepoSlug(branchedRepoSlug)
                     .setBuild(build)

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -43,6 +43,7 @@ import org.springframework.stereotype.Service;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -182,7 +183,7 @@ public class TravisBuildMonitor extends CommonPollingMonitor<TravisBuildMonitor.
                 String branchedRepoSlug = build.branchedRepoSlug();
                 int cachedBuild = buildCache.getLastBuild(master, branchedRepoSlug, build.getState().isRunning());
                 GenericBuild genericBuild = TravisBuildConverter.genericBuild(build, travisService.getBaseUrl());
-                List<Integer> jobIds = build.getJobs().stream().map(V3Job::getId).collect(Collectors.toList());
+                List<Integer> jobIds = build.getJobs() != null ? build.getJobs().stream().map(V3Job::getId).collect(Collectors.toList()) : Collections.emptyList();
                 if (build.getNumber() > cachedBuild && !build.spinnakerTriggered() && travisService.isLogReady(jobIds)) {
                 BuildDelta delta = new BuildDelta()
                     .setBranchedRepoSlug(branchedRepoSlug)

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
@@ -33,7 +33,10 @@ import java.util.Map;
 @ConditionalOnProperty("travis.enabled")
 public class TravisCache {
 
-    private final static String ID = "travis:builds:queue";
+    private static final String ID = "travis:builds";
+    private static final String QUEUE_TYPE = ID + ":queue";
+    private static final String LOG_TYPE = ID + ":log";
+    private static final int LOG_EXPIRE_SECONDS = 600;
 
     private final RedisClientDelegate redisClientDelegate;
     private final IgorConfigurationProperties igorConfigurationProperties;
@@ -46,7 +49,7 @@ public class TravisCache {
 
     public Map<String, Integer> getQueuedJob(String master, int queueNumber) {
         Map<String, String> result = redisClientDelegate.withCommandsClient(c -> {
-            return c.hgetAll(makeKey(master, queueNumber));
+            return c.hgetAll(makeKey(QUEUE_TYPE, master, queueNumber));
         });
 
         if (result.isEmpty()) {
@@ -61,7 +64,7 @@ public class TravisCache {
     }
 
     public int setQueuedJob(String master, int repositoryId, int requestId) {
-        String key = makeKey(master, requestId);
+        String key = makeKey(QUEUE_TYPE, master, requestId);
         redisClientDelegate.withCommandsClient(c -> {
             c.hset(key, "requestId", Integer.toString(requestId));
             c.hset(key, "repositoryId", Integer.toString(repositoryId));
@@ -69,17 +72,31 @@ public class TravisCache {
         return requestId;
     }
 
-    public void remove(String master, int queueId) {
+    public void removeQuededJob(String master, int queueId) {
         redisClientDelegate.withCommandsClient(c -> {
-            c.del(makeKey(master, queueId));
+            c.del(makeKey(QUEUE_TYPE, master, queueId));
         });
     }
 
-    private String makeKey(String master, int queueId) {
-        return baseKey() + ":" + master + ":" + queueId;
+    public void setJobLog(String master, int jobId, String log) {
+      String key = makeKey(LOG_TYPE, master, jobId);
+      redisClientDelegate.withCommandsClient(c -> {
+        c.setex(key, LOG_EXPIRE_SECONDS, log);
+      });
+    }
+
+    public String getJobLog(String master, int jobId) {
+      String key = makeKey(LOG_TYPE, master, jobId);
+      return redisClientDelegate.withCommandsClient(c -> {
+        return c.get(key);
+      });
+    }
+
+    private String makeKey(String type, String master, int id) {
+        return baseKey() + ":" + type + ":" + master + ":" + id;
     }
 
     private String baseKey() {
-        return igorConfigurationProperties.getSpinnaker().getJedis().getPrefix() + ":" + ID;
+        return igorConfigurationProperties.getSpinnaker().getJedis().getPrefix();
     }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
@@ -79,17 +79,17 @@ public class TravisCache {
     }
 
     public void setJobLog(String master, int jobId, String log) {
-      String key = makeKey(LOG_TYPE, master, jobId);
-      redisClientDelegate.withCommandsClient(c -> {
-        c.setex(key, LOG_EXPIRE_SECONDS, log);
-      });
+        String key = makeKey(LOG_TYPE, master, jobId);
+        redisClientDelegate.withCommandsClient(c -> {
+            c.setex(key, LOG_EXPIRE_SECONDS, log);
+        });
     }
 
     public String getJobLog(String master, int jobId) {
-      String key = makeKey(LOG_TYPE, master, jobId);
-      return redisClientDelegate.withCommandsClient(c -> {
-        return c.get(key);
-      });
+        String key = makeKey(LOG_TYPE, master, jobId);
+        return redisClientDelegate.withCommandsClient(c -> {
+            return c.get(key);
+        });
     }
 
     private String makeKey(String type, String master, int id) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/TravisClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/TravisClient.java
@@ -42,7 +42,6 @@ import retrofit.http.Headers;
 import retrofit.http.POST;
 import retrofit.http.Path;
 import retrofit.http.Query;
-import retrofit.http.Streaming;
 
 public interface TravisClient {
     @POST("/auth/github")
@@ -87,11 +86,6 @@ public interface TravisClient {
 
     @GET("/jobs/{job_id}")
     public abstract Jobs jobs(@Header("Authorization") String accessToken, @Path("job_id") int jobId);
-
-    @Streaming
-    @Headers("Accept: text/plain")
-    @GET("/logs/{logId}")
-    public abstract Response log(@Header("Authorization") String accessToken, @Path("logId") int logId);
 
     @Headers({"Travis-API-Version: 3", "Accept: text/plain"})
     @GET("/job/{jobId}/log")

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
@@ -60,11 +60,11 @@ public class V3Log {
 
     public boolean isReady() {
         if (logParts == null || logParts.isEmpty()) {
-          return false;
+            return false;
         }
         int numberOfParts = logParts.size() - 1;
-      V3LogPart lastLogPart = logParts.get(numberOfParts);
-      return numberOfParts == lastLogPart.number && lastLogPart.isFinal();
+        V3LogPart lastLogPart = logParts.get(numberOfParts);
+        return numberOfParts == lastLogPart.number && lastLogPart.isFinal();
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
@@ -71,7 +71,7 @@ public class V3Log {
     static class V3LogPart {
         private String content;
         private Integer number;
-        private boolean _final;
+        private boolean isFinal;
 
         public String getContent() {
             return content;
@@ -90,11 +90,11 @@ public class V3Log {
         }
 
         public boolean isFinal() {
-            return _final;
+            return isFinal;
         }
 
-        public void setFinal(boolean _final) {
-            this._final = _final;
+        public void setFinal(boolean isFinal) {
+            this.isFinal = isFinal;
         }
     }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
@@ -59,8 +59,12 @@ public class V3Log {
     }
 
     public boolean isReady() {
+        if (logParts == null || logParts.isEmpty()) {
+          return false;
+        }
         int numberOfParts = logParts.size() - 1;
-        return numberOfParts == logParts.get(numberOfParts).number && logParts.get(numberOfParts).isFinal();
+      V3LogPart lastLogPart = logParts.get(numberOfParts);
+      return numberOfParts == lastLogPart.number && lastLogPart.isFinal();
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
@@ -58,10 +58,16 @@ public class V3Log {
         this.logParts = logParts;
     }
 
+    public boolean isReady() {
+        int numberOfParts = logParts.size() - 1;
+        return numberOfParts == logParts.get(numberOfParts).number && logParts.get(numberOfParts).isFinal();
+    }
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class V3LogPart {
         private String content;
         private Integer number;
+        private boolean _final;
 
         public String getContent() {
             return content;
@@ -77,6 +83,14 @@ public class V3Log {
 
         public void setNumber(Integer number) {
             this.number = number;
+        }
+
+        public boolean isFinal() {
+            return _final;
+        }
+
+        public void setFinal(boolean _final) {
+            this._final = _final;
         }
     }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
@@ -286,8 +286,6 @@ public class TravisService implements BuildOperations, BuildProperties {
             return "";
         }
         String travisLog = jobIds.stream()
-            .map(this::getJob)
-            .map(Job::getId)
             .map(this::getJobLog)
             .filter(Objects::nonNull)
             .collect(Collectors.joining("\n"));

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.hystrix.SimpleJava8HystrixCommand;
 import com.netflix.spinnaker.igor.build.model.GenericBuild;
 import com.netflix.spinnaker.igor.build.model.GenericGitRevision;
 import com.netflix.spinnaker.igor.build.model.GenericJobConfiguration;
+import com.netflix.spinnaker.igor.build.model.Result;
 import com.netflix.spinnaker.igor.model.BuildServiceProvider;
 import com.netflix.spinnaker.igor.service.ArtifactDecorator;
 import com.netflix.spinnaker.igor.service.BuildOperations;
@@ -54,8 +55,6 @@ import net.logstash.logback.argument.StructuredArguments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import retrofit.RetrofitError;
-import retrofit.client.Response;
-import retrofit.mime.TypedByteArray;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -137,7 +136,7 @@ public class TravisService implements BuildOperations, BuildProperties {
         return new SimpleJava8HystrixCommand<>(groupKey, buildCommandKey("getGenericBuild"), () -> {
             String repoSlug = cleanRepoSlug(inputRepoSlug);
             Build build = getBuild(repoSlug, buildNumber);
-            return getGenericBuild(build, repoSlug, true);
+            return getGenericBuild(build, repoSlug);
         }).execute();
     }
 
@@ -276,7 +275,8 @@ public class TravisService implements BuildOperations, BuildProperties {
 
     public Job getJob(int jobId) {
         log.debug("fetching job for {}", jobId);
-        Jobs jobs = travisClient.jobs(getAccessToken(), jobId);
+        Jobs jobs = new SimpleJava8HystrixCommand<>(groupKey, buildCommandKey("getJob"), () ->
+            travisClient.jobs(getAccessToken(), jobId)).execute();
         return jobs.getJob();
     }
 
@@ -287,14 +287,9 @@ public class TravisService implements BuildOperations, BuildProperties {
         }
         String travisLog = jobIds.stream()
             .map(this::getJob)
-            .map(job -> {
-                if (job.getLogId() > 0) {
-                    return getLog(job.getLogId());
-                } else {
-                    V3Log log = getJobLog(job.getId());
-                    return log == null ? "" : log.getContent();
-                }
-            })
+            .map(Job::getId)
+            .map(this::getJobLog)
+            .filter(Objects::nonNull)
             .collect(Collectors.joining("\n"));
         log.info("fetched logs for [buildNumber:{}], [buildId:{}], [logLength:{}]", build.getNumber(), build.getId(), travisLog.length());
         return travisLog;
@@ -305,21 +300,42 @@ public class TravisService implements BuildOperations, BuildProperties {
             .map(V3Job::getId)
             .map(this::getJobLog)
             .filter(Objects::nonNull)
-            .map(V3Log::getContent)
             .collect(Collectors.joining("\n"));
         log.info("fetched logs for [buildNumber:{}], [buildId:{}], [logLength:{}]", build.getNumber(), build.getId(), travisLog.length());
         return travisLog;
     }
 
-    public String getLog(int logId) {
-        log.debug("fetching log by logId {}", logId);
-        Response response = travisClient.log(getAccessToken(), logId);
-        return new String(((TypedByteArray) response.getBody()).getBytes());
+    public boolean isLogReady(List<Integer> jobIds) {
+        return jobIds.stream()
+            .map(this::getAndCacheJobLog)
+            .allMatch(Optional::isPresent);
     }
 
-    public V3Log getJobLog(int jobId) {
+    private Optional<String> getAndCacheJobLog(int jobId) {
         log.debug("fetching log by jobId {}", jobId);
-        return travisClient.jobLog(getAccessToken(), jobId);
+        String cachedLog = travisCache.getJobLog(groupKey, jobId);
+        if (cachedLog != null) {
+            log.info("Found log for jobId {} in the cache", jobId);
+            return Optional.of(cachedLog);
+        }
+        V3Log v3Log = new SimpleJava8HystrixCommand<>(groupKey, buildCommandKey("getJobLog"), () ->
+            travisClient.jobLog(getAccessToken(), jobId)).execute();
+        if (v3Log != null && v3Log.isReady()) {
+            log.info("Log for jobId {} was ready, caching it", jobId);
+            travisCache.setJobLog(groupKey, jobId, v3Log.getContent());
+            return Optional.of(v3Log.getContent());
+        }
+        return Optional.empty();
+    }
+
+    public String getJobLog(int jobId) {
+        Optional<String> jobLog = getAndCacheJobLog(jobId);
+        if (jobLog.isPresent()) {
+            return jobLog.get();
+        } else {
+            log.warn("Incomplete log for jobId {}! This is not supposed to happen.", jobId);
+            return null;
+        }
     }
 
     public Repo getRepo(int repositoryId) {
@@ -331,13 +347,12 @@ public class TravisService implements BuildOperations, BuildProperties {
     }
 
     public GenericBuild getGenericBuild(Build build, String repoSlug) {
-        return getGenericBuild(build, repoSlug, false);
-    }
-
-    public GenericBuild getGenericBuild(Build build, String repoSlug, boolean fetchLogs) {
         GenericBuild genericBuild = TravisBuildConverter.genericBuild(build, repoSlug, baseUrl);
-        if (fetchLogs) {
+        boolean logReady = isLogReady(build.getJob_ids());
+        if (logReady) {
             parseAndDecorateArtifacts(getLog(build), genericBuild);
+        } else {
+            genericBuild.setResult(Result.BUILDING);
         }
         return genericBuild;
     }
@@ -370,7 +385,7 @@ public class TravisService implements BuildOperations, BuildProperties {
         Request requestResponse = travisClient.request(getAccessToken(), queuedJob.get("repositoryId"), queuedJob.get("requestId"));
         if (!requestResponse.getBuilds().isEmpty()) {
             log.info("{}: Build found: [{}:{}] . Removing {} from {} travisCache.", StructuredArguments.kv("group", groupKey), requestResponse.getRepository().getSlug(), requestResponse.getBuilds().get(0).getNumber(), queueId, groupKey);
-            travisCache.remove(groupKey, queueId);
+            travisCache.removeQuededJob(groupKey, queueId);
             LinkedHashMap<String, Integer> map = new LinkedHashMap<>(1);
             map.put("number", requestResponse.getBuilds().get(0).getNumber());
             return map;

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -56,6 +56,7 @@ class TravisBuildMonitorSpec extends Specification {
             Optional.of(echoService),
             Optional.empty()
         )
+        travisService.isLogReady(_) >> true
     }
 
     void 'flag a new build on master, but do not send event on repo if a newer build is present at repo level'() {
@@ -76,6 +77,7 @@ class TravisBuildMonitorSpec extends Specification {
         1 * travisService.getReposForAccounts() >> repos
         1 * travisService.getBuilds(repo, 5) >> [ build ]
         build.branchedRepoSlug() >> "test-org/test-repo/master"
+        build.jobs >> []
         build.getNumber() >> 4
         build.getState() >> TravisBuildState.passed
         build.repository >> repository
@@ -118,6 +120,7 @@ class TravisBuildMonitorSpec extends Specification {
         build.branchedRepoSlug() >> "test-org/test-repo/master"
         build.getNumber() >> 4
         build.getState() >> TravisBuildState.passed
+        build.jobs >> []
         build.repository >> repository
         repository.slug >> 'test-org/test-repo'
 
@@ -153,6 +156,7 @@ class TravisBuildMonitorSpec extends Specification {
         build.branchedRepoSlug() >> "test-org/test-repo/my_branch"
         build.getNumber() >> 4
         build.getState() >> TravisBuildState.passed
+        build.jobs >> []
         build.repository >> repository
         repository.slug >> 'test-org/test-repo'
 
@@ -195,6 +199,7 @@ class TravisBuildMonitorSpec extends Specification {
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo/my_branch', 4, false, CACHED_JOB_TTL_SECONDS)
         1 * buildCache.setLastBuild(MASTER, 'test-org/test-repo', 4, false, CACHED_JOB_TTL_SECONDS)
 
+        build.jobs >> []
         build.repository >> repository
         repository.slug >> 'test-org/test-repo'
         build.getState() >> "passed"
@@ -223,10 +228,12 @@ class TravisBuildMonitorSpec extends Specification {
         build.branchedRepoSlug() >> "test-org/test-repo/my_branch"
         build.getNumber() >> 4
         build.getState() >> TravisBuildState.passed
+        build.jobs >> []
         build.repository >> repository
         buildDifferentBranch.branchedRepoSlug() >> "test-org/test-repo/different_branch"
         buildDifferentBranch.getNumber() >> 3
         buildDifferentBranch.getState() >> TravisBuildState.passed
+        buildDifferentBranch.jobs >> []
         buildDifferentBranch.repository >> repository
         repository.slug >> 'test-org/test-repo'
         1 * travisService.getGenericBuild(build, true) >> TravisBuildConverter.genericBuild(build, MASTER)


### PR DESCRIPTION
The Travis™ API often returns incomplete logs for a few moments (~30-60 seconds) after a build completes. As we are dependent on the logs for detecting both build artifacts and fetching properties, I've added additional checks that will cause Spinnaker to wait until the logs are ready before trying to parse them. If you thought that there's an endpoint in the Travis API to check if the logs are ready yet, you would be wrong. So we have to check this by actually downloading the logs multiple times until they are complete.

**Pros:** We get rid of a whole bunch of weird, non-deterministic bugs caused by the last few lines of the log to sometimes be cut away. Especially since the last couple of lines is where users usually upload artifacts, our pipelines will now Work More Often™ and Fail Less™ because of missing artifacts and/or properties.

**Cons:** It will take, on average, 30 seconds longer before a completed build triggers a Spinnaker pipeline or a Travis stage completes. And we're probably causing some increased load on Travis since we are asking for logs more often.

**Bonus:** I've added Redis caching for the logs as well, with a TTL of 10 minutes. As soon as the log is ready, it goes into the cache.