### PR TITLE
config(jenkins): add a separate property to enable the poller

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -249,7 +249,7 @@ class BuildController {
     private BuildOperations getBuildService(String master) {
         def buildService = buildServices.getService(master)
         if (buildService == null) {
-            throw new NotFoundException("Master '${master}' not found}")
+            throw new NotFoundException("Master '${master}' not found")
         }
         return buildService
     }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -49,7 +49,7 @@ import static net.logstash.logback.argument.StructuredArguments.kv
  */
 @Service
 @SuppressWarnings('CatchException')
-@ConditionalOnProperty('jenkins.enabled')
+@ConditionalOnProperty('jenkins.enabled && ${jenkins.poller.enabled:true}')
 class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta> {
 
     private final JenkinsCache cache
@@ -159,7 +159,7 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
             log.error("Error processing builds for [{}:{}]", kv("master", master), kv("job", job.name), e)
             if (e.cause instanceof RetrofitError) {
                 def re = (RetrofitError) e.cause
-                log.error("Error communicating with jenkins for [{}:{}]: {}", kv("master", master), kv("job", job.name), kv("url", re.url), re);
+                log.error("Error communicating with jenkins for [{}:{}]: {}", kv("master", master), kv("job", job.name), kv("url", re.url), re)
             }
         }
     }


### PR DESCRIPTION
Before this change, setting jenkins.enabled to false disabled both the
poller and the Jenkins APIs (look up jobs, build info, start jobs...)
