### PR TITLE
feat(travis): Support for log_complete from Travis API

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -74,7 +74,7 @@ class BuildController {
             return null
 
         try {
-            build.genericGitRevisions = buildService.getGenericGitRevisions(job, buildNumber)
+            build.genericGitRevisions = buildService.getGenericGitRevisions(job, build)
         } catch (Exception e) {
             log.error("could not get scm results for {} / {} / {}", kv("master", master), kv("job", job), kv("buildNumber", buildNumber), e)
         }
@@ -108,7 +108,7 @@ class BuildController {
         def buildService = getBuildService(master)
         GenericBuild build = jobStatus(buildService, master, job, buildNumber)
         if (build && buildService instanceof BuildProperties && artifactExtractor != null) {
-            build.properties = buildService.getBuildProperties(job, buildNumber, propertyFile)
+            build.properties = buildService.getBuildProperties(job, build, propertyFile)
             return artifactExtractor.extractArtifacts(build)
         }
         return Collections.emptyList()
@@ -240,7 +240,8 @@ class BuildController {
         def buildService = getBuildService(master)
         if (buildService instanceof BuildProperties) {
             BuildProperties buildProperties = (BuildProperties) buildService
-            return buildProperties.getBuildProperties(job, buildNumber, fileName)
+          def genericBuild = buildService.getGenericBuild(job, buildNumber)
+          return buildProperties.getBuildProperties(job, genericBuild, fileName)
         }
         return Collections.emptyMap()
     }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/model/GenericGitRevision.java
@@ -5,10 +5,12 @@ import java.time.Instant;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.experimental.Wither;
 
 @Getter
 @EqualsAndHashCode(of = "sha1")
 @Builder
+@Wither
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class GenericGitRevision {
   private String name;

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.java
@@ -63,7 +63,7 @@ public class GitlabCiService implements BuildOperations {
   }
 
   @Override
-  public List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber) {
+  public List<GenericGitRevision> getGenericGitRevisions(String job, GenericBuild build) {
     throw new UnsupportedOperationException();
   }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
@@ -254,19 +254,18 @@ public class JenkinsService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public Map<String, Object> getBuildProperties(String job, int buildNumber, String fileName) {
+  public Map<String, Object> getBuildProperties(String job, GenericBuild build, String fileName) {
     if (StringUtils.isEmpty(fileName)) {
       return new HashMap<>();
     }
     Map<String, Object> map = new HashMap<>();
     try {
-      String path = getArtifactPathFromBuild(job, buildNumber, fileName);
+      String path = getArtifactPathFromBuild(job, build.getNumber(), fileName);
       try (InputStream propertyStream =
-          this.getPropertyFile(job, buildNumber, path).getBody().in()) {
+          this.getPropertyFile(job, build.getNumber(), path).getBody().in()) {
         if (fileName.endsWith(".yml") || fileName.endsWith(".yaml")) {
           Yaml yml = new Yaml(new SafeConstructor());
-          map = (Map<String, Object>) yml.load(propertyStream);
+          map = yml.load(propertyStream);
         } else if (fileName.endsWith(".json")) {
           map = objectMapper.readValue(propertyStream, new TypeReference<Map<String, Object>>() {});
         } else {
@@ -331,8 +330,8 @@ public class JenkinsService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  public List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber) {
-    ScmDetails scmDetails = getGitDetails(job, buildNumber);
+  public List<GenericGitRevision> getGenericGitRevisions(String job, GenericBuild build) {
+    ScmDetails scmDetails = getGitDetails(job, build.getNumber());
     return scmDetails.genericGitRevisions();
   }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildOperations.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildOperations.java
@@ -31,10 +31,10 @@ public interface BuildOperations extends BuildService {
    * Get a list of the Spinnaker representation of the Git commits relevant for the given build
    *
    * @param job The name of the job
-   * @param buildNumber The build number
+   * @param build The build
    * @return A list of git revisions relevant for the build
    */
-  List<GenericGitRevision> getGenericGitRevisions(String job, int buildNumber);
+  List<GenericGitRevision> getGenericGitRevisions(String job, GenericBuild build);
 
   /**
    * Return all information of a given build

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildProperties.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/service/BuildProperties.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.igor.service;
 
+import com.netflix.spinnaker.igor.build.model.GenericBuild;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -29,10 +30,10 @@ public interface BuildProperties {
    * Get build properties defined in the given build
    *
    * @param job The name of the job
-   * @param buildNumber The build number
+   * @param build The build
    * @param fileName The file name containing the properties. Not all providers require this
    *     parameter.
    * @return A map of properties
    */
-  Map<String, ?> getBuildProperties(String job, int buildNumber, @Nullable String fileName);
+  Map<String, ?> getBuildProperties(String job, GenericBuild build, @Nullable String fileName);
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerService.groovy
@@ -80,7 +80,7 @@ class WerckerService implements BuildOperations {
     }
 
     @Override
-    List<GenericGitRevision> getGenericGitRevisions(final String job, final int buildNumber) {
+    List<GenericGitRevision> getGenericGitRevisions(final String job, final GenericBuild build) {
         return null
     }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
@@ -113,14 +113,12 @@ public class ConcourseService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  public List<GenericGitRevision> getGenericGitRevisions(String jobPath, int buildNumber) {
-    GenericBuild build = getGenericBuild(jobPath, buildNumber);
+  public List<GenericGitRevision> getGenericGitRevisions(String jobPath, GenericBuild build) {
     return build == null ? emptyList() : build.getGenericGitRevisions();
   }
 
   @Override
-  public Map<String, ?> getBuildProperties(String jobPath, int buildNumber, String fileName) {
-    GenericBuild build = getGenericBuild(jobPath, buildNumber);
+  public Map<String, ?> getBuildProperties(String jobPath, GenericBuild build, String fileName) {
     return build == null ? emptyMap() : build.getProperties();
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -30,7 +30,11 @@ import com.netflix.spinnaker.igor.history.EchoService;
 import com.netflix.spinnaker.igor.history.model.GenericBuildContent;
 import com.netflix.spinnaker.igor.history.model.GenericBuildEvent;
 import com.netflix.spinnaker.igor.model.BuildServiceProvider;
-import com.netflix.spinnaker.igor.polling.*;
+import com.netflix.spinnaker.igor.polling.CommonPollingMonitor;
+import com.netflix.spinnaker.igor.polling.DeltaItem;
+import com.netflix.spinnaker.igor.polling.LockService;
+import com.netflix.spinnaker.igor.polling.PollContext;
+import com.netflix.spinnaker.igor.polling.PollingDelta;
 import com.netflix.spinnaker.igor.service.BuildServices;
 import com.netflix.spinnaker.igor.travis.client.model.Repo;
 import com.netflix.spinnaker.igor.travis.client.model.v3.TravisBuildState;
@@ -226,7 +230,7 @@ public class TravisBuildMonitor
                       : Collections.emptyList();
               if (build.getNumber() > cachedBuild
                   && !build.spinnakerTriggered()
-                  && travisService.isLogReady(jobIds)) {
+                  && travisService.isLogReady(build)) {
                 BuildDelta delta =
                     new BuildDelta()
                         .setBranchedRepoSlug(branchedRepoSlug)
@@ -264,10 +268,7 @@ public class TravisBuildMonitor
     if (!buildDelta.getBuild().spinnakerTriggered()) {
       if (echoService.isPresent()) {
         log.info(
-            "({}) pushing event for :"
-                + branchedSlug
-                + ":"
-                + String.valueOf(buildDelta.getBuild().getNumber()),
+            "({}) pushing event for :" + branchedSlug + ":" + buildDelta.getBuild().getNumber(),
             kv("master", master));
 
         GenericProject project = new GenericProject(branchedSlug, buildDelta.getGenericBuild());

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/TravisClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/TravisClient.java
@@ -19,23 +19,19 @@ package com.netflix.spinnaker.igor.travis.client;
 
 import com.netflix.spinnaker.igor.travis.client.model.AccessToken;
 import com.netflix.spinnaker.igor.travis.client.model.Accounts;
-import com.netflix.spinnaker.igor.travis.client.model.Build;
 import com.netflix.spinnaker.igor.travis.client.model.Builds;
 import com.netflix.spinnaker.igor.travis.client.model.EmptyObject;
 import com.netflix.spinnaker.igor.travis.client.model.GithubAuth;
-import com.netflix.spinnaker.igor.travis.client.model.Jobs;
-import com.netflix.spinnaker.igor.travis.client.model.Repo;
 import com.netflix.spinnaker.igor.travis.client.model.RepoRequest;
-import com.netflix.spinnaker.igor.travis.client.model.RepoWrapper;
 import com.netflix.spinnaker.igor.travis.client.model.Repos;
 import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse;
 import com.netflix.spinnaker.igor.travis.client.model.v3.Request;
+import com.netflix.spinnaker.igor.travis.client.model.v3.Root;
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build;
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Builds;
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Log;
 import retrofit.client.Response;
 import retrofit.http.Body;
-import retrofit.http.EncodedPath;
 import retrofit.http.GET;
 import retrofit.http.Header;
 import retrofit.http.Headers;
@@ -44,32 +40,22 @@ import retrofit.http.Path;
 import retrofit.http.Query;
 
 public interface TravisClient {
+  /**
+   * Root endpoint (<a
+   * href="https://developer.travis-ci.com/resource/home">developer.travis-ci.com/resource/home</a>),
+   * describes the API and its capabilities
+   *
+   * @return The root object, describing the API
+   */
+  @GET("/v3/")
+  @Headers("Travis-API-Version: 3")
+  public Root getRoot();
+
   @POST("/auth/github")
   public abstract AccessToken accessToken(@Body GithubAuth gitHubAuth);
 
   @GET("/accounts")
   public abstract Accounts accounts(@Header("Authorization") String accessToken);
-
-  @GET("/builds")
-  public abstract Builds builds(@Header("Authorization") String accessToken);
-
-  @GET("/builds")
-  public abstract Builds builds(
-      @Header("Authorization") String accessToken, @Query("repository_id") int repositoryId);
-
-  @GET("/builds")
-  public abstract Builds builds(
-      @Header("Authorization") String accessToken, @Query("slug") String repoSlug);
-
-  @GET("/builds/{build_id}")
-  public abstract Build build(
-      @Header("Authorization") String accessToken, @Path("build_id") int buildId);
-
-  @GET("/builds")
-  public abstract Build build(
-      @Header("Authorization") String accessToken,
-      @Query("repository_id") int repositoryId,
-      @Query("number") int buildNumber);
 
   @GET("/builds")
   public abstract Builds builds(
@@ -85,14 +71,6 @@ public interface TravisClient {
       @Query("limit") int limit,
       @Query("offset") int offset);
 
-  @GET("/repos/{repositoryId}")
-  public abstract Repo repo(
-      @Header("Authorization") String accessToken, @Path("repositoryId") int repositoryId);
-
-  @GET("/repos/{repo_slug}")
-  public abstract RepoWrapper repoWrapper(
-      @Header("Authorization") String accessToken, @EncodedPath("repo_slug") String repoSlug);
-
   @POST("/repo/{repoSlug}/requests")
   @Headers("Travis-API-Version: 3")
   public abstract TriggerResponse triggerBuild(
@@ -104,9 +82,6 @@ public interface TravisClient {
   public abstract Response usersSync(
       @Header("Authorization") String accessToken, @Body EmptyObject emptyObject);
 
-  @GET("/jobs/{job_id}")
-  public abstract Jobs jobs(@Header("Authorization") String accessToken, @Path("job_id") int jobId);
-
   @Headers({"Travis-API-Version: 3", "Accept: text/plain"})
   @GET("/job/{jobId}/log")
   public abstract V3Log jobLog(
@@ -115,21 +90,25 @@ public interface TravisClient {
   @GET("/build/{build_id}")
   @Headers("Travis-API-Version: 3")
   public abstract V3Build v3build(
-      @Header("Authorization") String accessToken, @Path("build_id") int repositoryId);
+      @Header("Authorization") String accessToken,
+      @Path("build_id") int buildId,
+      @Query("include") String include);
 
   @GET("/repo/{repository_id}/builds")
   @Headers("Travis-API-Version: 3")
   public abstract V3Builds builds(
       @Header("Authorization") String accessToken,
       @Path("repository_id") int repositoryId,
-      @Query("limit") int limit);
+      @Query("limit") int limit,
+      @Query("include") String include);
 
   @GET("/repo/{repository_slug}/builds")
   @Headers("Travis-API-Version: 3")
   public abstract V3Builds v3builds(
       @Header("Authorization") String accessToken,
       @Path("repository_slug") String repositorySlug,
-      @Query("limit") int limit);
+      @Query("limit") int limit,
+      @Query("include") String include);
 
   @GET("/repo/{repository_slug}/builds")
   @Headers("Travis-API-Version: 3")
@@ -137,7 +116,8 @@ public interface TravisClient {
       @Header("Authorization") String accessToken,
       @Path("repository_slug") String repositorySlug,
       @Query("branch.name") String branchName,
-      @Query("limit") int limit);
+      @Query("limit") int limit,
+      @Query("include") String include);
 
   @GET("/repo/{repository_slug}/builds")
   @Headers("Travis-API-Version: 3")
@@ -146,7 +126,8 @@ public interface TravisClient {
       @Path("repository_slug") String repositorySlug,
       @Query("branch.name") String branchName,
       @Query("event_type") String eventType,
-      @Query("limit") int limit);
+      @Query("limit") int limit,
+      @Query("include") String include);
 
   @GET("/repo/{repository_slug}/builds")
   @Headers("Travis-API-Version: 3")
@@ -154,7 +135,8 @@ public interface TravisClient {
       @Header("Authorization") String accessToken,
       @Path("repository_slug") String repositorySlug,
       @Query("event_type") String EventType,
-      @Query("limit") int limit);
+      @Query("limit") int limit,
+      @Query("include") String include);
 
   @GET("/repo/{repository_id}/request/{request_id}")
   @Headers("Travis-API-Version: 3")

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/Root.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/Root.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.travis.client.model.v3;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Class representing the root endpoint of the Travis API. Currently only used for feature
+ * detection, as the API can differ a bit between versions. Only the elements required for the
+ * feature detection are represented in the class.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@NoArgsConstructor
+public class Root {
+  private Resources resources;
+
+  public boolean hasLogCompleteAttribute() {
+    return resources.build.attributes.contains("log_complete");
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @Data
+  @NoArgsConstructor
+  private static class Resources {
+    private Build build;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @Data
+  @NoArgsConstructor
+  private static class Build {
+    private List<String> attributes;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.igor.build.model.GenericGitRevision;
 import com.netflix.spinnaker.igor.travis.client.model.Config;
 import java.time.Instant;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.simpleframework.xml.Default;
 import org.simpleframework.xml.Root;
 
@@ -31,6 +32,7 @@ import org.simpleframework.xml.Root;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Root(name = "builds")
+@Slf4j
 public class V3Build {
   private V3Branch branch;
 
@@ -54,6 +56,9 @@ public class V3Build {
 
   @JsonProperty("finished_at")
   private Instant finishedAt;
+
+  @JsonProperty("log_complete")
+  private Boolean logComplete;
 
   private List<V3Job> jobs;
   private Config config;
@@ -201,5 +206,13 @@ public class V3Build {
 
   public void setConfig(Config config) {
     this.config = config;
+  }
+
+  public Boolean getLogComplete() {
+    return logComplete;
+  }
+
+  public void setLogComplete(Boolean logComplete) {
+    this.logComplete = logComplete;
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Commit.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Commit.java
@@ -17,22 +17,32 @@
 
 package com.netflix.spinnaker.igor.travis.client.model.v3;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.netflix.spinnaker.igor.build.model.GenericGitRevision;
+import java.time.Instant;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.simpleframework.xml.Default;
 import org.simpleframework.xml.Root;
 
 @Default
 @Root(name = "commits")
+@Data
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class V3Commit {
   private int id;
   private String sha;
   private String ref;
   private String message;
-
-  @JsonProperty("compare_url")
   private String compareUrl;
+  private Instant committedAt;
+  private Person author;
+  private Person committer;
 
   public boolean isTag() {
     return ref != null && ref.split("/")[1].equals("tags");
@@ -42,43 +52,23 @@ public class V3Commit {
     return ref != null && ref.split("/")[1].equals("pull");
   }
 
-  public int getId() {
-    return id;
+  @Data
+  @NoArgsConstructor
+  @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class Person {
+    private String name;
+    private String avatarUrl;
   }
 
-  public void setId(int id) {
-    this.id = id;
-  }
-
-  public String getSha() {
-    return sha;
-  }
-
-  public void setSha(String sha) {
-    this.sha = sha;
-  }
-
-  public String getRef() {
-    return ref;
-  }
-
-  public void setRef(String ref) {
-    this.ref = ref;
-  }
-
-  public String getMessage() {
-    return message;
-  }
-
-  public void setMessage(String message) {
-    this.message = message;
-  }
-
-  public String getCompareUrl() {
-    return compareUrl;
-  }
-
-  public void setCompareUrl(String compareUrl) {
-    this.compareUrl = compareUrl;
+  @JsonIgnore
+  public GenericGitRevision getGenericGitRevision() {
+    return GenericGitRevision.builder()
+        .sha1(sha)
+        .committer(getAuthor().getName())
+        .compareUrl(compareUrl)
+        .message(message)
+        .timestamp(committedAt)
+        .build();
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
@@ -66,7 +66,7 @@ public class V3Log {
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  static class V3LogPart {
+  public static class V3LogPart {
     private String content;
     private Integer number;
     private boolean isFinal;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisBuildConverter.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisBuildConverter.java
@@ -31,6 +31,7 @@ public class TravisBuildConverter {
     genericBuild.setResult(build.getState().getResult());
     genericBuild.setName(repoSlug);
     genericBuild.setUrl(url(repoSlug, baseUrl, build.getId()));
+    genericBuild.setId(String.valueOf(build.getId()));
     if (build.getFinishedAt() != null) {
       genericBuild.setTimestamp(String.valueOf(build.getTimestamp()));
     }
@@ -45,6 +46,7 @@ public class TravisBuildConverter {
     genericBuild.setResult(build.getState().getResult());
     genericBuild.setName(build.getRepository().getSlug());
     genericBuild.setUrl(url(build.getRepository().getSlug(), baseUrl, build.getId()));
+    genericBuild.setId(String.valueOf(build.getId()));
     if (build.getFinishedAt() != null) {
       genericBuild.setTimestamp(String.valueOf(build.getTimestamp()));
     }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -108,7 +108,7 @@ class InfoControllerSpec extends Specification {
         TravisService travisService = new TravisService('travis-baz', null, null, 100, null, null, Optional.empty(), [], null,
             new Permissions.Builder()
                 .add(Authorization.READ, ['group-3', 'group-4'])
-                .add(Authorization.WRITE, 'group-3').build())
+                .add(Authorization.WRITE, 'group-3').build(), false)
         createMocks([
             'jenkins-foo': jenkinsService1,
             'jenkins-bar': jenkinsService2,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
@@ -16,7 +16,10 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -35,7 +38,11 @@ import com.netflix.spinnaker.igor.RedisConfig;
 import com.netflix.spinnaker.igor.config.GoogleCloudBuildConfig;
 import com.netflix.spinnaker.igor.config.LockManagerConfig;
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.igor.jenkins.service
 
 import com.netflix.spinnaker.fiat.model.resources.Permissions
+import com.netflix.spinnaker.igor.build.model.GenericBuild
 import com.netflix.spinnaker.igor.build.model.GenericGitRevision
 import com.netflix.spinnaker.igor.config.JenkinsConfig
 import com.netflix.spinnaker.igor.config.JenkinsProperties
@@ -279,9 +280,11 @@ class JenkinsServiceSpec extends Specification {
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
         service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
+        def genericBuild = new GenericBuild()
+        genericBuild.number = 1
 
         when:
-        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
+        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', genericBuild)
 
         then:
         genericGitRevision.size() == 1
@@ -332,9 +335,11 @@ class JenkinsServiceSpec extends Specification {
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
         service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
+        def genericBuild = new GenericBuild()
+        genericBuild.number = 1
 
         when:
-        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
+        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', genericBuild)
 
         then:
         genericGitRevision.size() == 2
@@ -385,9 +390,11 @@ class JenkinsServiceSpec extends Specification {
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
         service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
+        def genericBuild = new GenericBuild()
+        genericBuild.number = 1
 
         when:
-        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
+        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', genericBuild)
 
         then:
         genericGitRevision.size() == 1
@@ -444,9 +451,11 @@ class JenkinsServiceSpec extends Specification {
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
         service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
+        def genericBuild = new GenericBuild()
+        genericBuild.number = 1
 
         when:
-        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
+        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', genericBuild)
 
         then:
         genericGitRevision.size() == 2
@@ -506,9 +515,11 @@ class JenkinsServiceSpec extends Specification {
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
         service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
+        def genericBuild = new GenericBuild()
+        genericBuild.number = 1
 
         when:
-        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
+        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', genericBuild)
 
         then:
         genericGitRevision.size() == 2
@@ -568,9 +579,11 @@ class JenkinsServiceSpec extends Specification {
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
         service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
+        def genericBuild = new GenericBuild()
+        genericBuild.number = 1
 
         when:
-        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', 1)
+        List<GenericGitRevision> genericGitRevision = service.getGenericGitRevisions('test', genericBuild)
 
         then:
         genericGitRevision.size() == 1
@@ -620,9 +633,11 @@ class JenkinsServiceSpec extends Specification {
             password: 'password')
         client = new JenkinsConfig().jenkinsClient(host)
         service = new JenkinsService('http://my.jenkins.net', client, false, Permissions.EMPTY)
+        def genericBuild = new GenericBuild()
+        genericBuild.number = 1
 
         expect:
-        service.getBuildProperties("PropertiesTest", 1, "props$extension") == testCase.result
+        service.getBuildProperties("PropertiesTest", genericBuild, "props$extension") == testCase.result
 
         cleanup:
         server.shutdown()

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
@@ -24,12 +24,10 @@ import com.netflix.spinnaker.igor.travis.client.model.Accounts
 import com.netflix.spinnaker.igor.travis.client.model.Build
 import com.netflix.spinnaker.igor.travis.client.model.Builds
 import com.netflix.spinnaker.igor.travis.client.model.GithubAuth
-import com.netflix.spinnaker.igor.travis.client.model.Job
-import com.netflix.spinnaker.igor.travis.client.model.Jobs
 import com.netflix.spinnaker.igor.travis.client.model.RepoRequest
-import com.netflix.spinnaker.igor.travis.client.model.RepoWrapper
 import com.netflix.spinnaker.igor.travis.client.model.Repos
 import com.netflix.spinnaker.igor.travis.client.model.TriggerResponse
+import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Builds
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Log
 import com.squareup.okhttp.mockwebserver.MockResponse
@@ -87,41 +85,6 @@ class TravisClientSpec extends Specification {
         account.login == 'gardalize'
     }
 
-    def "Builds"() {
-        given:
-        setResponse '''{
-        "builds": [
-        {
-            "commit_id": 6534711,
-            "config": { },
-            "duration": 2648,
-            "finished_at": "2014-04-08T19:52:56Z",
-            "id": 22555277,
-            "job_ids": [22555278, 22555279, 22555280, 22555281],
-            "number": "784",
-            "pull_request": true,
-            "pull_request_number": "1912",
-            "pull_request_title": "Example PR",
-            "repository_id": 82,
-            "started_at": "2014-04-08T19:37:44Z",
-            "state": "failed"
-        }
-        ],
-        "jobs": [ ],
-        "commits": [ ]
-        }'''
-
-        when:
-        Builds builds = client.builds("someToken")
-
-        then:
-        builds.builds.first().commitId == 6534711
-        builds.builds.first().job_ids   == [22555278, 22555279, 22555280, 22555281]
-
-    }
-
-
-
     def "Repos"() {
         given:
         setResponse '''{"repos":[{"id":8059977,"slug":"gardalize/travistest","description":"testing travis stuff","last_build_id":118583435,"last_build_number":"5","last_build_state":"passed","last_build_duration":39,"last_build_language":null,"last_build_started_at":"2016-03-25T22:29:44Z","last_build_finished_at":"2016-03-25T22:30:23Z","active":true,"github_language":"Ruby"}]}'''
@@ -133,49 +96,6 @@ class TravisClientSpec extends Specification {
         repos.repos.first().id   == 8059977
         repos.repos.first().slug == "gardalize/travistest"
         repos.repos.first().lastBuildId == 118583435
-    }
-
-    def "repoWrapper(accessToken, repoSlug)"() {
-        given:
-        setResponse '''
-        {
-        "repo": {
-            "id": 8059977,
-            "slug": "gardalize/travistest",
-            "active": true,
-            "description": "testing travis stuff",
-            "last_build_id": 123621158,
-            "last_build_number": "51",
-            "last_build_state": "passed",
-            "last_build_duration": 38,
-            "last_build_language": null,
-            "last_build_started_at": "2016-04-16T21:26:35Z",
-            "last_build_finished_at": "2016-04-16T21:27:13Z",
-            "github_language": "Ruby"
-            }
-        }
-        '''
-
-        when:
-        RepoWrapper repoWrapper = client.repoWrapper("someToken", "gardalize/travistest")
-
-        then:
-        repoWrapper.repo.slug == "gardalize/travistest"
-        repoWrapper.repo.lastBuildDuration == 38
-    }
-
-
-    def "Job"() {
-        given:
-        setResponse '''{"job":{"id":118582578,"repository_id":8059977,"repository_slug":"gardalize/travistest","build_id":118582577,"commit_id":33511919,"log_id":85633918,"number":"4.1","config":{"language":"ruby","rvm":"1.9.3",".result":"configured","group":"stable","dist":"precise","os":"linux"},"state":"passed","started_at":"2016-03-25T22:26:13Z","finished_at":"2016-03-25T22:26:48Z","queue":"builds.docker","allow_failure":false,"tags":null,"annotation_ids":[]},"commit":{"id":33511919,"sha":"f8f8a8defe21ddc337185850cf894fe40ada2b9f","branch":"master","branch_is_default":true,"message":"rake","committed_at":"2016-03-25T22:25:19Z","author_name":"Gard Rimestad","author_email":"gardalize@gurters.com","committer_name":"Gard Rimestad","committer_email":"gardalize@gurters.com","compare_url":"https://github.com/gardalize/travistest/compare/2a9956914194...f8f8a8defe21"},"annotations":[]}'''
-
-        when:
-        Jobs jobs = client.jobs("someToken", 118582578)
-
-        then:
-        Job job = jobs.job
-        job.id     == 118582578
-        job.logId == 85633918
     }
 
     def "triggerBuild()" () {
@@ -293,7 +213,41 @@ class TravisClientSpec extends Specification {
         !v3Log.ready
     }
 
-    def "getBuilds(accessToken, repoSlug, buildNumber"() {
+  def "detect incomplete log due to missing part"() {
+    given:
+    setResponse '''
+        {
+            "@type": "log",
+            "@href": "/job/123/log",
+            "@representation": "standard",
+            "@permissions": {
+                "read": true,
+                "debug": false,
+                "cancel": false,
+                "restart": false,
+                "delete_log": false
+            },
+            "id": 1337,
+            "content": "ERROR: An error occured while trying to parse your .travis.yml file.\\n\\nPlease make sure that the file is valid YAML.\\n\\nhttp://lint.travis-ci.org can check your .travis.yml.\\n\\nThe error was \\"undefined method `merge' for false:FalseClass\\".",
+            "log_parts": [
+                {
+                    "content": "http://lint.travis-ci.org can check your .travis.yml.\\n\\nThe error was \\"undefined method `merge' for false:FalseClass\\".",
+                    "final": true,
+                    "number": 1
+                }
+            ],
+            "@raw_log_href": "/v3/job/123/log.txt?log.token=hfeus7seyfhfe8"
+        }'''.stripIndent()
+
+    when:
+    V3Log v3Log = client.jobLog("someToken", 123)
+
+    then:
+    v3Log.content.contains "false:FalseClass"
+    !v3Log.ready
+  }
+
+    def "getBuilds(accessToken, repoSlug, buildNumber)"() {
         given:
         setResponse '''
             {
@@ -497,148 +451,235 @@ class TravisClientSpec extends Specification {
     def "Parse builds from the v3 api"() {
         given:
         setResponse '''
-{
-    "@type": "builds",
-    "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2",
-    "@representation": "standard",
-    "@pagination": {
-        "limit": 2,
-        "offset": 0,
-        "count": 160,
-        "is_first": true,
-        "is_last": false,
-        "next": {
-            "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2&offset=2",
-            "offset": 2,
-            "limit": 2
-        },
-        "prev": null,
-        "first": {
-            "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2",
-            "offset": 0,
-            "limit": 2
-        },
-        "last": {
-            "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2&offset=158",
-            "offset": 158,
-            "limit": 2
-        }
-    },
-    "builds": [
-        {
-            "@type": "build",
-            "@href": "/api/build/1386282",
-            "@representation": "standard",
-            "@permissions": {
-                "read": true,
-                "cancel": true,
-                "restart": true
-            },
-            "id": 1386282,
-            "number": "389",
-            "state": "passed",
-            "duration": 413,
-            "event_type": "push",
-            "previous_state": "passed",
-            "pull_request_title": null,
-            "pull_request_number": null,
-            "started_at": "2017-06-06T18:06:56Z",
-            "finished_at": "2017-06-06T18:13:49Z",
-            "repository": {
-                "@type": "repository",
-                "@href": "/api/repo/1996",
-                "@representation": "minimal",
-                "id": 1996,
-                "name": "orca",
-                "slug": "spt-infrastructure/orca"
-            },
-            "branch": {
-                "@type": "branch",
-                "@href": "/api/repo/1996/branch/sch_master",
-                "@representation": "minimal",
-                "name": "sch_master"
-            },
-            "commit": {
-                "@type": "commit",
-                "@representation": "minimal",
-                "id": 802307,
-                "sha": "3d38456a3656a65032c4db9c08d3648abb696b58",
-                "ref": "refs/heads/sch_master",
-                "message": "Merge pull request #54 from spt-infrastructure/DOCD-1025\\n\\nDocd 1025",
-                "compare_url": "https://github.schibsted.io/spt-infrastructure/orca/compare/0b373922a733...3d38456a3656",
-                "committed_at": "2017-06-06T18:06:51Z"
-            },
-            "jobs": [
-                {
-                    "@type": "job",
-                    "@href": "/api/job/1386283",
-                    "@representation": "minimal",
-                    "id": 1386283
-                }
-            ]
-        },
-        {
-            "@type": "build",
-            "@href": "/api/build/1384443",
-            "@representation": "standard",
-            "@permissions": {
-                "read": true,
-                "cancel": true,
-                "restart": true
-            },
-            "id": 1384443,
-            "number": "388",
-            "state": "passed",
-            "duration": 717,
-            "event_type": "pull_request",
-            "previous_state": "passed",
-            "pull_request_title": "Docd 1025",
-            "pull_request_number": 54,
-            "started_at": "2017-06-06T13:46:06Z",
-            "finished_at": "2017-06-06T13:58:03Z",
-            "repository": {
-                "@type": "repository",
-                "@href": "/api/repo/1996",
-                "@representation": "minimal",
-                "id": 1996,
-                "name": "orca",
-                "slug": "spt-infrastructure/orca"
-            },
-            "branch": {
-                "@type": "branch",
-                "@href": "/api/repo/1996/branch/sch_master",
-                "@representation": "minimal",
-                "name": "sch_master"
-            },
-            "commit": {
-                "@type": "commit",
-                "@representation": "minimal",
-                "id": 801226,
-                "sha": "40e8099ba9cab03febe17b38a650b8868434a068",
-                "ref": "refs/pull/54/merge",
-                "message": "DOCD-1025 enable pipelineTemplates and add proxy",
-                "compare_url": "https://github.schibsted.io/spt-infrastructure/orca/pull/54",
-                "committed_at": "2017-06-06T13:34:13Z"
-            },
-            "jobs": [
-                {
-                    "@type": "job",
-                    "@href": "/api/job/1384444",
-                    "@representation": "minimal",
-                    "id": 1384444
-                }
-            ]
-        }
-    ]
-}
-'''
+          {
+              "@type": "builds",
+              "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2",
+              "@representation": "standard",
+              "@pagination": {
+                  "limit": 2,
+                  "offset": 0,
+                  "count": 160,
+                  "is_first": true,
+                  "is_last": false,
+                  "next": {
+                      "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2&offset=2",
+                      "offset": 2,
+                      "limit": 2
+                  },
+                  "prev": null,
+                  "first": {
+                      "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2",
+                      "offset": 0,
+                      "limit": 2
+                  },
+                  "last": {
+                      "@href": "/api/repo/spt-infrastructure%2Forca/builds?branch.name=sch_master&limit=2&offset=158",
+                      "offset": 158,
+                      "limit": 2
+                  }
+              },
+              "builds": [
+                  {
+                      "@type": "build",
+                      "@href": "/api/build/1386282",
+                      "@representation": "standard",
+                      "@permissions": {
+                          "read": true,
+                          "cancel": true,
+                          "restart": true
+                      },
+                      "id": 1386282,
+                      "number": "389",
+                      "state": "passed",
+                      "duration": 413,
+                      "event_type": "push",
+                      "previous_state": "passed",
+                      "pull_request_title": null,
+                      "pull_request_number": null,
+                      "started_at": "2017-06-06T18:06:56Z",
+                      "finished_at": "2017-06-06T18:13:49Z",
+                      "repository": {
+                          "@type": "repository",
+                          "@href": "/api/repo/1996",
+                          "@representation": "minimal",
+                          "id": 1996,
+                          "name": "orca",
+                          "slug": "spt-infrastructure/orca"
+                      },
+                      "branch": {
+                          "@type": "branch",
+                          "@href": "/api/repo/1996/branch/sch_master",
+                          "@representation": "minimal",
+                          "name": "sch_master"
+                      },
+                      "commit": {
+                          "@type": "commit",
+                          "@representation": "minimal",
+                          "id": 802307,
+                          "sha": "3d38456a3656a65032c4db9c08d3648abb696b58",
+                          "ref": "refs/heads/sch_master",
+                          "message": "Merge pull request #54 from spt-infrastructure/DOCD-1025\\n\\nDocd 1025",
+                          "compare_url": "https://github.schibsted.io/spt-infrastructure/orca/compare/0b373922a733...3d38456a3656",
+                          "committed_at": "2017-06-06T18:06:51Z"
+                      },
+                      "jobs": [
+                          {
+                              "@type": "job",
+                              "@href": "/api/job/1386283",
+                              "@representation": "minimal",
+                              "id": 1386283
+                          }
+                      ]
+                  },
+                  {
+                      "@type": "build",
+                      "@href": "/api/build/1384443",
+                      "@representation": "standard",
+                      "@permissions": {
+                          "read": true,
+                          "cancel": true,
+                          "restart": true
+                      },
+                      "id": 1384443,
+                      "number": "388",
+                      "state": "passed",
+                      "duration": 717,
+                      "event_type": "pull_request",
+                      "previous_state": "passed",
+                      "pull_request_title": "Docd 1025",
+                      "pull_request_number": 54,
+                      "started_at": "2017-06-06T13:46:06Z",
+                      "finished_at": "2017-06-06T13:58:03Z",
+                      "repository": {
+                          "@type": "repository",
+                          "@href": "/api/repo/1996",
+                          "@representation": "minimal",
+                          "id": 1996,
+                          "name": "orca",
+                          "slug": "spt-infrastructure/orca"
+                      },
+                      "branch": {
+                          "@type": "branch",
+                          "@href": "/api/repo/1996/branch/sch_master",
+                          "@representation": "minimal",
+                          "name": "sch_master"
+                      },
+                      "commit": {
+                          "@type": "commit",
+                          "@representation": "minimal",
+                          "id": 801226,
+                          "sha": "40e8099ba9cab03febe17b38a650b8868434a068",
+                          "ref": "refs/pull/54/merge",
+                          "message": "DOCD-1025 enable pipelineTemplates and add proxy",
+                          "compare_url": "https://github.schibsted.io/spt-infrastructure/orca/pull/54",
+                          "committed_at": "2017-06-06T13:34:13Z"
+                      },
+                      "jobs": [
+                          {
+                              "@type": "job",
+                              "@href": "/api/job/1384444",
+                              "@representation": "minimal",
+                              "id": 1384444
+                          }
+                      ]
+                  }
+              ]
+          }
+          '''
 
         when:
-        V3Builds builds = client.v3builds("someToken", "org/repo","bah", 2)
+        V3Builds builds = client.v3builds("someToken", "org/repo","bah", 2, null)
 
         then:
         builds.builds.size() == 2
     }
+
+  def "Fetch a single V3 build"() {
+    given:
+    setResponse '''
+      {
+          "@type": "build",
+          "@href": "/api/build/7128433",
+          "@representation": "standard",
+          "@permissions": {
+              "read": true,
+              "cancel": true,
+              "restart": true
+          },
+          "id": 7128433,
+          "number": "265",
+          "state": "passed",
+          "duration": 19,
+          "event_type": "api",
+          "previous_state": "passed",
+          "pull_request_title": null,
+          "pull_request_number": null,
+          "started_at": "2019-05-31T10:27:47Z",
+          "finished_at": "2019-05-31T10:28:06Z",
+          "repository": {
+              "@type": "repository",
+              "@href": "/api/repo/8881",
+              "@representation": "minimal",
+              "id": 8881,
+              "name": "jervi-is-testing",
+              "slug": "arrested-developers/jervi-is-testing"
+          },
+          "branch": {
+              "@type": "branch",
+              "@href": "/api/repo/8881/branch/master",
+              "@representation": "minimal",
+              "name": "master"
+          },
+          "tag": null,
+          "commit": {
+              "@type": "commit",
+              "@representation": "standard",
+              "id": 4113219,
+              "sha": "fc726afaaf5d3892dae017e2dbe6fa8534f4423a",
+              "ref": null,
+              "message": "Triggered from Spinnaker: Hello world! 🐥 awesomeapp:Testing trigger",
+              "compare_url": "https://github.acme.io/arrested-developers/jervi-is-testing/compare/5e8a99bbc0e189dfbe1cec4b8da2a48aaa2f672e...fc726afaaf5d3892dae017e2dbe6fa8534f4423a",
+              "committed_at": "2019-05-31T10:26:30Z",
+              "committer": {
+                  "name": "Alice",
+                  "avatar_url": "https://0.gravatar.com/avatar/xxxxxxxxxxxxxxxxxx"
+              },
+              "author": {
+                  "name": "Bob",
+                  "avatar_url": "https://0.gravatar.com/avatar/xxxxxxxxxxxxxxxxxx"
+              }
+          },
+          "jobs": [
+              {
+                  "@type": "job",
+                  "@href": "/api/job/7128434",
+                  "@representation": "minimal",
+                  "id": 7128434
+              }
+          ],
+          "stages": [],
+          "created_by": {
+              "@type": "user",
+              "@href": "/api/user/574",
+              "@representation": "minimal",
+              "id": 574,
+              "login": "spinnaker"
+          },
+          "updated_at": "2019-05-31T10:28:06.312Z",
+          "log_complete": true
+      }
+          '''
+
+    when:
+    V3Build build = client.v3build("someToken", 7128433, "build.log_complete")
+
+    then:
+    build.number == 265
+    build.commit.committer.name == "Alice"
+    build.commit.author.name == "Bob"
+    build.jobs*.id == [7128434]
+    build.getLogComplete()
+  }
 
     def "commits, dont mark regular branches as tags"() {
         given:
@@ -678,7 +719,7 @@ class TravisClientSpec extends Specification {
         Builds builds = client.builds("someToken", "org/repo", 38)
 
         then:
-        builds.commits.first().isTag() == false
+        !builds.commits.first().isTag()
 
     }
 

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/MainTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/MainTest.java
@@ -16,16 +16,28 @@
 
 package com.netflix.spinnaker.igor;
 
+import com.netflix.hystrix.Hystrix;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {Main.class})
-@ContextConfiguration(classes = {RedisConfig.class})
+@SpringBootTest(classes = {RedisConfig.class, Main.class})
 public class MainTest {
+
+  @BeforeClass
+  public static void setUp() {
+    Hystrix.reset();
+  }
+
   @Test
   public void startupTest() {}
+
+  @AfterClass
+  public static void tearDown() {
+    Hystrix.reset();
+  }
 }


### PR DESCRIPTION
Travis added a new property in version 2.2.9 (also available on travis-ci.org) that tells us if the log is complete or not. This allows us to be more efficient in the way we fetch artifacts and properties from Travis. It is not backwards compatible, so we have to keep the old way of doing it around for a while.

Each Travis master will be queried at Igor startup for some simple feature detection to determine wether to use the legacy method or the new method.

A few interfaces has been changed to use GenericBuild instead of `buildNumber`. This allows for some reduction in complexity for a few of the providers that don't use `buildNumber` internally, as we don't have to query the master for `buildId` multiple times.

Also contains some spring cleaning of the TravisClient and the TravisService, it contained a lot of unused methods.

*Note:* Even with this new `log_complete` property, we need to try to download the log for new builds, otherwise the triggers will be triggered very late. The reason is that the `log_complete` will be false for a while even when the log is actually complete, it just isn't concatenated in the API yet. We instead do the concatenation manually after checking that we have all the parts and that the last part is the final one. If Travis fixes this in the future, we can remove this code path.