### PR TITLE
 feat(gcb): Add ttl to build cache entries and fall back to polling

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildConfig.java
@@ -19,10 +19,7 @@ package com.netflix.spinnaker.igor.config;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.netflix.spinnaker.igor.IgorConfigurationProperties;
-import com.netflix.spinnaker.igor.gcb.GoogleCloudBuildAccount;
-import com.netflix.spinnaker.igor.gcb.GoogleCloudBuildAccountFactory;
-import com.netflix.spinnaker.igor.gcb.GoogleCloudBuildAccountRepository;
-import com.netflix.spinnaker.igor.gcb.GoogleCloudBuildCache;
+import com.netflix.spinnaker.igor.gcb.*;
 import com.netflix.spinnaker.igor.polling.LockService;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -33,6 +30,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Optional;
 
 @Configuration
 @ComponentScan("com.netflix.spinnaker.igor.gcb")
@@ -67,6 +65,18 @@ public class GoogleCloudBuildConfig {
       lockService,
       redisClientDelegate,
       igorConfigurationProperties.getSpinnaker().getJedis().getPrefix()
+    );
+  }
+
+  @Bean
+  GoogleCloudBuildClient.Factory googleCloudBuildClientFactory(
+    CloudBuildFactory cloudBuildFactory,
+    GoogleCloudBuildExecutor googleCloudBuildExecutor
+  ) {
+    return new GoogleCloudBuildClient.Factory(
+      cloudBuildFactory,
+      googleCloudBuildExecutor,
+      Optional.ofNullable(getClass().getPackage().getImplementationVersion()).orElse("Unknown")
     );
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildConfig.java
@@ -39,34 +39,34 @@ import java.security.GeneralSecurityException;
 @ConditionalOnProperty("gcb.enabled")
 @EnableConfigurationProperties({GoogleCloudBuildProperties.class, IgorConfigurationProperties.class})
 public class GoogleCloudBuildConfig {
-    @Bean
-    HttpTransport httpTransport() throws IOException, GeneralSecurityException {
-      return GoogleNetHttpTransport.newTrustedTransport();
-    }
+  @Bean
+  HttpTransport httpTransport() throws IOException, GeneralSecurityException {
+    return GoogleNetHttpTransport.newTrustedTransport();
+  }
 
-    @Bean
-    GoogleCloudBuildAccountRepository googleCloudBuildAccountRepository(
-        GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory,
-        GoogleCloudBuildProperties googleCloudBuildProperties
-    ) {
-        GoogleCloudBuildAccountRepository credentials = new GoogleCloudBuildAccountRepository();
-        googleCloudBuildProperties.getAccounts().forEach(a -> {
-            GoogleCloudBuildAccount account = googleCloudBuildAccountFactory.build(a);
-            credentials.registerAccount(a.getName(), account);
-        });
-        return credentials;
-    }
+  @Bean
+  GoogleCloudBuildAccountRepository googleCloudBuildAccountRepository(
+    GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory,
+    GoogleCloudBuildProperties googleCloudBuildProperties
+  ) {
+    GoogleCloudBuildAccountRepository credentials = new GoogleCloudBuildAccountRepository();
+    googleCloudBuildProperties.getAccounts().forEach(a -> {
+      GoogleCloudBuildAccount account = googleCloudBuildAccountFactory.build(a);
+      credentials.registerAccount(a.getName(), account);
+    });
+    return credentials;
+  }
 
-    @Bean
-    GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory(
-      IgorConfigurationProperties igorConfigurationProperties,
-      RedisClientDelegate redisClientDelegate,
-      LockService lockService
-    ) {
-      return new GoogleCloudBuildCache.Factory(
-        lockService,
-        redisClientDelegate,
-        igorConfigurationProperties.getSpinnaker().getJedis().getPrefix()
-      );
-    }
+  @Bean
+  GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory(
+    IgorConfigurationProperties igorConfigurationProperties,
+    RedisClientDelegate redisClientDelegate,
+    LockService lockService
+  ) {
+    return new GoogleCloudBuildCache.Factory(
+      lockService,
+      redisClientDelegate,
+      igorConfigurationProperties.getSpinnaker().getJedis().getPrefix()
+    );
+  }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
@@ -24,13 +24,13 @@ import java.util.List;
 @ConfigurationProperties(prefix = "gcb")
 @Data
 public class GoogleCloudBuildProperties {
-    private List<Account> accounts;
+  private List<Account> accounts;
 
-    @Data
-    public static class Account {
-        private String name;
-        private String project;
-        private String subscriptionName;
-        private String jsonKey;
-    }
+  @Data
+  public static class Account {
+    private String name;
+    private String project;
+    private String subscriptionName;
+    private String jsonKey;
+  }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -16,36 +16,32 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
-import com.google.api.services.cloudbuild.v1.CloudBuild;
 import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.Operation;
-import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Map;
 
 /**
- * Generates authenticated requests to the Google Cloud Build API for a single configured account, delegating to
- * GoogleCloudBuildExecutor to execute these requests.
+ * Handles getting and updating build information for a single account. Delegates operations to either the
+ * GoogleCloudBuildCache or GoogleCloudBuildClient.
  */
 @RequiredArgsConstructor
 public class GoogleCloudBuildAccount {
-  private final String projectId;
-  private final CloudBuild cloudBuild;
-  private final GoogleCloudBuildExecutor executor;
-  private final GoogleCloudBuildCache googleCloudBuildCache;
+  private final GoogleCloudBuildClient client;
+  private final GoogleCloudBuildCache cache;
 
   @SuppressWarnings("unchecked")
   public Map<String, Object> createBuild(Build build) {
-    Operation operation = executor.execute(() -> cloudBuild.projects().builds().create(projectId, build));
+    Operation operation = client.createBuild(build);
     return (Map<String, Object>) operation.getMetadata().get("build");
   }
 
   public void updateBuild(String buildId, String status, String serializedBuild) {
-    googleCloudBuildCache.updateBuild(buildId, status, serializedBuild);
+    cache.updateBuild(buildId, status, serializedBuild);
   }
 
   public String getBuild(String buildId) {
-    return googleCloudBuildCache.getBuild(buildId);
+    return cache.getBuild(buildId);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -20,8 +20,6 @@ import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.Operation;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Map;
-
 /**
  * Handles getting and updating build information for a single account. Delegates operations to either the
  * GoogleCloudBuildCache or GoogleCloudBuildClient.
@@ -30,11 +28,12 @@ import java.util.Map;
 public class GoogleCloudBuildAccount {
   private final GoogleCloudBuildClient client;
   private final GoogleCloudBuildCache cache;
+  private final GoogleCloudBuildParser googleCloudBuildParser;
 
   @SuppressWarnings("unchecked")
-  public Map<String, Object> createBuild(Build build) {
+  public Build createBuild(Build build) {
     Operation operation = client.createBuild(build);
-    return (Map<String, Object>) operation.getMetadata().get("build");
+    return googleCloudBuildParser.convert(operation.getMetadata().get("build"), Build.class);
   }
 
   public void updateBuild(String buildId, String status, String serializedBuild) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
@@ -17,14 +17,11 @@
 package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.services.cloudbuild.v1.CloudBuild;
 import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 /**
  * Creates GoogleCloudBuildAccounts
@@ -34,25 +31,16 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class GoogleCloudBuildAccountFactory {
   private final GoogleCredentialService credentialService;
-  private final CloudBuildFactory cloudBuildFactory;
-  private final GoogleCloudBuildExecutor googleCloudBuildExecutor;
+  private final GoogleCloudBuildClient.Factory googleCloudBuildClientFactory;
   private final GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory;
 
   public GoogleCloudBuildAccount build(GoogleCloudBuildProperties.Account account) {
     GoogleCredential credential = getCredential(account);
-    String applicationName = getApplicationName();
-    CloudBuild cloudBuild = cloudBuildFactory.getCloudBuild(credential, applicationName);
 
     return new GoogleCloudBuildAccount(
-      account.getProject(),
-      cloudBuild,
-      googleCloudBuildExecutor,
+      googleCloudBuildClientFactory.create(credential, account.getProject()),
       googleCloudBuildCacheFactory.create(account.getName())
     );
-  }
-
-  private String getApplicationName() {
-    return Optional.ofNullable(getClass().getPackage().getImplementationVersion()).orElse("Unknown");
   }
 
   private GoogleCredential getCredential(GoogleCloudBuildProperties.Account account) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
@@ -33,13 +33,15 @@ public class GoogleCloudBuildAccountFactory {
   private final GoogleCredentialService credentialService;
   private final GoogleCloudBuildClient.Factory googleCloudBuildClientFactory;
   private final GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory;
+  private final GoogleCloudBuildParser googleCloudBuildParser;
 
   public GoogleCloudBuildAccount build(GoogleCloudBuildProperties.Account account) {
     GoogleCredential credential = getCredential(account);
 
     return new GoogleCloudBuildAccount(
       googleCloudBuildClientFactory.create(credential, account.getProject()),
-      googleCloudBuildCacheFactory.create(account.getName())
+      googleCloudBuildCacheFactory.create(account.getName()),
+      googleCloudBuildParser
     );
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCache.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCache.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.igor.polling.LockService;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.util.Map;
@@ -29,6 +30,7 @@ import java.util.Map;
  * receives PubSub build notifications and sends them to igor.
  */
 @RequiredArgsConstructor(access=AccessLevel.PRIVATE)
+@Slf4j
 public class GoogleCloudBuildCache {
   private static final int inProgressTtlSeconds = 60 * 10;
   private static final int completedTtlSeconds = 60 * 60 * 24;
@@ -82,6 +84,7 @@ public class GoogleCloudBuildCache {
         return inProgressTtlSeconds;
       }
     } catch (IllegalArgumentException e) {
+      log.warn("Received unknown Google Cloud Build Status: {}", statusString);
       return inProgressTtlSeconds;
     }
   }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.services.cloudbuild.v1.CloudBuild;
+import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.Operation;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Generates authenticated requests to the Google Cloud Build API for a single configured account, delegating to
+ * GoogleCloudBuildExecutor to execute these requests.
+ */
+@RequiredArgsConstructor(access=AccessLevel.PRIVATE)
+public class GoogleCloudBuildClient {
+  private final String projectId;
+  private final CloudBuild cloudBuild;
+  private final GoogleCloudBuildExecutor executor;
+
+  @RequiredArgsConstructor
+  public static class Factory {
+    private final CloudBuildFactory cloudBuildFactory;
+    private final GoogleCloudBuildExecutor executor;
+    private final String applicationName;
+
+    public GoogleCloudBuildClient create(GoogleCredential credential, String projectId) {
+      CloudBuild cloudBuild = cloudBuildFactory.getCloudBuild(credential, applicationName);
+      return new GoogleCloudBuildClient(projectId, cloudBuild, executor);
+    }
+  }
+
+  public Operation createBuild(Build build) {
+    return executor.execute(() -> cloudBuild.projects().builds().create(projectId, build));
+  }
+
+  public Build getBuild(String buildId) {
+    return executor.execute(() -> cloudBuild.projects().builds().get(projectId, buildId));
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.*;
 import retrofit.http.Query;
 
 import java.util.List;
-import java.util.Map;
 
 @ConditionalOnProperty("gcb.enabled")
 @RestController
@@ -41,7 +40,7 @@ public class GoogleCloudBuildController {
   }
 
   @RequestMapping(value = "/builds/create/{account}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-  Map<String, Object> createBuild(@PathVariable String account, @RequestBody String buildString)  {
+  Build createBuild(@PathVariable String account, @RequestBody String buildString)  {
     Build build = googleCloudBuildParser.parse(buildString, Build.class);
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).createBuild(build);
   }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -57,10 +57,6 @@ public class GoogleCloudBuildController {
 
   @RequestMapping(value = "/builds/{account}/{buildId}", method = RequestMethod.GET)
   Build getBuild(@PathVariable String account, @PathVariable String buildId) {
-    String serializedBuild =  googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getBuild(buildId);
-    if (serializedBuild == null) {
-      throw new NotFoundException(String.format("Build %s in account %s was not found", buildId, account));
-    }
-    return googleCloudBuildParser.parse(serializedBuild, Build.class);
+    return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getBuild(buildId);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.cloudbuild.v1.CloudBuildRequest;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import org.apache.http.client.HttpResponseException;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
@@ -16,9 +16,11 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.cloudbuild.v1.CloudBuildRequest;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
-import org.apache.http.client.HttpResponseException;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -30,15 +32,19 @@ import java.io.IOException;
  */
 @Component
 @ConditionalOnProperty("gcb.enabled")
+@Slf4j
 public class GoogleCloudBuildExecutor {
   //TODO(ezimanyi): Consider adding retry logic here
   public <T> T execute(RequestFactory<T> requestFactory) {
     try {
       CloudBuildRequest<T> request = requestFactory.get();
       return request.execute();
-    } catch (HttpResponseException e) {
+    } catch (GoogleJsonResponseException e) {
       if (e.getStatusCode() == 400) {
+        log.error(e.getMessage());
         throw new InvalidRequestException(e.getMessage());
+      } else if (e.getStatusCode() == 404) {
+        throw new NotFoundException(e.getMessage());
       }
       throw new RuntimeException(e);
     } catch (IOException e) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
@@ -16,11 +16,14 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
+import com.google.api.client.json.JsonGenerator;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 
 /**
  * ObjectMapper does not properly handle deserializing Google Cloud Build objects
@@ -36,6 +39,23 @@ public class GoogleCloudBuildParser {
   public final <T> T parse(String input, Class<T> destinationClass) {
     try {
       return jacksonFactory.createJsonParser(input).parse(destinationClass);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public final <T> T convert(Object input, Class<T> destinationClass) {
+    String inputString = serialize(input);
+    return parse(inputString, destinationClass);
+  }
+
+  public final String serialize(Object input) {
+    try {
+      Writer writer = new StringWriter();
+      JsonGenerator generator = jacksonFactory.createJsonGenerator(writer);
+      generator.serialize(input);
+      generator.flush();
+      return writer.toString();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
@@ -30,7 +30,7 @@ public enum GoogleCloudBuildStatus {
   TIMEOUT(StatusType.COMPLETE),
   CANCELLED(StatusType.COMPLETE);
 
-  private StatusType statusType;
+  private final StatusType statusType;
 
   GoogleCloudBuildStatus(StatusType statusType) {
     this.statusType = statusType;
@@ -44,6 +44,6 @@ public enum GoogleCloudBuildStatus {
     UNKNOWN,
     QUEUED,
     WORKING,
-    COMPLETE;
+    COMPLETE
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
@@ -40,6 +40,10 @@ public enum GoogleCloudBuildStatus {
     return this.statusType.compareTo(other.statusType) >= 0;
   }
 
+  public boolean isComplete() {
+    return statusType == StatusType.COMPLETE;
+  }
+
   private enum StatusType {
     UNKNOWN,
     QUEUED,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.services.cloudbuild.v1.CloudBuild;
 import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,17 +27,15 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class GoogleCloudBuildAccountFactoryTest {
   private GoogleCredentialService googleCredentialService = mock(GoogleCredentialService.class);
-  private CloudBuildFactory cloudBuildFactory = mock(CloudBuildFactory.class);
-  private GoogleCloudBuildExecutor executor = mock(GoogleCloudBuildExecutor.class);
+  private GoogleCloudBuildClient.Factory googleCloudBuildClientFactory = mock(GoogleCloudBuildClient.Factory.class);
   private GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory = mock(GoogleCloudBuildCache.Factory.class);
 
   private GoogleCredential googleCredential = mock(GoogleCredential.class);
-  private CloudBuild cloudBuild = mock(CloudBuild.class);
+  private GoogleCloudBuildClient googleCloudBuildClient = mock(GoogleCloudBuildClient.class);
 
   private GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory = new GoogleCloudBuildAccountFactory(
     googleCredentialService,
-    cloudBuildFactory,
-    executor,
+    googleCloudBuildClientFactory,
     googleCloudBuildCacheFactory
   );
 
@@ -48,13 +45,13 @@ public class GoogleCloudBuildAccountFactoryTest {
     accountConfig.setJsonKey("");
 
     when(googleCredentialService.getApplicationDefault()).thenReturn(googleCredential);
-    when(cloudBuildFactory.getCloudBuild(eq(googleCredential), any(String.class))).thenReturn(cloudBuild);
+    when(googleCloudBuildClientFactory.create(eq(googleCredential), any(String.class))).thenReturn(googleCloudBuildClient);
 
     GoogleCloudBuildAccount account = googleCloudBuildAccountFactory.build(accountConfig);
 
     verify(googleCredentialService).getApplicationDefault();
     verify(googleCredentialService, never()).getFromKey(any());
-    verify(cloudBuildFactory).getCloudBuild(eq(googleCredential), any(String.class));
+    verify(googleCloudBuildClientFactory).create(eq(googleCredential), any(String.class));
   }
 
   @Test
@@ -63,13 +60,13 @@ public class GoogleCloudBuildAccountFactoryTest {
     accountConfig.setJsonKey("/path/to/file");
 
     when(googleCredentialService.getFromKey("/path/to/file")).thenReturn(googleCredential);
-    when(cloudBuildFactory.getCloudBuild(eq(googleCredential), any(String.class))).thenReturn(cloudBuild);
+    when(googleCloudBuildClientFactory.create(eq(googleCredential), any(String.class))).thenReturn(googleCloudBuildClient);
 
     GoogleCloudBuildAccount account = googleCloudBuildAccountFactory.build(accountConfig);
 
     verify(googleCredentialService, never()).getApplicationDefault();
     verify(googleCredentialService).getFromKey("/path/to/file");
-    verify(cloudBuildFactory).getCloudBuild(eq(googleCredential), any(String.class));
+    verify(googleCloudBuildClientFactory).create(eq(googleCredential), any(String.class));
   }
 
   private GoogleCloudBuildProperties.Account getBaseAccount() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
@@ -29,6 +29,7 @@ public class GoogleCloudBuildAccountFactoryTest {
   private GoogleCredentialService googleCredentialService = mock(GoogleCredentialService.class);
   private GoogleCloudBuildClient.Factory googleCloudBuildClientFactory = mock(GoogleCloudBuildClient.Factory.class);
   private GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory = mock(GoogleCloudBuildCache.Factory.class);
+  private GoogleCloudBuildParser googleCloudBuildParser = new GoogleCloudBuildParser();
 
   private GoogleCredential googleCredential = mock(GoogleCredential.class);
   private GoogleCloudBuildClient googleCloudBuildClient = mock(GoogleCloudBuildClient.class);
@@ -36,7 +37,8 @@ public class GoogleCloudBuildAccountFactoryTest {
   private GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory = new GoogleCloudBuildAccountFactory(
     googleCredentialService,
     googleCloudBuildClientFactory,
-    googleCloudBuildCacheFactory
+    googleCloudBuildCacheFactory,
+    googleCloudBuildParser
   );
 
   @Test

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountSpec.groovy
@@ -70,7 +70,24 @@ class GoogleCloudBuildAccountSpec extends Specification {
 
     then:
     1 * cache.getBuild(buildId) >> serializedBuild
-    result == serializedBuild
+    result == build
+  }
+
+  def "getBuild falls back to polling when nothing is in the cache, and updates the cache"() {
+    given:
+    def buildId = "5ecc2461-761b-41a7-b325-210ad9b5a2b5"
+    def status = "WORKING"
+    def build = getBuild(status)
+    def serializedBuild = parser.serialize(build)
+
+    when:
+    def result = googleCloudBuildAccount.getBuild(buildId)
+
+    then:
+    1 * cache.getBuild(buildId) >> null
+    1 * client.getBuild(buildId) >> build
+    1 * cache.updateBuild(buildId, status, serializedBuild)
+    result == build
   }
 
   private static Build getBuild(String status) {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountSpec.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.api.services.cloudbuild.v1.model.Build
+import com.google.api.services.cloudbuild.v1.model.BuildOptions
+import com.google.api.services.cloudbuild.v1.model.BuildStep
+import com.google.api.services.cloudbuild.v1.model.Operation
+import spock.lang.Specification
+
+class GoogleCloudBuildAccountSpec extends Specification {
+  GoogleCloudBuildClient client = Mock(GoogleCloudBuildClient)
+  GoogleCloudBuildCache cache = Mock(GoogleCloudBuildCache)
+  GoogleCloudBuildParser parser = new GoogleCloudBuildParser()
+  GoogleCloudBuildAccount googleCloudBuildAccount = new GoogleCloudBuildAccount(client, cache, parser)
+
+  static ObjectMapper objectMapper = new ObjectMapper()
+
+  def "createBuild creates a build"() {
+    given:
+    def build = getBuild("")
+    def queuedBuild = getBuild().setStatus("QUEUED").setOptions(new BuildOptions().setLogging("LEGACY"))
+
+    when:
+    def result = googleCloudBuildAccount.createBuild(build)
+
+    then:
+    1 * client.createBuild(build) >> createBuildOperation(queuedBuild)
+    result == queuedBuild
+  }
+
+  def "updateBuild forwards the build to the cache"() {
+    given:
+    def buildId = "5ecc2461-761b-41a7-b325-210ad9b5a2b5"
+    def status = "QUEUED"
+    def build = getBuild(status)
+    def serializedBuild = parser.serialize(build)
+
+    when:
+    googleCloudBuildAccount.updateBuild(buildId, status, serializedBuild)
+
+    then:
+    1 * cache.updateBuild(buildId, status, serializedBuild)
+  }
+
+  def "getBuild returns the value in the cache"() {
+    given:
+    def buildId = "5ecc2461-761b-41a7-b325-210ad9b5a2b5"
+    def status = "WORKING"
+    def build = getBuild(status)
+    def serializedBuild = parser.serialize(build)
+
+    when:
+    def result = googleCloudBuildAccount.getBuild(buildId)
+
+    then:
+    1 * cache.getBuild(buildId) >> serializedBuild
+    result == serializedBuild
+  }
+
+  private static Build getBuild(String status) {
+    List<String> args = new ArrayList<>();
+    args.add("echo");
+    args.add("Hello, world!");
+
+    BuildStep buildStep = new BuildStep().setArgs(args).setName("hello");
+    BuildOptions buildOptions = new BuildOptions().setLogging("LEGACY");
+
+    return new Build()
+      .setStatus(status)
+      .setSteps(Collections.singletonList(buildStep))
+      .setOptions(buildOptions);
+  }
+
+  private static createBuildOperation(Build inputBuild) {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("@type", "type.googleapis.com/google.devtools.cloudbuild.v1.BuildOperationMetadata");
+    metadata.put("build", objectMapper.convertValue(inputBuild, Map.class));
+
+    Operation operation = new Operation();
+    operation.setName("operations/build/spinnaker-gcb-test/operationid");
+    operation.setMetadata(metadata);
+    return operation;
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutorTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutorTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class GoogleCloudBuildExecutorTest {
   private GoogleCloudBuildExecutor executor = new GoogleCloudBuildExecutor();
+  @SuppressWarnings("unchecked")
   private CloudBuildRequest<GenericJson> request = (CloudBuildRequest<GenericJson>) mock(CloudBuildRequest.class);
 
   @Test

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParserSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParserSpec.groovy
@@ -17,11 +17,9 @@
 package com.netflix.spinnaker.igor.gcb
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.api.services.cloudbuild.v1.model.Build
-import com.google.api.services.cloudbuild.v1.model.BuildOptions
-import com.google.api.services.cloudbuild.v1.model.BuildStep
+import com.google.api.services.cloudbuild.v1.model.*
 import spock.lang.Specification
-import spock.lang.Subject;
+import spock.lang.Subject
 
 class GoogleCloudBuildParserSpec extends Specification {
   @Subject
@@ -32,7 +30,27 @@ class GoogleCloudBuildParserSpec extends Specification {
   def "correctly parses a build"() {
     given:
     def build = getBuild()
-    def serializedBuild = objectMapper.writeValueAsString(build)
+    def serializedBuild = parser.serialize(build)
+    def deserializedBuild = parser.parse(serializedBuild, Build.class)
+
+    expect:
+    deserializedBuild == build
+  }
+
+  def "converts a build from a map"() {
+    given:
+    def build = getBuild()
+    def serializedBuild = objectMapper.convertValue(build, Map.class)
+    def deserializedBuild = parser.convert(serializedBuild, Build.class)
+
+    expect:
+    deserializedBuild == build
+  }
+
+  def "correctly serializes a build"() {
+    given:
+    def build = getBuild()
+    def serializedBuild = parser.serialize(build)
     def deserializedBuild = parser.parse(serializedBuild, Build.class)
 
     expect:
@@ -47,6 +65,9 @@ class GoogleCloudBuildParserSpec extends Specification {
     BuildStep buildStep = new BuildStep().setArgs(args).setName("hello");
     BuildOptions buildOptions = new BuildOptions().setLogging("LEGACY");
 
-    return new Build().setSteps(Collections.singletonList(buildStep)).setOptions(buildOptions);
+    return new Build()
+      .setSteps(Collections.singletonList(buildStep))
+      .setOptions(buildOptions)
+      .setSource(new Source().setStorageSource(new StorageSource().setGeneration(12345)));
   }
 }


### PR DESCRIPTION
* style(gcb): Change indent to 2 spaces 

  The default for igor was recently changed to 2 spaces to match our other microservices; update the 2 gcb files that still have 4-space indents. This commit is whitespace-only.

* refactor(gcb): Extract all interactions with GCB API to a client class 

  Currently GoogleCloudBuildAccount directly generates calls to the GCB API (though uses a GoogleCloudBuildExecutor to actually execute the requests). As we add more complex logic to GoogleCloudBuildAccount and want to add some unit tests, it makes sense to pull the logic that is just generating API calls into a separate class so it can be easily stubbed.

  Create a GoogleCloudBuildClient which will expose GCB API operations and execute them for the consumer.

* refactor(gcb): Standardize return values in GoogleCloudBuildAccount 

  We'll standardize on having the account class accept and return GCB objects rather than serialized objects or maps.

* feat(gcb): Add ttl to build cache entries and fall back to polling 

  In order to handle cases where a pubsub message is not delivered, we'd like to fall back to polling if we haven't received an update on a build in some amount of time.

  Configure this by adding a TTL on all entries in the cache; we'll set a shorter TTL for in-progress builds (as we expect an update) and a longer one for completed builds (which should never have another status change). If we check the cache and there is no build there, fall back to an external poll, and store that result for the same amount of time.
