### PR TITLE
fix(concourse): Fix deserialization of put resource metadata

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/Event.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/Event.java
@@ -19,12 +19,14 @@ package com.netflix.spinnaker.igor.concourse.client.model;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@ToString
 @Data
 public class Event {
   private Data data;
@@ -34,6 +36,7 @@ public class Event {
     return data.getOrigin() == null ? null : data.getOrigin().getId();
   }
 
+  @ToString
   @Setter
   public static class Data {
     @Getter

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/Plan.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/Plan.java
@@ -46,12 +46,20 @@ public class Plan {
     private ResourceShape put;
 
     @Nullable
+    private OnSuccess onSuccess;
+
+    @Nullable
     public Resource getResource() {
-      ResourceShape shape = get == null ? put : get;
+      String resourceId = id;
+      ResourceShape shape = get;
+      if(shape == null && onSuccess != null) {
+        shape = onSuccess.getStep().put;
+        resourceId = onSuccess.getStep().id;
+      }
       if (shape == null) {
         return null;
       }
-      return new Resource(id, shape.getName(), shape.getType());
+      return new Resource(resourceId, shape.getName(), shape.getType());
     }
   }
 
@@ -59,6 +67,11 @@ public class Plan {
   private static class ResourceShape {
     private String type;
     private String name;
+  }
+
+  @Data
+  private static class OnSuccess {
+    private Op step;
   }
 
   public List<Resource> getResources() {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/Plan.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/Plan.java
@@ -52,7 +52,7 @@ public class Plan {
     public Resource getResource() {
       String resourceId = id;
       ResourceShape shape = get;
-      if(shape == null && onSuccess != null) {
+      if (shape == null && onSuccess != null) {
         shape = onSuccess.getStep().put;
         resourceId = onSuccess.getStep().id;
       }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
@@ -218,6 +218,7 @@ public class ConcourseService implements BuildOperations, BuildProperties {
 
     Disposable eventStream = events
       .doOnNext(event -> {
+        log.debug("Event for build {}: {}", buildId, event);
         Resource resource = resources.get(event.getResourceId());
         if (resource != null) {
           resource.setMetadata(event.getData().getMetadata());


### PR DESCRIPTION
Put resource ids are buried under two further levels of nesting than get resources:

![image](https://user-images.githubusercontent.com/1697736/55761842-44245680-5a26-11e9-9b10-035f0f7b4077.png)
 