### PR TITLE
fix(artifactory): correctly construct Artifactory URL

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
@@ -152,7 +152,7 @@ public class ArtifactoryBuildMonitor
                       aqlResponse.parseBody(ArtifactoryQueryResults.class).getResults();
                   return new ArtifactPollingDelta(
                       search.getName(),
-                      client.getUri(),
+                      search.getBaseUrl(),
                       search.getPartitionName(),
                       Collections.singletonList(
                           new ArtifactDelta(

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItem.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItem.java
@@ -26,6 +26,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 public class ArtifactoryItem {
+  private String name;
   private String repo;
   private String path;
   private List<ArtifactoryArtifact> artifacts;
@@ -44,7 +45,7 @@ public class ArtifactoryItem {
         String location = null;
         if (baseUrl != null) {
           location =
-              baseUrl + "/artifactory/webapp/#/artifacts/browse/tree/General/" + repo + "/" + path;
+              baseUrl + "/webapp/#/artifacts/browse/tree/General/" + repo + "/" + path + "/" + name;
         }
 
         final Artifact.ArtifactBuilder artifactBuilder =

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItemTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItemTest.java
@@ -28,6 +28,7 @@ class ArtifactoryItemTest {
   @Test
   void toMatchableArtifact() {
     ArtifactoryItem artifact = new ArtifactoryItem();
+    artifact.setName("1.0.1.pom");
     artifact.setPath("io/pivotal/spinnaker/demo/0.1.0-dev.20+d9a14fb");
     artifact.setRepo("libs-demo-local");
 
@@ -41,8 +42,8 @@ class ArtifactoryItemTest {
     assertThat(matchableArtifact.getName()).isEqualTo("io.pivotal.spinnaker:demo");
     assertThat(matchableArtifact.getLocation())
         .isEqualTo(
-            "http://localhost:8080/artifactory/webapp/#/artifacts/browse/tree/General/libs-demo-local/io/pivotal"
-                + "/spinnaker/demo/0.1.0-dev.20+d9a14fb");
+            "http://localhost:8080/webapp/#/artifacts/browse/tree/General/libs-demo-local/io/pivotal"
+                + "/spinnaker/demo/0.1.0-dev.20+d9a14fb/1.0.1.pom");
   }
 
   @Test


### PR DESCRIPTION
Previously we got the base URL from the client which unintuitively removed the context root for us. Now we grab it from the search which has the Artifactory base URLs that Igor is configured with.
We also provide a more specific URL that identifies a particular pom, rather than just the directory of the group, artifact, and version.
