### PR TITLE
feat(gcb): Add permissioning to Google Cloud Build accounts

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/InfoController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/InfoController.groovy
@@ -70,7 +70,7 @@ class InfoController {
     @Autowired(required = false)
     ConcourseProperties concourseProperties
 
-    @Autowired(required =false)
+    @Autowired(required = false)
     GoogleCloudBuildProperties gcbProperties
 
     @RequestMapping(value = '/masters', method = RequestMethod.GET)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/InfoController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/InfoController.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.build
 
 import com.netflix.spinnaker.igor.config.ConcourseProperties
 import com.netflix.spinnaker.igor.config.GitlabCiProperties
+import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties
 import com.netflix.spinnaker.igor.config.JenkinsProperties
 import com.netflix.spinnaker.igor.config.TravisProperties
 import com.netflix.spinnaker.igor.config.WerckerProperties
@@ -69,6 +70,9 @@ class InfoController {
     @Autowired(required = false)
     ConcourseProperties concourseProperties
 
+    @Autowired(required =false)
+    GoogleCloudBuildProperties gcbProperties
+
     @RequestMapping(value = '/masters', method = RequestMethod.GET)
     @PostFilter("hasPermission(filterObject, 'BUILD_SERVICE', 'READ')")
     List<String> listMasters(@RequestParam(value = "type", defaultValue = "") String type) {
@@ -84,7 +88,13 @@ class InfoController {
 
     @RequestMapping(value = '/buildServices', method = RequestMethod.GET)
     List<BuildService> getAllBuildServices() {
-        buildServices.allBuildServices
+      List<BuildService> allBuildServices = new ArrayList<>(buildServices.allBuildServices)
+      // GCB accounts are not part of com.netflix.spinnaker.igor.service.BuildServices class.
+      if (gcbProperties != null) {
+        allBuildServices.addAll(gcbProperties.getGcbBuildServices())
+      }
+
+      return allBuildServices
     }
 
     @RequestMapping(value = '/jobs/{master:.+}', method = RequestMethod.GET)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/BuildServiceProvider.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/model/BuildServiceProvider.groovy
@@ -22,5 +22,6 @@ enum BuildServiceProvider {
   TRAVIS,
   CONCOURSE,
   GITLAB_CI,
-  WERCKER
+  WERCKER,
+  GCB
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
@@ -16,7 +16,11 @@
 
 package com.netflix.spinnaker.igor.config;
 
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.igor.model.BuildServiceProvider;
+import com.netflix.spinnaker.igor.service.BuildService;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -25,11 +29,26 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class GoogleCloudBuildProperties {
   private List<Account> accounts;
 
+  public List<BuildService> getGcbBuildServices() {
+    return this.accounts.stream().map(BuildService::getView).collect(Collectors.toList());
+  }
+
   @Data
-  public static class Account {
+  public static class Account implements BuildService {
     private String name;
     private String project;
     private String subscriptionName;
     private String jsonKey;
+    private Permissions.Builder permissions = new Permissions.Builder();
+
+    @Override
+    public BuildServiceProvider getBuildServiceProvider() {
+      return BuildServiceProvider.GCB;
+    }
+
+    @Override
+    public Permissions getPermissions() {
+      return this.permissions.build();
+    }
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -22,6 +22,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import retrofit.http.Query;
 
@@ -34,6 +36,7 @@ public class GoogleCloudBuildController {
   private final GoogleCloudBuildParser googleCloudBuildParser;
 
   @RequestMapping(value = "/accounts", method = RequestMethod.GET)
+  @PostFilter("hasPermission(filterObject, 'BUILD_SERVICE', 'READ')")
   List<String> getAccounts() {
     return googleCloudBuildAccountRepository.getAccounts();
   }
@@ -42,6 +45,7 @@ public class GoogleCloudBuildController {
       value = "/builds/create/{account}",
       method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'WRITE')")
   Build createBuild(@PathVariable String account, @RequestBody String buildString) {
     Build build = googleCloudBuildParser.parse(buildString, Build.class);
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).createBuild(build);
@@ -62,11 +66,13 @@ public class GoogleCloudBuildController {
   }
 
   @RequestMapping(value = "/builds/{account}/{buildId}", method = RequestMethod.GET)
+  @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'READ')")
   Build getBuild(@PathVariable String account, @PathVariable String buildId) {
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getBuild(buildId);
   }
 
   @RequestMapping(value = "/builds/{account}/{buildId}/artifacts", method = RequestMethod.GET)
+  @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'READ')")
   List<Artifact> getArtifacts(@PathVariable String account, @PathVariable String buildId) {
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getArtifacts(buildId);
   }


### PR DESCRIPTION
Added permissioning to Google Cloud Build accounts.  
It solves https://github.com/spinnaker/spinnaker/issues/4814

Protects the gcb accounts so that only defined roles can READ and WRITE.

- To be able to configure a pipeline with the gcb account, you need READ permissions.
- To be able to submit a CloudBuild job using the account, you need WRITE permissions.
