### PR TITLE
fix(core): Spring does not override default configuration files.

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -1,11 +1,11 @@
 ext {
-  springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
+  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/")
 }
 
 apply plugin: 'spinnaker.application'
 
 run {
-  systemProperty('spring.config.location', project.springConfigLocation)
+  systemProperty('spring.config.additional-location', project.springConfigLocation)
 }
 
 mainClassName = 'com.netflix.spinnaker.igor.Main'

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/Main.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/Main.groovy
@@ -38,13 +38,13 @@ import java.security.Security
 class Main extends SpringBootServletInitializer {
 
     static final Map<String, String> DEFAULT_PROPS = [
-        'netflix.environment'    : 'test',
-        'netflix.account'        : '${netflix.environment}',
-        'netflix.stack'          : 'test',
-        'spring.config.location' : '${user.home}/.spinnaker/',
-        'spring.application.name': 'igor',
-        'spring.config.name'     : 'spinnaker,${spring.application.name}',
-        'spring.profiles.active' : '${netflix.environment},local'
+      'netflix.environment'              : 'test',
+      'netflix.account'                  : '${netflix.environment}',
+      'netflix.stack'                    : 'test',
+      'spring.config.additional-location': '${user.home}/.spinnaker/',
+      'spring.application.name'          : 'igor',
+      'spring.config.name'               : 'spinnaker,${spring.application.name}',
+      'spring.profiles.active'           : '${netflix.environment},local'
     ]
 
     static {


### PR DESCRIPTION
In the Spring Boot 2 upgrade, `spring.config.location` overrides all other config locations. The equivalent property is now called `spring.config.additional-location`.
This fix allows the app the to run without additional config files.