### PR TITLE
fix(nexus): change Nexus config

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/NexusProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/NexusProperties.java
@@ -24,5 +24,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties(prefix = "nexus")
 public class NexusProperties {
-  private List<NexusRepo> repos;
+  private List<NexusRepo> searches;
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusController.java
@@ -55,7 +55,9 @@ public class NexusController {
 
   @GetMapping("/names")
   List<String> getNexusNames() {
-    return nexusProperties.getRepos().stream().map(NexusRepo::getName).collect(Collectors.toList());
+    return nexusProperties.getSearches().stream()
+        .map(NexusRepo::getName)
+        .collect(Collectors.toList());
   }
 
   @PostMapping(path = "/webhook", consumes = "application/json")

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusEventPoster.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusEventPoster.java
@@ -97,14 +97,14 @@ public class NexusEventPoster {
 
   private Optional<NexusRepo> findNexusRepo(NexusAssetWebhookPayload payload) {
     if (payload.getNodeId() != null) {
-      return nexusProperties.getRepos().stream()
+      return nexusProperties.getSearches().stream()
           .filter(
               repo -> {
                 return payload.getNodeId().equals(repo.getNodeId());
               })
           .findFirst();
     } else {
-      return nexusProperties.getRepos().stream()
+      return nexusProperties.getSearches().stream()
           .filter(
               repo -> {
                 return payload.getRepositoryName().equals(repo.getRepo());

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java
@@ -40,7 +40,7 @@ class NexusEventPosterTest {
     nexusRepo.setRepo("maven-snapshots");
     nexusRepo.setBaseUrl("http://localhost:8082/repository/");
     nexusRepo.setNodeId("123");
-    nexusProperties.setRepos(Collections.singletonList(nexusRepo));
+    nexusProperties.setSearches(Collections.singletonList(nexusRepo));
   }
 
   private NexusEventPoster nexusEventPoster = new NexusEventPoster(nexusProperties, echoService);


### PR DESCRIPTION
Originally I used “repos” to list Nexus repos. Artifactory uses “searches”. I used “repo” instead at first because Nexus actually pushes rather than the polling search that Artifactory does.  But it seems like it is best to stay consistent with Artifactory config naming, and the underlying implementation doesn’t really matter. Though they will function a bit differently. Also, there is a lot of Hal code that could be shared if the naming was consistent. This change makes the naming consistent.
