### PR TITLE
fix(boot2): Allow url-encoded % in URLs

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/IgorConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/IgorConfig.groovy
@@ -83,6 +83,7 @@ class IgorConfig extends WebMvcConfigurerAdapter {
     StrictHttpFirewall httpFirewall() {
       def firewall = new StrictHttpFirewall()
       firewall.allowUrlEncodedSlash = true
+      firewall.allowUrlEncodedPercent = true
       return firewall
     }
 


### PR DESCRIPTION
Follow-up to  #454

Before:
```
$ curl localhost:8088/jobs/master/%25
{"timestamp":"2019-08-31T01:45:37.293+0000","status":500,"error":"Internal Server Error","message":"The request was rejected because the URL contained a potentially malicious String \"%25\""}%
```

After:
```
$ curl localhost:8088/jobs/master/%25
{"timestamp":"2019-08-31T01:46:30.379+0000","status":404,"error":"Not Found","message":"Master 'master' does not exist"}%
```

As previously noted, we don't seem to have any existing tests that make actual requests that route through `StrictFirewall`.