### PR TITLE
 fix(artifactory): Avoid AQL 500 when context root is non-empty

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -63,13 +63,3 @@ dependencies {
     testCompile 'com.github.tomakehurst:wiremock-jre8:2.22.0'
     testCompile 'org.mockito:mockito-core:2.6.8'
 }
-
-configurations.all {
-    resolutionStrategy {
-        force 'org.apache.log4j:log4j:1.2.17'
-        force 'commons-codec:commons-codec:1.7'
-    }
-    exclude group: 'javax.servlet', module: 'servlet-api'
-    exclude group: "org.slf4j", module: "slf4j-log4j12"
-    exclude group: "org.mortbay.jetty", module: "servlet-api"
-}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
@@ -124,7 +124,7 @@ public class ArtifactoryBuildMonitor extends CommonPollingMonitor<ArtifactoryBui
 
         ArtifactoryRequest aqlRequest = new ArtifactoryRequestImpl()
           .method(ArtifactoryRequest.Method.POST)
-          .apiUrl("/api/search/aql")
+          .apiUrl("api/search/aql")
           .requestType(ArtifactoryRequest.ContentType.TEXT)
           .responseType(ArtifactoryRequest.ContentType.JSON)
           .requestBody(aqlQuery);


### PR DESCRIPTION
When the context root is non-empty, the Artifactory client constructs a post request with an extra slash in the path, which in turn causes Artifactory to throw a spurious error about a missing repo key.

```
POST /artifactory//api/search/aql
```