### PR TITLE
feat(core): Use Spring Cloud Config for external configuration of acc…

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -57,6 +57,7 @@ dependencies {
 
     implementation "com.google.apis:google-api-services-cloudbuild"
     implementation "com.google.apis:google-api-services-storage"
+    implementation "com.netflix.spinnaker.kork:kork-config"
     implementation "com.netflix.spinnaker.kork:kork-core"
     implementation "com.netflix.spinnaker.kork:kork-artifacts"
     implementation "com.netflix.spinnaker.kork:kork-stackdriver"

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/Main.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/Main.groovy
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.igor
 
 import com.netflix.config.ConfigurationManager
+import com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder
+import com.netflix.spinnaker.kork.configserver.ConfigServerBootstrap
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
@@ -34,35 +36,28 @@ import java.security.Security
 @Configuration
 @EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration])
 @EnableConfigurationProperties(IgorConfigurationProperties)
-@ComponentScan([ 'com.netflix.spinnaker.config', 'com.netflix.spinnaker.igor'])
+@ComponentScan(['com.netflix.spinnaker.config', 'com.netflix.spinnaker.igor'])
 class Main extends SpringBootServletInitializer {
 
-    static final Map<String, String> DEFAULT_PROPS = [
-      'netflix.environment'              : 'test',
-      'netflix.account'                  : '${netflix.environment}',
-      'netflix.stack'                    : 'test',
-      'spring.config.additional-location': '${user.home}/.spinnaker/',
-      'spring.application.name'          : 'igor',
-      'spring.config.name'               : 'spinnaker,${spring.application.name}',
-      'spring.profiles.active'           : '${netflix.environment},local'
-    ]
+  static final Map<String, Object> DEFAULT_PROPS = new DefaultPropertiesBuilder().build()
 
-    static {
-        /**
-         * We often operate in an environment where we expect resolution of DNS names for remote dependencies to change
-         * frequently, so it's best to tell the JVM to avoid caching DNS results internally.
-         */
-        InetAddressCachePolicy.cachePolicy = InetAddressCachePolicy.NEVER
-        Security.setProperty('networkaddress.cache.ttl', '0')
-        ConfigurationManager.loadCascadedPropertiesFromResources("hystrix")
-    }
+  static {
+    /**
+     * We often operate in an environment where we expect resolution of DNS names for remote dependencies to change
+     * frequently, so it's best to tell the JVM to avoid caching DNS results internally.
+     */
+    InetAddressCachePolicy.cachePolicy = InetAddressCachePolicy.NEVER
+    Security.setProperty('networkaddress.cache.ttl', '0')
+    ConfigurationManager.loadCascadedPropertiesFromResources("hystrix")
+  }
 
-    static void main(String... args) {
-        new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Main).run(args)
-    }
+  static void main(String... args) {
+    ConfigServerBootstrap.systemProperties("igor")
+    new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Main).run(args)
+  }
 
-    @Override
-    SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-        application.properties(DEFAULT_PROPS).sources(Main)
-    }
+  @Override
+  SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+    application.properties(DEFAULT_PROPS).sources(Main)
+  }
 }


### PR DESCRIPTION
Adds support for loading account info (e.g. for CI and SCM accounts) from an external Spring Cloud Config source. See https://docs.google.com/document/d/16EWk-ChZkae87hCSCFdl3ElepTLC-ac-4uv1tCyfZcc/edit#heading=h.dxx7kr140erk