### PR TITLE
feat(nexus): add Nexus webhook for artifact triggering

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/NexusConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/NexusConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty("nexus.enabled")
+@EnableConfigurationProperties(NexusProperties.class)
+public class NexusConfig {}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/NexusProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/NexusProperties.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.config;
+
+import com.netflix.spinnaker.igor.nexus.model.NexusRepo;
+import java.util.List;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "nexus")
+public class NexusProperties {
+  private List<NexusRepo> repos;
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.nexus;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.igor.config.NexusProperties;
+import com.netflix.spinnaker.igor.history.EchoService;
+import com.netflix.spinnaker.igor.nexus.model.NexusAssetWebhookPayload;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@ConditionalOnProperty("nexus.enabled")
+@RequestMapping("/nexus")
+@Slf4j
+public class NexusController {
+
+  private final NexusProperties nexusProperties;
+  private final Optional<EchoService> echoService;
+  private final Registry registry;
+  private final Id missedNotificationId;
+
+  public NexusController(
+      NexusProperties nexusProperties, Optional<EchoService> echoService, Registry registry) {
+    this.nexusProperties = nexusProperties;
+    this.echoService = echoService;
+    this.registry = registry;
+
+    missedNotificationId = registry.createId("webhook.missedEchoNotification");
+  }
+
+  @PostMapping(path = "/webhook", consumes = "application/json")
+  public void webhook(@RequestBody NexusAssetWebhookPayload payload) {
+    if (!echoService.isPresent()) {
+      log.warn("Cannot send build notification: Echo is not configured");
+      registry
+          .counter(missedNotificationId.withTag("webhook", NexusController.class.getSimpleName()))
+          .increment();
+    } else {
+      if (payload != null) {
+        new NexusEventPoster(nexusProperties, echoService.get()).postEvent(payload);
+      }
+    }
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusEventPoster.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusEventPoster.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.nexus;
+
+import com.netflix.spinnaker.igor.config.NexusProperties;
+import com.netflix.spinnaker.igor.history.EchoService;
+import com.netflix.spinnaker.igor.nexus.model.NexusAssetEvent;
+import com.netflix.spinnaker.igor.nexus.model.NexusAssetWebhookPayload;
+import com.netflix.spinnaker.igor.nexus.model.NexusRepo;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.apache.logging.log4j.util.Strings;
+
+public class NexusEventPoster {
+
+  private final NexusProperties nexusProperties;
+  private final EchoService echoService;
+
+  public NexusEventPoster(NexusProperties nexusProperties, EchoService echoService) {
+    this.nexusProperties = nexusProperties;
+    this.echoService = echoService;
+  }
+
+  public void postEvent(NexusAssetWebhookPayload payload) {
+    if ((payload.getAction().equals("CREATED") || payload.getAction().equals("UPDATED"))
+        && payload.getAsset().getFormat().equals("maven2")
+        && payload.getAsset().getName().endsWith(".pom")) {
+
+      final String[] nameTokens = payload.getAsset().getName().split("/");
+      final List<String> nameList = Arrays.asList(nameTokens);
+      final String version = nameList.get(nameList.size() - 2);
+      final String artifactId = nameList.get(nameList.size() - 3);
+      final String group = Strings.join(nameList.subList(0, nameList.size() - 3), '.');
+      final Artifact artifact =
+          Artifact.builder()
+              .type("maven/file")
+              .reference(group + ":" + artifactId + ":" + version)
+              .name(group + ":" + artifactId)
+              .version(version)
+              .provenance(payload.getRepositoryName())
+              .build();
+      final Optional<NexusRepo> oRepo = findNexusRepo(payload);
+      oRepo.ifPresent(
+          repo -> {
+            AuthenticatedRequest.allowAnonymous(
+                () ->
+                    echoService.postEvent(
+                        new NexusAssetEvent(
+                            new NexusAssetEvent.Content(repo.getName(), artifact))));
+          });
+    }
+  }
+
+  private Optional<NexusRepo> findNexusRepo(NexusAssetWebhookPayload payload) {
+    if (payload.getNodeId() != null) {
+      return nexusProperties.getRepos().stream()
+          .filter(
+              repo -> {
+                return payload.getNodeId().equals(repo.getNodeId());
+              })
+          .findFirst();
+    } else {
+      return nexusProperties.getRepos().stream()
+          .filter(
+              repo -> {
+                return payload.getRepositoryName().equals(repo.getRepo());
+              })
+          .findFirst();
+    }
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/model/NexusAssetEvent.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/model/NexusAssetEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.nexus.model;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.igor.history.model.Event;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Data
+public class NexusAssetEvent extends Event {
+  private final Content content;
+  private final Map<String, String> details =
+      ImmutableMap.<String, String>builder().put("type", "nexus").put("source", "igor").build();
+
+  @Data
+  @AllArgsConstructor
+  public static class Content {
+    String name;
+    Artifact artifact;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/model/NexusAssetWebhookPayload.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/model/NexusAssetWebhookPayload.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.nexus.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+public class NexusAssetWebhookPayload {
+  private String timestamp;
+  private String nodeId;
+  private String initiator;
+  private String repositoryName;
+  private String action;
+  private NexusAsset asset;
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class NexusAsset {
+    private String id;
+    private String assetId;
+    private String format;
+    private String name;
+  }
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/model/NexusRepo.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/model/NexusRepo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.nexus.model;
+
+import javax.annotation.Nullable;
+import lombok.Data;
+
+@Data
+public class NexusRepo {
+  private String name;
+  private NexusRepositoryType repoType = NexusRepositoryType.Maven;
+  private String baseUrl;
+  private String repo;
+  private String nodeId;
+
+  @Nullable private String username;
+
+  @Nullable private String password;
+}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/model/NexusRepositoryType.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/model/NexusRepositoryType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.nexus.model;
+
+public enum NexusRepositoryType {
+  Maven,
+}

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.nexus;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import com.netflix.spinnaker.igor.config.NexusProperties;
+import com.netflix.spinnaker.igor.history.EchoService;
+import com.netflix.spinnaker.igor.nexus.model.NexusAssetEvent;
+import com.netflix.spinnaker.igor.nexus.model.NexusAssetWebhookPayload;
+import com.netflix.spinnaker.igor.nexus.model.NexusRepo;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class NexusEventPosterTest {
+
+  private EchoService echoService = mock(EchoService.class);
+  private NexusProperties nexusProperties = new NexusProperties();
+
+  {
+    final NexusRepo nexusRepo = new NexusRepo();
+    nexusRepo.setName("nexus-snapshots");
+    nexusRepo.setRepo("maven-snapshots");
+    nexusRepo.setNodeId("123");
+    nexusProperties.setRepos(Collections.singletonList(nexusRepo));
+  }
+
+  private NexusEventPoster nexusEventPoster = new NexusEventPoster(nexusProperties, echoService);
+  final NexusAssetWebhookPayload payload = new NexusAssetWebhookPayload();
+
+  {
+    payload.setAction("CREATED");
+    payload.setAsset(new NexusAssetWebhookPayload.NexusAsset());
+    payload.getAsset().setFormat("maven2");
+  }
+
+  @Test
+  void postArtifact() {
+    payload.setRepositoryName("maven-snapshots");
+    payload.getAsset().setName("com/example/demo/0.0.1-SNAPSHOT/demo-0.0.1-20190828.022502-3.pom");
+
+    nexusEventPoster.postEvent(payload);
+
+    final Artifact expectedArtifact =
+        Artifact.builder()
+            .type("maven/file")
+            .reference("com.example" + ":" + "demo" + ":" + "0.0.1-SNAPSHOT")
+            .name("com.example" + ":" + "demo")
+            .version("0.0.1-SNAPSHOT")
+            .provenance("maven-snapshots")
+            .build();
+    verify(echoService)
+        .postEvent(
+            new NexusAssetEvent(new NexusAssetEvent.Content("nexus-snapshots", expectedArtifact)));
+  }
+
+  @Test
+  void postUpdatedArtifact() {
+    payload.setAction("UPDATED");
+    payload.setRepositoryName("maven-snapshots");
+    payload.getAsset().setName("com/example/demo/0.0.1-SNAPSHOT/demo-0.0.1-20190828.022502-3.pom");
+
+    nexusEventPoster.postEvent(payload);
+
+    final Artifact expectedArtifact =
+        Artifact.builder()
+            .type("maven/file")
+            .reference("com.example" + ":" + "demo" + ":" + "0.0.1-SNAPSHOT")
+            .name("com.example" + ":" + "demo")
+            .version("0.0.1-SNAPSHOT")
+            .provenance("maven-snapshots")
+            .build();
+    verify(echoService)
+        .postEvent(
+            new NexusAssetEvent(new NexusAssetEvent.Content("nexus-snapshots", expectedArtifact)));
+  }
+
+  @Test
+  void postDeletedArtifactShouldNotSendEvent() {
+    payload.setAction("DELETED");
+    payload.setRepositoryName("maven-snapshots");
+    payload.getAsset().setName("com/example/demo/0.0.1-SNAPSHOT/demo-0.0.1-20190828.022502-3.pom");
+
+    nexusEventPoster.postEvent(payload);
+
+    verifyZeroInteractions(echoService);
+  }
+
+  @Test
+  void postNonPomArtifactShouldNotSendEvent() {
+    payload.setRepositoryName("maven-snapshots");
+    payload.getAsset().setName("com/example/demo/0.0.1-SNAPSHOT/demo-0.0.1-20190828.022502-3.jar");
+
+    nexusEventPoster.postEvent(payload);
+
+    verifyZeroInteractions(echoService);
+  }
+
+  @Test
+  void postNonMatchingRepoArtifactShouldNotSendEvent() {
+    payload.setRepositoryName("DNE");
+    payload.getAsset().setName("com/example/demo/0.0.1-SNAPSHOT/demo-0.0.1-20190828.022502-3.pom");
+
+    nexusEventPoster.postEvent(payload);
+
+    verifyZeroInteractions(echoService);
+  }
+
+  @Test
+  void postNonMatchingRepoArtifactWithRepoId() {
+    payload.setRepositoryName("DNE");
+    payload.setNodeId("123");
+    payload.getAsset().setName("com/example/demo/0.0.1-SNAPSHOT/demo-0.0.1-20190828.022502-3.pom");
+
+    nexusEventPoster.postEvent(payload);
+
+    final Artifact expectedArtifact =
+        Artifact.builder()
+            .type("maven/file")
+            .reference("com.example" + ":" + "demo" + ":" + "0.0.1-SNAPSHOT")
+            .name("com.example" + ":" + "demo")
+            .version("0.0.1-SNAPSHOT")
+            .provenance("DNE")
+            .build();
+    verify(echoService)
+        .postEvent(
+            new NexusAssetEvent(new NexusAssetEvent.Content("nexus-snapshots", expectedArtifact)));
+  }
+}


### PR DESCRIPTION
Nexus does not provide the same querying functionality that Artifactory does. We can't use the same timestamp trick in AQL for polling the latest artifacts, but we can configure a webhook in Nexus to notify of new assets. This commit adds that webhook endpoint in Igor so that Nexus can notify Igor of new assets which will send the new artifact to echo.