### PR TITLE
fix(jenkins): don't npe on dynamic choice parameters

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -222,7 +222,10 @@ class BuildController {
     static void validateJobParameters(JobConfig jobConfig, Map<String, String> requestParams) {
         jobConfig.parameterDefinitionList.each { parameterDefinition ->
             String matchingParam = requestParams[parameterDefinition.name]
-            if (matchingParam != null && parameterDefinition.type == 'ChoiceParameterDefinition' && !parameterDefinition.choices.contains(matchingParam)) {
+            if (matchingParam != null &&
+                parameterDefinition.type == 'ChoiceParameterDefinition' &&
+                parameterDefinition.choices != null &&
+                !parameterDefinition.choices.contains(matchingParam)) {
                 throw new InvalidJobParameterException("`${matchingParam}` is not a valid choice " +
                     "for `${parameterDefinition.name}`. Valid choices are: ${parameterDefinition.choices.join(', ')}")
             }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -42,6 +42,7 @@ import retrofit.client.Response
 import spock.lang.Shared
 import spock.lang.Specification
 
+import static com.netflix.spinnaker.igor.build.BuildController.*
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -310,4 +311,39 @@ class BuildControllerSpec extends Specification {
         response.status == HttpStatus.BAD_REQUEST.value()
         response.errorMessage == "Job '${JOB_NAME}' is not buildable. It may be disabled."
     }
+
+  void 'validation successful for null list of choices'() {
+    given:
+    Map<String, String> requestParams = ["hey" : "you"]
+    ParameterDefinition parameterDefinition = new ParameterDefinition()
+    parameterDefinition.choices = null
+    parameterDefinition.type = "ChoiceParameterDefinition"
+    parameterDefinition.name = "hey"
+    JobConfig jobConfig = new JobConfig()
+    jobConfig.parameterDefinitionList = [parameterDefinition]
+
+    when:
+    validateJobParameters(jobConfig, requestParams)
+
+    then:
+    noExceptionThrown()
+  }
+
+  void 'validation failed for option not in list of choices'() {
+    given:
+    Map<String, String> requestParams = ["hey" : "you"]
+    ParameterDefinition parameterDefinition = new ParameterDefinition()
+    parameterDefinition.choices = ["why", "not"]
+    parameterDefinition.type = "ChoiceParameterDefinition"
+    parameterDefinition.name = "hey"
+    JobConfig jobConfig = new JobConfig()
+    jobConfig.parameterDefinitionList = [parameterDefinition]
+
+    when:
+    validateJobParameters(jobConfig, requestParams)
+
+    then:
+    thrown(InvalidJobParameterException)
+  }
+
 }


### PR DESCRIPTION
In Jenkins, you can have a "dynamic choice parameter". This means that you can write a script to generate all the dropdown choices for a parameter. It seems like this script is only run when you hit "build with parameters". When you query for the job config (`https://jenkins-controller/job/job-name//api/xml?exclude=/*/action&exclude=/*/build&exclude=/*/property[not(parameterDefinition)]`) you actually get no choices. Better yet, instead of an empty list, `choices` is null!

This PR makes adds a null check to `parameterDefinition.choices` so that if it's `null` we just don't validate. Right now we throw an `NPE`.