### PR TITLE
fix(travis): Correctly parse global_env from Travis v3 API

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/Config.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/Config.java
@@ -17,23 +17,30 @@
 
 package com.netflix.spinnaker.igor.travis.client.model.v3;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.netflix.spinnaker.igor.build.model.GenericParameterDefinition;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.simpleframework.xml.Default;
 
 @Default
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Slf4j
 public class Config {
-  @JsonProperty("global_env")
   private List<Object> globalEnv;
 
   @JsonProperty("merge_mode")
@@ -75,12 +82,36 @@ public class Config {
         .collect(Collectors.toList());
   }
 
+  @JsonGetter("global_env")
   public List<Object> getGlobalEnv() {
     return globalEnv;
   }
 
-  public void setGlobalEnv(List<Object> globalEnv) {
-    this.globalEnv = globalEnv;
+  @JsonSetter("global_env")
+  @SuppressWarnings("unchecked")
+  public void setGlobalEnv(Object globalEnv) {
+    if (globalEnv == null) {
+      this.globalEnv = null;
+    } else if (globalEnv instanceof String) {
+      // Matches KEY=VALUE pairs. See ConfigSpec for matching examples
+      Pattern pattern = Pattern.compile("(\\S*?)=(?>(?>[\"'])(.*?)(?>[\"'])|(\\S*))");
+      Matcher matcher = pattern.matcher((String) globalEnv);
+      List<String> env = new ArrayList<>();
+      while (matcher.find()) {
+        String key = matcher.group(1);
+        String value = matcher.group(2);
+        if (StringUtils.isBlank(value)) {
+          value = matcher.group(3);
+        }
+        value = StringUtils.trimToEmpty(value);
+        env.add(key + "=" + value);
+      }
+      this.globalEnv = new ArrayList<>(env);
+    } else if (globalEnv instanceof List) {
+      this.globalEnv = (List) globalEnv;
+    } else {
+      log.warn("Unknown type for 'global_env', ignoring: {}", globalEnv);
+    }
   }
 
   public String getMergeMode() {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/Config.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/Config.java
@@ -90,10 +90,8 @@ public class Config {
   @JsonSetter("global_env")
   @SuppressWarnings("unchecked")
   public void setGlobalEnv(Object globalEnv) {
-    if (globalEnv == null) {
-      this.globalEnv = null;
-    } else if (globalEnv instanceof String) {
-      // Matches KEY=VALUE pairs. See ConfigSpec for matching examples
+    if (globalEnv instanceof String) {
+      // Matches space separated KEY=VALUE pairs. See ConfigSpec for matching examples
       Pattern pattern = Pattern.compile("(\\S*?)=(?>(?>[\"'])(.*?)(?>[\"'])|(\\S*))");
       Matcher matcher = pattern.matcher((String) globalEnv);
       List<String> env = new ArrayList<>();

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/ConfigSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/ConfigSpec.groovy
@@ -113,7 +113,7 @@ class ConfigSpec extends Specification {
                                                                                           "A_USER=user@schibsted.com",
                                                                                           "A_PWD=[secure]",
                                                                                           "KEY_ID=SOMEKEYID",
-                                                                                          "SOME_SECRET=[secure]" ,
+                                                                                          "SOME_SECRET=[secure]",
                                                                                           "ROLE=arn:aws:iam::0123456789:role/MyRole",
                                                                                           "KEY=whatabout=this\\\\",
                                                                                           "KEY2=and=this\\\\"]

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/ConfigSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/client/model/v3/ConfigSpec.groovy
@@ -78,4 +78,44 @@ class ConfigSpec extends Specification {
         null                   || null
     }
 
+    @Unroll
+    def "should handle different env_var types"() {
+        given:
+        Config config = new Config()
+
+        when:
+        config.setGlobalEnv(globalEnv)
+
+        then:
+        config.globalEnv == expectedGlobalEnv
+
+        where:
+        globalEnv                                                                     || expectedGlobalEnv
+        ["KEY_1=value 1", "KEY_2=value 2"]                                            || ["KEY_1=value 1", "KEY_2=value 2"]
+        "TF_INPUT=false " +
+            "SOME_KEY=\"with spaces\" " +
+            "ANOTHER_KEY=withoutspaces " +
+            "lowercase-key=\"string with=equals sign\" " +
+            "REGION=eu-west-1 " +
+            "STACK_NAME=testing " +
+            "A_USER=user@schibsted.com " +
+            "A_PWD=[secure] " +
+            "KEY_ID=\"SOMEKEYID\" " +
+            "SOME_SECRET=[secure] " +
+            "ROLE='arn:aws:iam::0123456789:role/MyRole' " +
+            "KEY=whatabout=this\\\\ " +
+            "KEY2=\"and=this\\\\\""                                                   || ["TF_INPUT=false",
+                                                                                          "SOME_KEY=with spaces",
+                                                                                          "ANOTHER_KEY=withoutspaces",
+                                                                                          "lowercase-key=string with=equals sign",
+                                                                                          "REGION=eu-west-1",
+                                                                                          "STACK_NAME=testing",
+                                                                                          "A_USER=user@schibsted.com",
+                                                                                          "A_PWD=[secure]",
+                                                                                          "KEY_ID=SOMEKEYID",
+                                                                                          "SOME_SECRET=[secure]" ,
+                                                                                          "ROLE=arn:aws:iam::0123456789:role/MyRole",
+                                                                                          "KEY=whatabout=this\\\\",
+                                                                                          "KEY2=and=this\\\\"]
+    }
 }


### PR DESCRIPTION
When the `config` section is returned as part of a *build* (which is unsupported in the Travis v3 API), `global_env` is a list of Strings. When it is returned as part of a *job*, `global_env` is instead a space separated String. And since env variable values can also contain spaces and equal signs, I had to create a little regex parser thingy.
This also fixes an issue in Deck where you can't add parameters to a Travis stage if `.travis.yml` contains anything in the `env.global` section.