### PR TITLE
chore(cleanup): minor dependency cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,6 @@ buildscript {
         classpath "com.netflix.spinnaker.gradle:spinnaker-dev-plugin:$spinnakerGradleVersion"
         if (Boolean.valueOf(enablePublishing)) {
           classpath "com.netflix.spinnaker.gradle:spinnaker-gradle-project:$spinnakerGradleVersion"
-// TODO: nebula-publishing-plugin version override should be removed as soon as spinnaker-gradle-project is updated
-// this override is needed to omit compileOnly dependencies from generated pom.xml
-          classpath "com.netflix.nebula:nebula-publishing-plugin:12.0.1"
         }
     }
 }
@@ -36,6 +33,12 @@ allprojects {
   apply plugin: 'spinnaker.base-project'
   if (Boolean.valueOf(enablePublishing)) {
     apply plugin: 'spinnaker.project'
+  }
+
+  if ([korkVersion, fiatVersion].find { it.endsWith('-SNAPSHOT') }) {
+    repositories {
+      mavenLocal()
+    }
   }
 
   if (name != "igor-bom") {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/Commit.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/model/Commit.groovy
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.igor.scm.bitbucket.client.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
+
+import java.time.ZonedDateTime
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class Commit {
@@ -37,6 +37,6 @@ class Commit {
 
   @JsonProperty(value = "date")
   public void setDate(String utctimestamp) {
-    date = DateTime.parse(utctimestamp, ISODateTimeFormat.dateTimeNoMillis()).toDate();
+    date = ZonedDateTime.parse(utctimestamp).toDate()
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/health/PollingMonitorHealth.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/health/PollingMonitorHealth.java
@@ -21,11 +21,11 @@ import static java.util.stream.Collectors.toList;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.patterns.PolledMeter;
 import com.netflix.spinnaker.igor.polling.PollingMonitor;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
-import org.joda.time.DateTimeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -99,13 +99,13 @@ public class PollingMonitorHealth implements HealthIndicator {
     return i ->
         i.getLastPoll() != null
             && (System.currentTimeMillis() - i.getLastPoll())
-                > 5 * i.getPollInterval() * DateTimeConstants.MILLIS_PER_SECOND;
+                > 5 * Duration.ofSeconds(i.getPollInterval()).toMillis();
   }
 
   private Health getPollingMonitorHealth(PollingMonitor pollingMonitor) {
     final long elapsed = System.currentTimeMillis() - pollingMonitor.getLastPoll();
     // has it been 5 x pollInterval since last poll?
-    if (elapsed > 5 * pollingMonitor.getPollInterval() * DateTimeConstants.MILLIS_PER_SECOND) {
+    if (elapsed > 5 * Duration.ofSeconds(pollingMonitor.getPollInterval()).toMillis()) {
       log.warn("{} {}msec since last poll, this poller is DOWN", pollingMonitor.getName(), elapsed);
       return Health.down()
           .withDetail(String.format("%s.status", pollingMonitor.getName()), "stopped")


### PR DESCRIPTION
testing some upcoming refactorings in kork, found a usage of joda-time that
came as a transitive dependency from somewhere, replaced usage with java.time