### PR TITLE
feat(gcb): Add endpoints for storing and retrieving build status

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
@@ -30,6 +30,7 @@ public class GoogleCloudBuildProperties {
     public static class Account {
         private String name;
         private String project;
+        private String subscriptionName;
         private String jsonKey;
     }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.gcb;
 import com.google.api.services.cloudbuild.v1.CloudBuild;
 import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.Operation;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -30,8 +31,17 @@ public class GoogleCloudBuildAccount {
   private final String projectId;
   private final CloudBuild cloudBuild;
   private final GoogleCloudBuildExecutor executor;
+  private final GoogleCloudBuildCache googleCloudBuildCache;
 
   public Operation createBuild(Build build) {
     return executor.execute(() -> cloudBuild.projects().builds().create(projectId, build));
+  }
+
+  public void updateBuild(String buildId, String status, String serializedBuild) {
+    googleCloudBuildCache.updateBuild(buildId, status, serializedBuild);
+  }
+
+  public String getBuild(String buildId) {
+    return googleCloudBuildCache.getBuild(buildId);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -22,6 +22,8 @@ import com.google.api.services.cloudbuild.v1.model.Operation;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Map;
+
 /**
  * Generates authenticated requests to the Google Cloud Build API for a single configured account, delegating to
  * GoogleCloudBuildExecutor to execute these requests.
@@ -33,8 +35,10 @@ public class GoogleCloudBuildAccount {
   private final GoogleCloudBuildExecutor executor;
   private final GoogleCloudBuildCache googleCloudBuildCache;
 
-  public Operation createBuild(Build build) {
-    return executor.execute(() -> cloudBuild.projects().builds().create(projectId, build));
+  @SuppressWarnings("unchecked")
+  public Map<String, Object> createBuild(Build build) {
+    Operation operation = executor.execute(() -> cloudBuild.projects().builds().create(projectId, build));
+    return (Map<String, Object>) operation.getMetadata().get("build");
   }
 
   public void updateBuild(String buildId, String status, String serializedBuild) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
@@ -17,15 +17,10 @@
 package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.http.HttpRequestInitializer;
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.cloudbuild.v1.CloudBuild;
 import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -41,13 +36,19 @@ public class GoogleCloudBuildAccountFactory {
   private final GoogleCredentialService credentialService;
   private final CloudBuildFactory cloudBuildFactory;
   private final GoogleCloudBuildExecutor googleCloudBuildExecutor;
+  private final GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory;
 
   public GoogleCloudBuildAccount build(GoogleCloudBuildProperties.Account account) {
     GoogleCredential credential = getCredential(account);
     String applicationName = getApplicationName();
     CloudBuild cloudBuild = cloudBuildFactory.getCloudBuild(credential, applicationName);
 
-    return new GoogleCloudBuildAccount(account.getProject(), cloudBuild, googleCloudBuildExecutor);
+    return new GoogleCloudBuildAccount(
+      account.getProject(),
+      cloudBuild,
+      googleCloudBuildExecutor,
+      googleCloudBuildCacheFactory.create(account.getName())
+    );
   }
 
   private String getApplicationName() {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCache.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCache.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.netflix.spinnaker.igor.polling.LockService;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Cache to keep track of the status of Google Cloud builds. In general, this cache will be updated as echo
+ * receives PubSub build notifications and sends them to igor.
+ */
+@RequiredArgsConstructor(access=AccessLevel.PRIVATE)
+public class GoogleCloudBuildCache {
+  private final LockService lockService;
+  private final RedisClientDelegate redisClientDelegate;
+  private final String keyPrefix;
+  private final String lockPrefix;
+
+  @RequiredArgsConstructor
+  public static class Factory {
+    private final LockService lockService;
+    private final RedisClientDelegate redisClientDelegate;
+    private final String baseKeyPrefix;
+    private static final String baseLockPrefix = "googleCloudBuild";
+
+    public GoogleCloudBuildCache create(String accountName) {
+      String keyPrefix = String.format("%s:%s", baseKeyPrefix, accountName);
+      String lockPrefix = String.format("%s.%s", baseLockPrefix, accountName);
+      return new GoogleCloudBuildCache(lockService, redisClientDelegate, keyPrefix, lockPrefix);
+    }
+  }
+
+  public String getBuild(String buildId) {
+    String key = new GoogleCloudBuildKey(keyPrefix, buildId).toString();
+    return redisClientDelegate.withCommandsClient(c -> {
+      Map<String, String> res = c.hgetAll(key);
+      return res.get("build");
+    });
+  }
+
+  private void internalUpdateBuild(String buildId, String status, String build) {
+    String key = new GoogleCloudBuildKey(keyPrefix, buildId).toString();
+    redisClientDelegate.withCommandsClient(c -> {
+      String oldStatus = c.hget(key, "status");
+      if (allowUpdate(oldStatus, status)) {
+        c.hset(key, "status", status);
+        c.hset(key, "build", build);
+      }
+    });
+  }
+
+  // As we may be processing build notifications out of order, only allow an update of the cache if
+  // the incoming build status is newer than the status that we currently have cached.
+  private boolean allowUpdate(String oldStatusString, String newStatusString) {
+    if (oldStatusString == null) {
+      return true;
+    }
+    if (newStatusString == null) {
+      return false;
+    }
+    try {
+      GoogleCloudBuildStatus oldStatus = GoogleCloudBuildStatus.valueOf(oldStatusString);
+      GoogleCloudBuildStatus newStatus = GoogleCloudBuildStatus.valueOf(newStatusString);
+      return newStatus.greaterThanOrEqualTo(oldStatus);
+    } catch (IllegalArgumentException e) {
+      // If one of the statuses is not recognized, allow the update (assuming that the later message is newer). This is
+      // to be robust against GCB adding statuses in the future.
+      return true;
+    }
+  }
+
+  public void updateBuild(String buildId, String status, String build) {
+    String lockName = String.format("%s.%s", lockPrefix, buildId);
+    lockService.acquire(lockName, Duration.ofSeconds(10), () -> {
+      internalUpdateBuild(buildId, status, build);
+    });
+  }
+
+  @RequiredArgsConstructor
+  static class GoogleCloudBuildKey {
+    private final String prefix;
+    private final String id;
+
+    public String toString() {
+      return String.format("%s:%s", prefix, id);
+    }
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -31,6 +31,7 @@ import java.util.List;
 @RequestMapping(value = "/gcb")
 public class GoogleCloudBuildController {
   private final GoogleCloudBuildAccountRepository googleCloudBuildAccountRepository;
+  private final GoogleCloudBuildParser googleCloudBuildParser;
 
   @RequestMapping(value = "/accounts", method = RequestMethod.GET)
   List<String> getAccounts() {
@@ -38,7 +39,8 @@ public class GoogleCloudBuildController {
   }
 
   @RequestMapping(value = "/builds/create/{account}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-  Operation createBuild(@PathVariable String account, @RequestBody Build build) {
+  Operation createBuild(@PathVariable String account, @RequestBody String buildString) {
+    Build build = googleCloudBuildParser.parse(buildString, Build.class);
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).createBuild(build);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.services.cloudbuild.v1.model.Build;
-import com.google.api.services.cloudbuild.v1.model.Operation;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -26,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 import retrofit.http.Query;
 
 import java.util.List;
+import java.util.Map;
 
 @ConditionalOnProperty("gcb.enabled")
 @RestController
@@ -41,7 +41,7 @@ public class GoogleCloudBuildController {
   }
 
   @RequestMapping(value = "/builds/create/{account}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-  Operation createBuild(@PathVariable String account, @RequestBody String buildString)  {
+  Map<String, Object> createBuild(@PathVariable String account, @RequestBody String buildString)  {
     Build build = googleCloudBuildParser.parse(buildString, Build.class);
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).createBuild(build);
   }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -18,10 +18,12 @@ package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.Operation;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import retrofit.http.Query;
 
 import java.util.List;
 
@@ -39,8 +41,27 @@ public class GoogleCloudBuildController {
   }
 
   @RequestMapping(value = "/builds/create/{account}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-  Operation createBuild(@PathVariable String account, @RequestBody String buildString) {
+  Operation createBuild(@PathVariable String account, @RequestBody String buildString)  {
     Build build = googleCloudBuildParser.parse(buildString, Build.class);
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).createBuild(build);
+  }
+
+  @RequestMapping(value = "/builds/{account}/{buildId}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+  void updateBuild(
+    @PathVariable String account,
+    @PathVariable String buildId,
+    @Query("status") String status,
+    @RequestBody String serializedBuild
+  ) {
+    googleCloudBuildAccountRepository.getGoogleCloudBuild(account).updateBuild(buildId, status, serializedBuild);
+  }
+
+  @RequestMapping(value = "/builds/{account}/{buildId}", method = RequestMethod.GET)
+  Build getBuild(@PathVariable String account, @PathVariable String buildId) {
+    String serializedBuild =  googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getBuild(buildId);
+    if (serializedBuild == null) {
+      throw new NotFoundException(String.format("Build %s in account %s was not found", buildId, account));
+    }
+    return googleCloudBuildParser.parse(serializedBuild, Build.class);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.client.json.jackson2.JacksonFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * ObjectMapper does not properly handle deserializing Google Cloud Build objects
+ * such as a Build. In order to work around this, use the Google Cloud recommended
+ * parser when we need to deserialize these objects.  This class encapsulates that
+ * parser so that we can localize the workaround to one place.
+ */
+@Component
+@ConditionalOnProperty("gcb.enabled")
+public class GoogleCloudBuildParser {
+  private final JacksonFactory jacksonFactory = JacksonFactory.getDefaultInstance();
+
+  public final <T> T parse(String input, Class<T> destinationClass) {
+    try {
+      return jacksonFactory.createJsonParser(input).parse(destinationClass);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+/**
+ * An enum of possible statuses of a GCB build. One of the primary purposes of this enum is to handle ordering of
+ * statuses to allow us to order build notifications.
+ */
+public enum GoogleCloudBuildStatus {
+  STATUS_UNKNOWN(StatusType.UNKNOWN),
+  QUEUED(StatusType.QUEUED),
+  WORKING(StatusType.WORKING),
+  SUCCESS(StatusType.COMPLETE),
+  FAILURE(StatusType.COMPLETE),
+  INTERNAL_ERROR(StatusType.COMPLETE),
+  TIMEOUT(StatusType.COMPLETE),
+  CANCELLED(StatusType.COMPLETE);
+
+  private StatusType statusType;
+
+  GoogleCloudBuildStatus(StatusType statusType) {
+    this.statusType = statusType;
+  }
+
+  public boolean greaterThanOrEqualTo(GoogleCloudBuildStatus other) {
+    return this.statusType.compareTo(other.statusType) >= 0;
+  }
+
+  private enum StatusType {
+    UNKNOWN,
+    QUEUED,
+    WORKING,
+    COMPLETE;
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
@@ -30,11 +30,17 @@ public class GoogleCloudBuildAccountFactoryTest {
   private GoogleCredentialService googleCredentialService = mock(GoogleCredentialService.class);
   private CloudBuildFactory cloudBuildFactory = mock(CloudBuildFactory.class);
   private GoogleCloudBuildExecutor executor = mock(GoogleCloudBuildExecutor.class);
+  private GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory = mock(GoogleCloudBuildCache.Factory.class);
 
   private GoogleCredential googleCredential = mock(GoogleCredential.class);
   private CloudBuild cloudBuild = mock(CloudBuild.class);
 
-  private GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory = new GoogleCloudBuildAccountFactory(googleCredentialService, cloudBuildFactory, executor);
+  private GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory = new GoogleCloudBuildAccountFactory(
+    googleCredentialService,
+    cloudBuildFactory,
+    executor,
+    googleCloudBuildCacheFactory
+  );
 
   @Test
   public void applicationDefaultCredentials() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCacheSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCacheSpec.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.api.services.cloudbuild.v1.model.Build
+import com.netflix.spinnaker.igor.polling.LockService
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.Duration
+
+class GoogleCloudBuildCacheSpec extends Specification {
+  @Shared LockService lockService = Stub(LockService) {
+    acquire(_ as String, _ as Duration, _ as Runnable ) >> { String lockName, Duration duration , Runnable runnable ->
+      runnable.run()
+    }
+  }
+  @Shared EmbeddedRedis redis = EmbeddedRedis.embed()
+  @Shared RedisClientDelegate redisClientDelegate = new JedisClientDelegate(redis.getPool())
+  String keyPrefix = "abc"
+  String lockPrefix = "def"
+  @Shared GoogleCloudBuildCache googleCloudBuildCache = new GoogleCloudBuildCache(lockService, redisClientDelegate, keyPrefix, lockPrefix)
+  @Shared ObjectMapper objectMapper = new ObjectMapper()
+
+  def cleanupSpec() {
+    redis.destroy()
+  }
+
+  def "properly stores a build"() {
+    given:
+    def buildId = "d7dd57a6-5a31-415c-a360-8ed083fdd837"
+    def status = "QUEUED"
+    def build = getBuild(buildId, status)
+    googleCloudBuildCache.updateBuild(buildId, status, build)
+
+    expect:
+    googleCloudBuildCache.getBuild(buildId) == build
+  }
+
+  def "only supersedes builds with newer information"() {
+    given:
+    def buildId = "1e87c466-1311-4480-bc38-cd4b759e378b"
+    def firstBuild = getBuild(buildId, firstStatus)
+    def secondBuild = getBuild(buildId, secondStatus)
+    googleCloudBuildCache.updateBuild(buildId, firstStatus, firstBuild)
+    googleCloudBuildCache.updateBuild(buildId, secondStatus, secondBuild)
+
+    expect:
+    googleCloudBuildCache.getBuild(buildId) == (shouldUpdate ? secondBuild : firstBuild)
+
+    where:
+    firstStatus  | secondStatus | shouldUpdate
+    "QUEUED"     | "WORKING"    | true
+    "WORKING"    | "QUEUED"     | false
+    "QUEUED"     | "SUCCESS"    | true
+    "SUCCESS"    | "QUEUED"     | false
+    "QUEUED"     | "SUCCESS"    | true
+    "SUCCESS"    | "QUEUED"     | false
+    "SUCCESS"    | "FAILURE"    | true
+    "FAILURE"    | "SUCCESS"    | true
+  }
+
+  def "updates are always allowed with unknown statuses"() {
+    given:
+    def buildId = "43a14e66-ee70-4c5c-85f3-a6f822429b7d"
+    def firstBuild = getBuild(buildId, firstStatus)
+    def secondBuild = getBuild(buildId, secondStatus)
+    googleCloudBuildCache.updateBuild(buildId, firstStatus, firstBuild)
+    googleCloudBuildCache.updateBuild(buildId, secondStatus, secondBuild)
+
+    expect:
+    googleCloudBuildCache.getBuild(buildId) == (shouldUpdate ? secondBuild : firstBuild)
+
+    where:
+    firstStatus  | secondStatus | shouldUpdate
+    "AAA"        | "BBB"        | true
+    "WORKING"    | "BBB"        | true
+    "BBB"        | "WORKING"    | true
+  }
+
+  private String getBuild(String id, String status) {
+    return objectMapper.writeValueAsString(new Build().setId(id).setStatus(status))
+  }
+
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParserSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParserSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.api.services.cloudbuild.v1.model.Build
+import com.google.api.services.cloudbuild.v1.model.BuildOptions
+import com.google.api.services.cloudbuild.v1.model.BuildStep
+import spock.lang.Specification
+import spock.lang.Subject;
+
+class GoogleCloudBuildParserSpec extends Specification {
+  @Subject
+  GoogleCloudBuildParser parser = new GoogleCloudBuildParser()
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  def "correctly parses a build"() {
+    given:
+    def build = getBuild()
+    def serializedBuild = objectMapper.writeValueAsString(build)
+    def deserializedBuild = parser.parse(serializedBuild, Build.class)
+
+    expect:
+    deserializedBuild == build
+  }
+
+  private static Build getBuild() {
+    List<String> args = new ArrayList<>();
+    args.add("echo");
+    args.add("Hello, world!");
+
+    BuildStep buildStep = new BuildStep().setArgs(args).setName("hello");
+    BuildOptions buildOptions = new BuildOptions().setLogging("LEGACY");
+
+    return new Build().setSteps(Collections.singletonList(buildStep)).setOptions(buildOptions);
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatusSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatusSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import spock.lang.Specification
+import spock.lang.Unroll;
+
+class GoogleCloudBuildStatusSpec extends Specification {
+  @Unroll
+  def "statuses are properly ordered"() {
+    when:
+    def oldStatus = GoogleCloudBuildStatus.valueOf(oldStatusString)
+    def newStatus = GoogleCloudBuildStatus.valueOf(newStatusString)
+    def result = newStatus.greaterThanOrEqualTo(oldStatus)
+
+    then:
+    result == expected
+
+    where:
+    oldStatusString  | newStatusString  | expected
+    "QUEUED"         | "WORKING"        | true
+    "WORKING"        | "QUEUED"         | false
+    "WORKING"        | "SUCCESS"        | true
+    "SUCCESS"        | "WORKING"        | false
+    "WORKING"        | "STATUS_UNKNOWN" | false
+    "STATUS_UNKNOWN" | "WORKING"        | true
+    "QUEUED"         | "SUCCESS"        | true
+    "SUCCESS"        | "QUEUED"         | false
+    "QUEUED"         | "FAILURE"        | true
+    "FAILURE"        | "QUEUED"         | false
+    "SUCCESS"        | "FAILURE"        | true
+    "FAILURE"        | "SUCCESS"        | true
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.BuildOptions;
 import com.google.api.services.cloudbuild.v1.model.BuildStep;
 import com.google.api.services.cloudbuild.v1.model.Operation;
 import com.netflix.spinnaker.igor.config.GoogleCloudBuildConfig;
@@ -119,7 +120,9 @@ public class GoogleCloudBuildTest {
     args.add("Hello, world!");
 
     BuildStep buildStep = new BuildStep().setArgs(args).setName("hello");
-    return new Build().setSteps(Collections.singletonList(buildStep));
+    BuildOptions buildOptions = new BuildOptions().setLogging("LEGACY");
+
+    return new Build().setSteps(Collections.singletonList(buildStep)).setOptions(buildOptions);
   }
 
   private Operation buildResponse() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTestConfig.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTestConfig.java
@@ -16,12 +16,15 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.testing.auth.oauth2.MockTokenServerTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.cloudbuild.v1.CloudBuildScopes;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -31,7 +34,17 @@ import java.io.InputStream;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
-public class WireMockConfig {
+public class GoogleCloudBuildTestConfig {
+  @Bean
+  ObjectMapper objectMapper() {
+    return new ObjectMapper();
+  }
+
+  @Bean
+  Registry registry() {
+    return new NoopRegistry();
+  }
+
   @Bean(name = "stubCloudBuildService")
   WireMockServer stubCloudBuildService() {
     WireMockServer server = new WireMockServer(options().dynamicPort());

--- a/igor-web/src/test/resources/gcb/gcb-test.yml
+++ b/igor-web/src/test/resources/gcb/gcb-test.yml
@@ -4,3 +4,5 @@ gcb:
   - name: gcb-account
     project: spinnaker-gcb-test
     jsonKey: /path/to/some/file
+locking:
+  enabled: true


### PR DESCRIPTION
* fix(gcb): Fix deserialization of Build object 

  Jackson's ObjectMapper does not properly deserialize Build objects, as nested properties that extend com.google.api.client.json.GenericJson
  (which itself implements Map) are are deserialized as Maps rather than as the specific type.

  There is probably a way of configuring ObjectMapper to do this properly but I have not (yet) been able to find it. As a workaround, use the Google Cloud supported deserialization classes to deserialize this JSON. In order to keep this workaround localized, make a small class that will handle deserializing Build classes.

  This commit also adds BuildOptions to the build in the integration test; adding this causes the test to fail when using the standard ObjectMapper for deserialization.

* feat(gcb): Add endpoints for storing and retrieving build status 

  Create and endpoint to accept the current status of a build and store it in Redis.  This endpoint is intended to be called by echo when it receives a PubSub message about a build status change.  We take care to look at the timestamp of incoming messages and only update the cache if the incoming information is newer, as PubSub does not guarantee delivery order.

  Create an endpoint to return the current status of the build, as per the cache.  This commit does not implement any fallback to calling the API if the cache does not contain the build; this will be added in a future commit.

* feat(gcb): Create build should return only the build 

  When creating a build, we should return only the build instead of the operation. In general, callers will only be interested in the id of the created build, and it will be easier for callers to just look up the
  "id" of the returned object instead of looking at the deeply nested operation -> metadata -> build -> id field.
