### PR TITLE
feat(gcb): Allow invoking existing GCB triggers

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -17,7 +17,10 @@
 package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.BuildTrigger;
+import com.google.api.services.cloudbuild.v1.model.ListBuildTriggersResponse;
 import com.google.api.services.cloudbuild.v1.model.Operation;
+import com.google.api.services.cloudbuild.v1.model.RepoSource;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,6 +72,22 @@ public class GoogleCloudBuildAccount {
       this.updateBuild(buildId, build.getStatus(), buildString);
     }
     return googleCloudBuildParser.parse(buildString, Build.class);
+  }
+
+  public List<BuildTrigger> listTriggers() {
+    ListBuildTriggersResponse listBuildTriggersResponse = client.listTriggers();
+    return listBuildTriggersResponse.getTriggers();
+  }
+
+  public Build runTrigger(String triggerId, RepoSource repoSource) {
+    Operation operation = client.runTrigger(triggerId, repoSource);
+    Build triggerResponse =
+        googleCloudBuildParser.convert(operation.getMetadata().get("build"), Build.class);
+    this.updateBuild(
+        triggerResponse.getId(),
+        triggerResponse.getStatus(),
+        googleCloudBuildParser.serialize(triggerResponse));
+    return triggerResponse;
   }
 
   public List<Artifact> getArtifacts(String buildId) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
@@ -18,7 +18,9 @@ package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.services.cloudbuild.v1.CloudBuild;
 import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.ListBuildTriggersResponse;
 import com.google.api.services.cloudbuild.v1.model.Operation;
+import com.google.api.services.cloudbuild.v1.model.RepoSource;
 import com.google.api.services.storage.Storage;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
@@ -56,6 +58,15 @@ public class GoogleCloudBuildClient {
 
   public Build getBuild(String buildId) {
     return executor.execute(() -> cloudBuild.projects().builds().get(projectId, buildId));
+  }
+
+  public ListBuildTriggersResponse listTriggers() {
+    return executor.execute(() -> cloudBuild.projects().triggers().list(projectId));
+  }
+
+  public Operation runTrigger(String triggerId, RepoSource repoSource) {
+    return executor.execute(
+        () -> cloudBuild.projects().triggers().run(projectId, triggerId, repoSource));
   }
 
   public InputStream fetchStorageObject(String bucket, String object, Long version)

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.BuildTrigger;
+import com.google.api.services.cloudbuild.v1.model.RepoSource;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -85,5 +87,26 @@ public class GoogleCloudBuildController {
       @PathVariable String account, @RequestBody String serializedBuild) {
     Build build = googleCloudBuildParser.parse(serializedBuild, Build.class);
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).extractArtifacts(build);
+  }
+
+  @RequestMapping(value = "/triggers/{account}", method = RequestMethod.GET)
+  @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'READ')")
+  List<BuildTrigger> listTriggers(@PathVariable String account) {
+    return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).listTriggers();
+  }
+
+  @RequestMapping(
+      value = "/triggers/run/{account}/{triggerId}",
+      method = RequestMethod.POST,
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'WRITE')")
+  Build runTrigger(
+      @PathVariable String account,
+      @PathVariable String triggerId,
+      @RequestBody String repoSourceString) {
+    RepoSource repoSource = googleCloudBuildParser.parse(repoSourceString, RepoSource.class);
+    return googleCloudBuildAccountRepository
+        .getGoogleCloudBuild(account)
+        .runTrigger(triggerId, repoSource);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -96,7 +96,7 @@ public class GoogleCloudBuildController {
   }
 
   @RequestMapping(
-      value = "/triggers/run/{account}/{triggerId}",
+      value = "/triggers/{account}/{triggerId}/run",
       method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'WRITE')")

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
@@ -213,7 +213,7 @@ public class GoogleCloudBuildTest {
   }
 
   @Test
-  public void testListTrigersWorksWhenNoTrigersDefined() throws Exception {
+  public void testListTrigersWorkWhenNoTrigerDefined() throws Exception {
     String emptyListResponse =
         objectMapper.writeValueAsString(listBuildTriggersResponse(Arrays.asList()));
     stubCloudBuildService.stubFor(
@@ -230,7 +230,7 @@ public class GoogleCloudBuildTest {
   }
 
   @Test
-  public void runTriggerSuccessfullyTest() throws Exception {
+  public void runTriggerWorksSuccessfullyTest() throws Exception {
     String buildResponse = objectMapper.writeValueAsString(buildResponse());
     String operationResponse = objectMapper.writeValueAsString(operationResponse());
     String repoSource = objectMapper.writeValueAsString(repoSource("master"));
@@ -242,7 +242,7 @@ public class GoogleCloudBuildTest {
 
     mockMvc
         .perform(
-            post("/gcb/triggers/run/gcb-account/my-id")
+            post("/gcb/triggers/gcb-account/my-id/run")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(repoSource))

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
@@ -33,16 +33,21 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.BuildOptions;
 import com.google.api.services.cloudbuild.v1.model.BuildStep;
+import com.google.api.services.cloudbuild.v1.model.BuildTrigger;
+import com.google.api.services.cloudbuild.v1.model.ListBuildTriggersResponse;
 import com.google.api.services.cloudbuild.v1.model.Operation;
+import com.google.api.services.cloudbuild.v1.model.RepoSource;
 import com.netflix.spinnaker.igor.RedisConfig;
 import com.netflix.spinnaker.igor.config.GoogleCloudBuildConfig;
 import com.netflix.spinnaker.igor.config.LockManagerConfig;
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -189,6 +194,65 @@ public class GoogleCloudBuildTest {
   }
 
   @Test
+  public void listTriggersTest() throws Exception {
+    List<BuildTrigger> triggers = Arrays.asList(buildTrigger("trigger1"), buildTrigger("trigger2"));
+    String listBuildTriggersResponseJson =
+        objectMapper.writeValueAsString(listBuildTriggersResponse(triggers));
+    String expectedTriggers = objectMapper.writeValueAsString(triggers);
+    stubCloudBuildService.stubFor(
+        WireMock.get(urlEqualTo("/v1/projects/spinnaker-gcb-test/triggers"))
+            .withHeader("Authorization", equalTo("Bearer test-token"))
+            .willReturn(aResponse().withStatus(200).withBody(listBuildTriggersResponseJson)));
+
+    mockMvc
+        .perform(get("/gcb/triggers/gcb-account").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().is(200))
+        .andExpect(content().json(expectedTriggers));
+
+    assertThat(stubCloudBuildService.findUnmatchedRequests().getRequests()).isEmpty();
+  }
+
+  @Test
+  public void testListTrigersWorksWhenNoTrigersDefined() throws Exception {
+    String emptyListResponse =
+        objectMapper.writeValueAsString(listBuildTriggersResponse(Arrays.asList()));
+    stubCloudBuildService.stubFor(
+        WireMock.get(urlEqualTo("/v1/projects/spinnaker-gcb-test/triggers"))
+            .withHeader("Authorization", equalTo("Bearer test-token"))
+            .willReturn(aResponse().withStatus(200).withBody(emptyListResponse)));
+
+    mockMvc
+        .perform(get("/gcb/triggers/gcb-account").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().is(200))
+        .andExpect(content().json("[]"));
+
+    assertThat(stubCloudBuildService.findUnmatchedRequests().getRequests()).isEmpty();
+  }
+
+  @Test
+  public void runTriggerSuccessfullyTest() throws Exception {
+    String buildResponse = objectMapper.writeValueAsString(buildResponse());
+    String operationResponse = objectMapper.writeValueAsString(operationResponse());
+    String repoSource = objectMapper.writeValueAsString(repoSource("master"));
+    stubCloudBuildService.stubFor(
+        WireMock.post(urlEqualTo("/v1/projects/spinnaker-gcb-test/triggers/my-id:run"))
+            .withHeader("Authorization", equalTo("Bearer test-token"))
+            .withRequestBody(equalToJson(repoSource))
+            .willReturn(aResponse().withStatus(200).withBody(operationResponse)));
+
+    mockMvc
+        .perform(
+            post("/gcb/triggers/run/gcb-account/my-id")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(repoSource))
+        .andExpect(status().is(200))
+        .andExpect(content().json(buildResponse));
+
+    assertThat(stubCloudBuildService.findUnmatchedRequests().getRequests()).isEmpty();
+  }
+
+  @Test
   public void fallbackToPollingTest() throws Exception {
     String buildId = "f0fc7c14-6035-4e5c-bda1-4848a73af5b4";
     String working = "WORKING";
@@ -240,6 +304,21 @@ public class GoogleCloudBuildTest {
 
   private Build taggedBuild() {
     return buildRequest().setTags(Collections.singletonList("started-by.spinnaker.io"));
+  }
+
+  private ListBuildTriggersResponse listBuildTriggersResponse(List<BuildTrigger> triggers) {
+    return new ListBuildTriggersResponse().setTriggers(triggers);
+  }
+
+  private BuildTrigger buildTrigger(String description) {
+    return new BuildTrigger()
+        .setDescription(description)
+        .setDisabled(false)
+        .setId(UUID.randomUUID().toString());
+  }
+
+  private RepoSource repoSource(String branch) {
+    return new RepoSource().setBranchName(branch);
   }
 
   private Build buildResponse() {


### PR DESCRIPTION
Added ability to call existing GCB triggers.
This is part of: https://github.com/spinnaker/spinnaker/issues/5076

Added two new endpoints to `igor` to:
* List existing triggers available for the gcb account.
* Call a trigger given its id. 

Calling a trigger will return a Build object, which then can be used to monitor the build using the existing functionality in `orca`.