### PR TITLE
feat(gcb): Add endpoint to fetch build artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     ext {
-      korkVersion = "5.0.0"
+      korkVersion = "5.2.0"
       fiatVersion = "1.0.0"
     }
     repositories {

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation "org.springframework.security:spring-security-web"
 
     implementation "com.google.apis:google-api-services-cloudbuild"
+    implementation "com.google.apis:google-api-services-storage"
     implementation "com.netflix.spinnaker.kork:kork-core"
     implementation "com.netflix.spinnaker.kork:kork-artifacts"
     implementation "com.netflix.spinnaker.kork:kork-stackdriver"

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
@@ -22,6 +22,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.cloudbuild.v1.CloudBuild;
+import com.google.api.services.storage.Storage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -50,6 +51,18 @@ public class CloudBuildFactory {
     HttpRequestInitializer requestInitializer = getRequestInitializer(credential);
     CloudBuild.Builder builder =
         new CloudBuild.Builder(httpTransport, jsonFactory, requestInitializer)
+            .setApplicationName(applicationName);
+
+    if (overrideRootUrl != null) {
+      builder.setRootUrl(overrideRootUrl);
+    }
+    return builder.build();
+  }
+
+  public Storage getCloudStorage(GoogleCredential credential, String applicationName) {
+    HttpRequestInitializer requestInitializer = getRequestInitializer(credential);
+    Storage.Builder builder =
+        new Storage.Builder(httpTransport, jsonFactory, requestInitializer)
             .setApplicationName(applicationName);
 
     if (overrideRootUrl != null) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.Operation;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -29,8 +31,8 @@ public class GoogleCloudBuildAccount {
   private final GoogleCloudBuildClient client;
   private final GoogleCloudBuildCache cache;
   private final GoogleCloudBuildParser googleCloudBuildParser;
+  private final GoogleCloudBuildArtifactFetcher googleCloudBuildArtifactFetcher;
 
-  @SuppressWarnings("unchecked")
   public Build createBuild(Build buildRequest) {
     Operation operation = client.createBuild(buildRequest);
     Build buildResponse =
@@ -54,5 +56,10 @@ public class GoogleCloudBuildAccount {
       this.updateBuild(buildId, build.getStatus(), buildString);
     }
     return googleCloudBuildParser.parse(buildString, Build.class);
+  }
+
+  public List<Artifact> getArtifacts(String buildId) {
+    Build build = getBuild(buildId);
+    return googleCloudBuildArtifactFetcher.getArtifacts(build);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -62,4 +62,8 @@ public class GoogleCloudBuildAccount {
     Build build = getBuild(buildId);
     return googleCloudBuildArtifactFetcher.getArtifacts(build);
   }
+
+  public List<Artifact> extractArtifacts(Build build) {
+    return googleCloudBuildArtifactFetcher.getArtifacts(build);
+  }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
@@ -36,10 +36,13 @@ public class GoogleCloudBuildAccountFactory {
   public GoogleCloudBuildAccount build(GoogleCloudBuildProperties.Account account) {
     GoogleCredential credential = getCredential(account);
 
+    GoogleCloudBuildClient client =
+        googleCloudBuildClientFactory.create(credential, account.getProject());
     return new GoogleCloudBuildAccount(
-        googleCloudBuildClientFactory.create(credential, account.getProject()),
+        client,
         googleCloudBuildCacheFactory.create(account.getName()),
-        googleCloudBuildParser);
+        googleCloudBuildParser,
+        new GoogleCloudBuildArtifactFetcher(client));
   }
 
   private GoogleCredential getCredential(GoogleCloudBuildProperties.Account account) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.BuiltImage;
+import com.google.api.services.cloudbuild.v1.model.Results;
+import com.netflix.spinnaker.igor.gcb.model.GoogleCloudBuildArtifact;
+import com.netflix.spinnaker.igor.gcb.model.GoogleCloudStorageObject;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GoogleCloudBuildArtifactFetcher {
+  private final GoogleCloudBuildClient client;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public List<Artifact> getArtifacts(Build build) {
+    List<Artifact> results = new ArrayList<>();
+
+    results.addAll(getDockerArtifacts(build));
+    results.addAll(getGoogleCloudStorageArtifacts(build));
+
+    return results;
+  }
+
+  private List<Artifact> getDockerArtifacts(Build build) {
+    Results results = build.getResults();
+    if (results == null) {
+      return Collections.emptyList();
+    }
+
+    List<BuiltImage> images = results.getImages();
+    if (images == null) {
+      return Collections.emptyList();
+    }
+
+    return images.stream().map(this::parseBuiltImage).collect(Collectors.toList());
+  }
+
+  private Artifact parseBuiltImage(BuiltImage image) {
+    String[] parts = image.getName().split(":");
+    return Artifact.builder()
+        .name(parts[0])
+        .version(image.getDigest())
+        .reference(String.format("%s@%s", parts[0], image.getDigest()))
+        .type("docker/image")
+        .build();
+  }
+
+  private List<Artifact> getGoogleCloudStorageArtifacts(Build build) {
+    GoogleCloudStorageObject manifest = getGoogleCloudStorageManifest(build);
+    if (manifest == null) {
+      return Collections.emptyList();
+    }
+
+    try {
+      return readGoogleCloudStorageManifest(manifest).stream()
+          .map(this::parseGoogleCloudBuildArtifact)
+          .distinct()
+          .collect(Collectors.toList());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Artifact parseGoogleCloudBuildArtifact(GoogleCloudBuildArtifact artifact) {
+    String location = artifact.getLocation();
+    GoogleCloudStorageObject object = GoogleCloudStorageObject.fromReference(location);
+    return Artifact.builder()
+        .name(object.getName())
+        .version(object.getVersionString())
+        .reference(location)
+        .type("gcs/object")
+        .build();
+  }
+
+  private GoogleCloudStorageObject getGoogleCloudStorageManifest(Build build) {
+    Results results = build.getResults();
+    if (results == null) {
+      return null;
+    }
+
+    String artifactManifest = results.getArtifactManifest();
+    if (artifactManifest == null) {
+      return null;
+    }
+
+    return GoogleCloudStorageObject.fromReference(artifactManifest);
+  }
+
+  private List<GoogleCloudBuildArtifact> readGoogleCloudStorageManifest(
+      GoogleCloudStorageObject manifest) throws IOException {
+    List<GoogleCloudBuildArtifact> results = new ArrayList<>();
+    InputStream is = client.fetchStorageObject(manifest.getBucket(), manifest.getObject());
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        results.add(objectMapper.readValue(line, GoogleCloudBuildArtifact.class));
+      }
+    }
+    return results;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
@@ -20,6 +20,9 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.services.cloudbuild.v1.CloudBuild;
 import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.Operation;
+import com.google.api.services.storage.Storage;
+import java.io.IOException;
+import java.io.InputStream;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class GoogleCloudBuildClient {
   private final String projectId;
   private final CloudBuild cloudBuild;
+  private final Storage cloudStorage;
   private final GoogleCloudBuildExecutor executor;
 
   @RequiredArgsConstructor
@@ -41,7 +45,8 @@ public class GoogleCloudBuildClient {
 
     public GoogleCloudBuildClient create(GoogleCredential credential, String projectId) {
       CloudBuild cloudBuild = cloudBuildFactory.getCloudBuild(credential, applicationName);
-      return new GoogleCloudBuildClient(projectId, cloudBuild, executor);
+      Storage cloudStorage = cloudBuildFactory.getCloudStorage(credential, applicationName);
+      return new GoogleCloudBuildClient(projectId, cloudBuild, cloudStorage, executor);
     }
   }
 
@@ -51,5 +56,9 @@ public class GoogleCloudBuildClient {
 
   public Build getBuild(String buildId) {
     return executor.execute(() -> cloudBuild.projects().builds().get(projectId, buildId));
+  }
+
+  public InputStream fetchStorageObject(String bucket, String object) throws IOException {
+    return cloudStorage.objects().get(bucket, object).executeMediaAsInputStream();
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.services.cloudbuild.v1.model.Build;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -63,5 +64,10 @@ public class GoogleCloudBuildController {
   @RequestMapping(value = "/builds/{account}/{buildId}", method = RequestMethod.GET)
   Build getBuild(@PathVariable String account, @PathVariable String buildId) {
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getBuild(buildId);
+  }
+
+  @RequestMapping(value = "/builds/{account}/{buildId}/artifacts", method = RequestMethod.GET)
+  List<Artifact> getArtifacts(@PathVariable String account, @PathVariable String buildId) {
+    return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getArtifacts(buildId);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -70,4 +70,14 @@ public class GoogleCloudBuildController {
   List<Artifact> getArtifacts(@PathVariable String account, @PathVariable String buildId) {
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getArtifacts(buildId);
   }
+
+  @RequestMapping(
+      value = "/artifacts/extract/{account}",
+      method = RequestMethod.PUT,
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  List<Artifact> extractArtifacts(
+      @PathVariable String account, @RequestBody String serializedBuild) {
+    Build build = googleCloudBuildParser.parse(serializedBuild, Build.class);
+    return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).extractArtifacts(build);
+  }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/model/GoogleCloudBuildArtifact.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/model/GoogleCloudBuildArtifact.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleCloudBuildArtifact {
+  private final String location;
+
+  @JsonCreator
+  public GoogleCloudBuildArtifact(@JsonProperty("location") String location) {
+    this.location = location;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/model/GoogleCloudStorageObject.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/model/GoogleCloudStorageObject.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GoogleCloudStorageObject {
+  private static final String PREFIX = "gs://";
+  private final String bucket;
+  private final String object;
+  private final Long version;
+
+  public static GoogleCloudStorageObject fromReference(String reference) {
+    String working = reference;
+    String bucket;
+    String object;
+    Long version;
+
+    if (working.startsWith(PREFIX)) {
+      working = working.substring(PREFIX.length());
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Google Cloud Storage path must begin with %s: %s", PREFIX, working));
+    }
+
+    if (working.contains("/")) {
+      int index = working.indexOf("/");
+      bucket = working.substring(0, index);
+      working = working.substring(index + 1);
+    } else {
+      throw new IllegalArgumentException("Google Cloud Storage path must begin with %s: %s");
+    }
+
+    if (working.contains("#")) {
+      int index = working.indexOf("#");
+      object = working.substring(0, index);
+      working = working.substring(index + 1);
+    } else {
+      object = working;
+      working = "";
+    }
+
+    if (working.equals("")) {
+      version = null;
+    } else {
+      version = Long.parseLong(working);
+    }
+
+    return new GoogleCloudStorageObject(bucket, object, version);
+  }
+
+  public String getVersionString() {
+    if (version == null) {
+      return null;
+    }
+    return version.toString();
+  }
+
+  public String getReference() {
+    String path = getName();
+    if (version == null) {
+      return path;
+    }
+
+    return String.format("%s#%s", path, version);
+  }
+
+  public String getName() {
+    return String.format("gs://%s/%s", bucket, object);
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountSpec.groovy
@@ -27,7 +27,8 @@ class GoogleCloudBuildAccountSpec extends Specification {
   GoogleCloudBuildClient client = Mock(GoogleCloudBuildClient)
   GoogleCloudBuildCache cache = Mock(GoogleCloudBuildCache)
   GoogleCloudBuildParser parser = new GoogleCloudBuildParser()
-  GoogleCloudBuildAccount googleCloudBuildAccount = new GoogleCloudBuildAccount(client, cache, parser)
+  GoogleCloudBuildArtifactFetcher artifactFetcher = new GoogleCloudBuildArtifactFetcher(client)
+  GoogleCloudBuildAccount googleCloudBuildAccount = new GoogleCloudBuildAccount(client, cache, parser, artifactFetcher)
 
   static ObjectMapper objectMapper = new ObjectMapper()
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcherSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcherSpec.groovy
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb
+
+
+import com.google.api.services.cloudbuild.v1.model.Build
+import com.google.api.services.cloudbuild.v1.model.BuiltImage
+import com.google.api.services.cloudbuild.v1.model.Results
+import spock.lang.Specification
+
+import java.util.stream.Collectors
+
+class GoogleCloudBuildArtifactFetcherSpec extends Specification {
+  static final String MANIFEST_BUCKET = "some-bucket"
+  static final String MANIFEST_OBJECT = "artifacts-b3c0b5d3-c1c1-4ed3-b9e6-06651e04d4aa.json"
+  static final String MANIFEST_PATH = "gs://some-bucket/artifacts-b3c0b5d3-c1c1-4ed3-b9e6-06651e04d4aa.json"
+
+  GoogleCloudBuildClient client = Mock(GoogleCloudBuildClient)
+  GoogleCloudBuildArtifactFetcher artifactFetcher = new GoogleCloudBuildArtifactFetcher(client)
+
+  def "returns an empty array when there are no artifacts"() {
+    given:
+    Build build = new Build()
+
+    when:
+    def artifacts = artifactFetcher.getArtifacts(build)
+
+    then:
+    artifacts.size() == 0
+  }
+
+  def "correctly creates a docker artifact"() {
+    given:
+    BuiltImage image = new BuiltImage()
+      .setName("gcr.io/my-project/my-container:latest")
+      .setDigest("d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5")
+    Build build = getBuild([image], false)
+
+    when:
+    def artifacts = artifactFetcher.getArtifacts(build)
+
+    then:
+    artifacts.size() == 1
+    artifacts[0].name == "gcr.io/my-project/my-container"
+    artifacts[0].version == "d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5"
+    artifacts[0].reference == "gcr.io/my-project/my-container@d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5"
+    artifacts[0].type == "docker/image"
+  }
+
+  def "correctly multiple a docker artifacts"() {
+    given:
+    List<BuiltImage> images = [
+      new BuiltImage()
+      .setName("gcr.io/my-project/my-container:latest")
+      .setDigest("d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5"),
+      new BuiltImage()
+        .setName("gcr.io/my-project/my-other-container:latest")
+        .setDigest("edeaaff3f1774ad2888673770c6d64097e391bc362d7d6fb34982ddf0efd18cb")
+    ]
+
+    Build build = getBuild(images, false)
+
+    when:
+    def artifacts = artifactFetcher.getArtifacts(build)
+
+    then:
+    artifacts.size() == 2
+    artifacts[0].name == "gcr.io/my-project/my-container"
+    artifacts[0].version == "d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5"
+    artifacts[0].reference == "gcr.io/my-project/my-container@d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5"
+    artifacts[0].type == "docker/image"
+
+    artifacts[1].name == "gcr.io/my-project/my-other-container"
+    artifacts[1].version == "edeaaff3f1774ad2888673770c6d64097e391bc362d7d6fb34982ddf0efd18cb"
+    artifacts[1].reference == "gcr.io/my-project/my-other-container@edeaaff3f1774ad2888673770c6d64097e391bc362d7d6fb34982ddf0efd18cb"
+    artifacts[1].type == "docker/image"
+  }
+
+  def "returns no artifacts for an empty manifest"() {
+    given:
+    Build build = getBuild([], true)
+
+    when:
+    def artifacts = artifactFetcher.getArtifacts(build)
+
+    then:
+    client.fetchStorageObject(MANIFEST_BUCKET, MANIFEST_OBJECT) >> new ByteArrayInputStream()
+
+    artifacts.size() == 0
+  }
+
+  def "correctly parses an artifact manifest with a single artifact"() {
+    given:
+    def gcsObjects = ["gs://artifact-bucket/test.out#1556268736494368"]
+    Build build = getBuild([], true)
+
+    when:
+    def artifacts = artifactFetcher.getArtifacts(build)
+
+    then:
+    client.fetchStorageObject(MANIFEST_BUCKET, MANIFEST_OBJECT) >> new ByteArrayInputStream(getManifest(gcsObjects).getBytes())
+
+    artifacts.size() == 1
+    artifacts[0].name == "gs://artifact-bucket/test.out"
+    artifacts[0].version == "1556268736494368"
+    artifacts[0].reference == "gs://artifact-bucket/test.out#1556268736494368"
+    artifacts[0].type == "gcs/object"
+  }
+
+
+  def "correctly parses an artifact manifest with a multiple artifacts"() {
+    given:
+    def gcsObjects = ["gs://artifact-bucket/test.out#1556268736494368", "gs://other-bucket/build.jar#2388597157"]
+    Build build = getBuild([], true)
+
+    when:
+    def artifacts = artifactFetcher.getArtifacts(build)
+
+    then:
+    client.fetchStorageObject(MANIFEST_BUCKET, MANIFEST_OBJECT) >> new ByteArrayInputStream(getManifest(gcsObjects).getBytes())
+
+    artifacts.size() == 2
+    artifacts[0].name == "gs://artifact-bucket/test.out"
+    artifacts[0].version == "1556268736494368"
+    artifacts[0].reference == "gs://artifact-bucket/test.out#1556268736494368"
+    artifacts[0].type == "gcs/object"
+
+    artifacts[1].name == "gs://other-bucket/build.jar"
+    artifacts[1].version == "2388597157"
+    artifacts[1].reference == "gs://other-bucket/build.jar#2388597157"
+    artifacts[1].type == "gcs/object"
+  }
+
+  def "can return both docker and gcs artifacts"() {
+    given:
+    BuiltImage image = new BuiltImage()
+      .setName("gcr.io/my-project/my-container:latest")
+      .setDigest("d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5")
+    def gcsObjects = ["gs://artifact-bucket/test.out#1556268736494368"]
+    Build build = getBuild([image], true)
+
+    when:
+    def artifacts = artifactFetcher.getArtifacts(build)
+
+    then:
+    client.fetchStorageObject(MANIFEST_BUCKET, MANIFEST_OBJECT) >> new ByteArrayInputStream(getManifest(gcsObjects).getBytes())
+
+    artifacts.size() == 2
+
+    artifacts[0].name == "gcr.io/my-project/my-container"
+    artifacts[0].version == "d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5"
+    artifacts[0].reference == "gcr.io/my-project/my-container@d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5"
+    artifacts[0].type == "docker/image"
+
+    artifacts[1].name == "gs://artifact-bucket/test.out"
+    artifacts[1].version == "1556268736494368"
+    artifacts[1].reference == "gs://artifact-bucket/test.out#1556268736494368"
+    artifacts[1].type == "gcs/object"
+  }
+
+  Build getBuild(List<BuiltImage> images, boolean hasManifest) {
+    Results results = new Results()
+
+    if (images) {
+      results.setImages(images)
+    }
+
+    if (hasManifest) {
+      results.setArtifactManifest(MANIFEST_PATH)
+    }
+
+    return new Build().setResults(results)
+  }
+
+  String getManifest(List<String> paths) {
+    List<String> fragments = paths.stream().map({p -> getManifestFragment(p)}).collect(Collectors.toList())
+    return String.join("\n", fragments);
+  }
+
+  String getManifestFragment(String path) {
+    return '{"location":"' + path + '","file_hash":[{"file_hash":[{"type":2,"value":"OE85d2dlRlRtc0FPOWJkaHRQc0Jzdz09"}]}]}'
+  }
+}

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/model/GoogleCloudStorageObjectSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/model/GoogleCloudStorageObjectSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb.model
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GoogleCloudStorageObjectSpec extends Specification {
+  @Unroll
+  def "properly reads a path"() {
+    when:
+    GoogleCloudStorageObject gcsObject = GoogleCloudStorageObject.fromReference(path)
+
+    then:
+    gcsObject.getBucket() == bucket
+    gcsObject.getObject() == object
+    gcsObject.getVersion() == version
+
+    where:
+    path                                       | bucket      | object                     | version
+    "gs://bucket/file"                         | "bucket"    | "file"                     | null
+    "gs://a_b-3.d/file"                        | "a_b-3.d"   | "file"                     | null
+    "gs://a_b-3.d/path-1/to_2/file@3.tar4"     | "a_b-3.d"   | "path-1/to_2/file@3.tar4"  | null
+    "gs://bucket/file#123"                     | "bucket"    | "file"                     | 123
+    "gs://bucket/file#0"                       | "bucket"    | "file"                     | 0
+    "gs://a_b-3.d/path-1/to_2/file@3.tar4#987" | "a_b-3.d"   | "path-1/to_2/file@3.tar4"  | 987
+  }
+
+  @Unroll
+  def "properly returns attributes"() {
+    when:
+    GoogleCloudStorageObject gcsObject = GoogleCloudStorageObject.fromReference(path)
+
+    then:
+    gcsObject.getReference() == path
+    gcsObject.getName() == name
+    gcsObject.getVersionString() == versionString
+
+    where:
+    path                                       | name                                    | versionString
+    "gs://bucket/file"                         | "gs://bucket/file"                      | null
+    "gs://a_b-3.d/file"                        | "gs://a_b-3.d/file"                     | null
+    "gs://a_b-3.d/path-1/to_2/file@3.tar4"     | "gs://a_b-3.d/path-1/to_2/file@3.tar4"  | null
+    "gs://bucket/file#123"                     | "gs://bucket/file"                      | "123"
+    "gs://bucket/file#0"                       | "gs://bucket/file"                      | "0"
+    "gs://a_b-3.d/path-1/to_2/file@3.tar4#987" | "gs://a_b-3.d/path-1/to_2/file@3.tar4"  | "987"
+  }
+
+
+  @Unroll
+  def "throws an exception on invalid paths"() {
+    when:
+    GoogleCloudStorageObject gcsObject = GoogleCloudStorageObject.fromReference(path)
+
+    then:
+    thrown(IllegalArgumentException)
+
+    where:
+    path << [
+      "abc/def",
+      "gs://abc",
+      "gs://abc/def#mnop"
+    ]
+  }
+}


### PR DESCRIPTION
* feat(gcb): Add support for parsing GCS paths 

  In order to fetch the list of artifacts produced by a build, we'll need to fetch the manifest from GCS. This will involve translating a GCS path into a bucket/object/version, which there is no helper function in the GCS library for; write a small class to do this and test it.

* feat(gcb): Add GCS object to GCB account 

  As Google Cloud Build stores a manifest of produced artifacts in Google Cloud Storage, a GCB account will need to be able to talk to GCS in order to return information about produced artifacts.

  This allows us to better encapsulate information about produced artifacts rather than having the GCB account simply return a path to the manfest and require the caller to parse any artifacts (which are in a GCB-specific format).

* feat(gcb): Add endpoint to fetch build artifacts 

  The endpoint should return a list of Spinnaker artifacts representing artifacts produced by the build.  A build can produce either docker containers or arbitrary files in Google Cloud Storage.

  Docker containers are directly included in the build output, so we can read the relevant fields and construct an artifact. GCS files are not included directly in the output; the output contains a GCS path to a manifest of produced files. We need to fetch and parse this manifest in order to generate the produced artifacts.

* feat(gcb): Add endpoint for extracting artifacts from build

  In some cases the consumer already has a build from which they'd like to extract artifacts; allow the consumer to send this build to igor rather than just the id (which could have igor fetch stale data).