### PR TITLE
chore(travis): Remove old build cache migrator

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -70,10 +70,6 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
     }
 
     @Override
-    void initialize() {
-    }
-
-    @Override
     void poll(boolean sendEvents) {
         if (keysMigration.isPresent() && keysMigration.get().running) {
             log.warn("Skipping poll cycle: Keys migration is in progress")

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
@@ -80,9 +80,6 @@ public class GitlabCiBuildMonitor
   }
 
   @Override
-  protected void initialize() {}
-
-  @Override
   public void poll(boolean sendEvents) {
     buildServices.getServiceNames(BuildServiceProvider.GITLAB_CI).stream()
         .map(it -> new PollContext(it, !sendEvents))

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -87,10 +87,6 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
     }
 
     @Override
-    void initialize() {
-    }
-
-    @Override
     void poll(boolean sendEvents) {
         buildServices.getServiceNames(BuildServiceProvider.JENKINS).stream().forEach(
             { master -> pollSingle(new PollContext(master, !sendEvents)) }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
@@ -120,7 +120,7 @@ public abstract class CommonPollingMonitor<I extends DeltaItem, T extends Pollin
     }
   }
 
-  protected abstract void initialize();
+  protected void initialize() {}
 
   /**
    * Returns a delta of stored state versus newly polled data. A polling monitor must not perform

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
@@ -89,10 +89,6 @@ class WerckerBuildMonitor extends CommonPollingMonitor<PipelineDelta, PipelinePo
     }
 
     @Override
-    void initialize() {
-    }
-
-    @Override
     void poll(boolean sendEvents) {
         long startTime = System.currentTimeMillis()
         log.info "WerckerBuildMonitor Polling cycle started: ${new Date()}, echoService:${echoService.isPresent()} "

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
@@ -76,9 +76,6 @@ public class ArtifactoryBuildMonitor
   }
 
   @Override
-  protected void initialize() {}
-
-  @Override
   public void poll(boolean sendEvents) {
     for (ArtifactorySearch search : artifactoryProperties.getSearches()) {
       pollSingle(new PollContext(search.getPartitionName(), !sendEvents));

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
@@ -71,9 +71,6 @@ public class ConcourseBuildMonitor
   }
 
   @Override
-  protected void initialize() {}
-
-  @Override
   protected JobPollingDelta generateDelta(PollContext ctx) {
     ConcourseProperties.Host host =
         concourseProperties.getMasters().stream()


### PR DESCRIPTION
This migrator has been in place since October 2017, and is no longer needed. Also it was a bit misleading. The `initialize` name suggests it is run on bean creation, but it actually ran every polling cycle, which seems a bit excess for a migrator. Since it was only used by the Travis integration, I just removed the whole thing.