### PR TITLE
fix(travis): List tag builds from travis

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
@@ -263,7 +263,7 @@ public class TravisService implements BuildOperations, BuildProperties {
             includeLogFetching());
     return builds.getBuilds().stream()
         .filter(build -> build.getCommit().isTag())
-        .filter(V3Build::getLogComplete)
+        .filter(this::isLogReady)
         .map(this::getGenericBuild)
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
This makes it possible to manually trigger pipelines on tag builds
again.
