### PR TITLE
feat(Artifactory Trigger): Add helm repo artifacts support to artifac…

### DIFF
--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
@@ -135,11 +135,11 @@ public class ArtifactoryBuildMonitor
                           ? ""
                           : search.getGroupId().replace('.', '/') + "/")
                       + "*\"},"
-                      + "\"name\": {\"$match\":\""
-                      + "*."
-                      + search.getSearchPattern()
+                      + "\"name\": {\"$match\":\"*"
+                      + search.getArtifactExtension()
                       + "\"}"
                       + "}).include(\"path\",\"repo\",\"name\", \"artifact.module.build\")";
+
               ArtifactoryRequest aqlRequest =
                   new ArtifactoryRequestImpl()
                       .method(ArtifactoryRequest.Method.POST)
@@ -159,7 +159,7 @@ public class ArtifactoryBuildMonitor
                       search.getPartitionName(),
                       Collections.singletonList(
                           new ArtifactDelta(
-                              System.currentTimeMillis(), search.getRepositoryType(), results)));
+                              System.currentTimeMillis(), search.getRepoType(), results)));
                 }
 
                 log.warn(

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
@@ -136,9 +136,10 @@ public class ArtifactoryBuildMonitor
                           : search.getGroupId().replace('.', '/') + "/")
                       + "*\"},"
                       + "\"name\": {\"$match\":\""
-                      + "*.pom\"}"
+                      + "*."
+                      + search.getSearchPattern()
+                      + "\"}"
                       + "}).include(\"path\",\"repo\",\"name\", \"artifact.module.build\")";
-
               ArtifactoryRequest aqlRequest =
                   new ArtifactoryRequestImpl()
                       .method(ArtifactoryRequest.Method.POST)
@@ -158,7 +159,7 @@ public class ArtifactoryBuildMonitor
                       search.getPartitionName(),
                       Collections.singletonList(
                           new ArtifactDelta(
-                              System.currentTimeMillis(), search.getRepoType(), results)));
+                              System.currentTimeMillis(), search.getRepositoryType(), results)));
                 }
 
                 log.warn(

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryRepositoryTypeConverter.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryRepositoryTypeConverter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.artifactory;
+
+import com.netflix.spinnaker.igor.artifactory.model.ArtifactoryRepositoryType;
+import org.springframework.core.convert.converter.Converter;
+
+public class ArtifactoryRepositoryTypeConverter
+    implements Converter<String, ArtifactoryRepositoryType> {
+
+  @Override
+  public ArtifactoryRepositoryType convert(String source) {
+    return ArtifactoryRepositoryType.valueOf(source.toUpperCase());
+  }
+}

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItem.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItem.java
@@ -36,8 +36,8 @@ public class ArtifactoryItem {
 
   @Nullable
   public Artifact toMatchableArtifact(ArtifactoryRepositoryType repositoryType, String baseUrl) {
-    switch (repositoryType) {
-      case MAVEN:
+    switch (repositoryType.getRepoTypeString()) {
+      case "Maven":
         String[] pathParts = path.split("/");
         String version = pathParts[pathParts.length - 1];
         String artifactId = pathParts[pathParts.length - 2];
@@ -75,7 +75,7 @@ public class ArtifactoryItem {
         }
 
         return artifactBuilder.build();
-      case HELM:
+      case "HELM":
         String filePath = null;
         if (baseUrl != null) {
           filePath = baseUrl + "/webapp/#/artifacts/browse/tree/General/" + repo + "/" + name;

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItem.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItem.java
@@ -35,9 +35,9 @@ public class ArtifactoryItem {
   private List<ArtifactoryArtifact> artifacts;
 
   @Nullable
-  public Artifact toMatchableArtifact(ArtifactoryRepositoryType repositoryType, String baseUrl) {
-    switch (repositoryType.getRepoTypeString()) {
-      case "Maven":
+  public Artifact toMatchableArtifact(ArtifactoryRepositoryType repoType, String baseUrl) {
+    switch (repoType) {
+      case MAVEN:
         String[] pathParts = path.split("/");
         String version = pathParts[pathParts.length - 1];
         String artifactId = pathParts[pathParts.length - 2];
@@ -75,13 +75,14 @@ public class ArtifactoryItem {
         }
 
         return artifactBuilder.build();
-      case "HELM":
+
+      case HELM:
         String filePath = null;
         if (baseUrl != null) {
           filePath = baseUrl + "/webapp/#/artifacts/browse/tree/General/" + repo + "/" + name;
         }
 
-        String helmVersion = getHelmFileVersion(name);
+        String helmVersion = getHelmFileVersion(name, repoType.getArtifactExtension());
         Artifact.ArtifactBuilder artifactBuilderHelm =
             Artifact.builder()
                 .type("helm/file")
@@ -95,9 +96,8 @@ public class ArtifactoryItem {
     return null;
   }
 
-  public String getHelmFileVersion(String artifactName) {
-    int lastIndex = artifactName.lastIndexOf("-");
-    return artifactName.substring(lastIndex + 1).replace(".tgz", "").trim();
+  private String getHelmFileVersion(String artifactName, String artifactExtension) {
+    return artifactName.replaceFirst(String.format("^.*-([^-]+)\\%s$", artifactExtension), "$1");
   }
 
   @Data

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItem.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItem.java
@@ -35,9 +35,9 @@ public class ArtifactoryItem {
   private List<ArtifactoryArtifact> artifacts;
 
   @Nullable
-  public Artifact toMatchableArtifact(ArtifactoryRepositoryType repoType, String baseUrl) {
-    switch (repoType) {
-      case Maven:
+  public Artifact toMatchableArtifact(ArtifactoryRepositoryType repositoryType, String baseUrl) {
+    switch (repositoryType) {
+      case MAVEN:
         String[] pathParts = path.split("/");
         String version = pathParts[pathParts.length - 1];
         String artifactId = pathParts[pathParts.length - 2];
@@ -75,8 +75,29 @@ public class ArtifactoryItem {
         }
 
         return artifactBuilder.build();
+      case HELM:
+        String filePath = null;
+        if (baseUrl != null) {
+          filePath = baseUrl + "/webapp/#/artifacts/browse/tree/General/" + repo + "/" + name;
+        }
+
+        String helmVersion = getHelmFileVersion(name);
+        Artifact.ArtifactBuilder artifactBuilderHelm =
+            Artifact.builder()
+                .type("helm/file")
+                .reference("")
+                .name(name)
+                .version(helmVersion)
+                .provenance(repo)
+                .location(filePath);
+        return artifactBuilderHelm.build();
     }
     return null;
+  }
+
+  public String getHelmFileVersion(String artifactName) {
+    int lastIndex = artifactName.lastIndexOf("-");
+    return artifactName.substring(lastIndex + 1).replace(".tgz", "").trim();
   }
 
   @Data

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryRepositoryType.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryRepositoryType.java
@@ -13,18 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.netflix.spinnaker.igor.artifactory.model;
 
 public enum ArtifactoryRepositoryType {
-  MAVEN("Maven"),
-  HELM("HELM");
-  String repoTypeString;
+  MAVEN("Maven", ".pom"),
+  HELM("HELM", ".tgz");
 
-  ArtifactoryRepositoryType(String repoTypeString) {
+  private final String repoTypeString;
+  private final String artifactExtension;
+
+  ArtifactoryRepositoryType(String repoTypeString, String extension) {
     this.repoTypeString = repoTypeString;
+    this.artifactExtension = extension;
   }
 
-  public String getRepoTypeString() {
-    return repoTypeString;
+  public String getArtifactExtension() {
+    return artifactExtension;
   }
 }

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryRepositoryType.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryRepositoryType.java
@@ -13,10 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.spinnaker.igor.artifactory.model;
 
 public enum ArtifactoryRepositoryType {
-  MAVEN,
-  HELM;
+  MAVEN("Maven"),
+  HELM("HELM");
+  String repoTypeString;
+
+  ArtifactoryRepositoryType(String repoTypeString) {
+    this.repoTypeString = repoTypeString;
+  }
+
+  public String getRepoTypeString() {
+    return repoTypeString;
+  }
 }

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryRepositoryType.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryRepositoryType.java
@@ -17,5 +17,6 @@
 package com.netflix.spinnaker.igor.artifactory.model;
 
 public enum ArtifactoryRepositoryType {
-  Maven,
+  MAVEN,
+  HELM;
 }

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactorySearch.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactorySearch.java
@@ -22,7 +22,7 @@ import lombok.Data;
 @Data
 public class ArtifactorySearch {
   private String name;
-  private String repoType;
+  private ArtifactoryRepositoryType repoType = ArtifactoryRepositoryType.MAVEN;
   private String baseUrl;
   private String repo;
 
@@ -39,12 +39,8 @@ public class ArtifactorySearch {
   /** Filter published artifact searches to just this group id. */
   @Nullable private String groupId;
 
-  /** Filter name of the artifact in the search to this pattern * */
-  @Nullable private String searchPattern;
-
-  /** Repotype returned based on repositoryType specified in search * */
-  public ArtifactoryRepositoryType getRepositoryType() {
-    return ArtifactoryRepositoryType.valueOf(repoType.toUpperCase());
+  public String getArtifactExtension() {
+    return repoType.getArtifactExtension();
   }
 
   public String getPartitionName() {

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactorySearch.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactorySearch.java
@@ -22,7 +22,7 @@ import lombok.Data;
 @Data
 public class ArtifactorySearch {
   private String name;
-  private ArtifactoryRepositoryType repoType = ArtifactoryRepositoryType.Maven;
+  private String repoType;
   private String baseUrl;
   private String repo;
 
@@ -38,6 +38,14 @@ public class ArtifactorySearch {
 
   /** Filter published artifact searches to just this group id. */
   @Nullable private String groupId;
+
+  /** Filter name of the artifact in the search to this pattern * */
+  @Nullable private String searchPattern;
+
+  /** Repotype returned based on repositoryType specified in search * */
+  public ArtifactoryRepositoryType getRepositoryType() {
+    return ArtifactoryRepositoryType.valueOf(repoType.toUpperCase());
+  }
 
   public String getPartitionName() {
     return baseUrl + "/" + repo;

--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/config/ArtifactoryConfig.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/config/ArtifactoryConfig.java
@@ -16,11 +16,20 @@
 
 package com.netflix.spinnaker.igor.config;
 
+import com.netflix.spinnaker.igor.artifactory.ArtifactoryRepositoryTypeConverter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConditionalOnProperty("artifactory.enabled")
 @EnableConfigurationProperties(ArtifactoryProperties.class)
-public class ArtifactoryConfig {}
+public class ArtifactoryConfig {
+  @Bean
+  @ConfigurationPropertiesBinding
+  public ArtifactoryRepositoryTypeConverter artifactoryRepositoryTypeConverter() {
+    return new ArtifactoryRepositoryTypeConverter();
+  }
+}

--- a/igor-monitor-artifactory/src/test/groovy/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitorSpec.groovy
+++ b/igor-monitor-artifactory/src/test/groovy/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitorSpec.groovy
@@ -18,8 +18,7 @@ package com.netflix.spinnaker.igor.artifactory
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.igor.IgorConfigurationProperties
-import com.netflix.spinnaker.igor.artifactory.ArtifactoryBuildMonitor
-import com.netflix.spinnaker.igor.artifactory.ArtifactoryCache
+import com.netflix.spinnaker.igor.artifactory.model.ArtifactoryRepositoryType
 import com.netflix.spinnaker.igor.artifactory.model.ArtifactorySearch
 import com.netflix.spinnaker.igor.config.ArtifactoryProperties
 import com.netflix.spinnaker.igor.history.EchoService
@@ -50,6 +49,7 @@ class ArtifactoryBuildMonitorSpec extends Specification {
         new ArtifactorySearch(
           baseUrl: url,
           repo: 'libs-releases-local',
+          repoType: ArtifactoryRepositoryType.MAVEN
         )
       ])
     )

--- a/igor-monitor-artifactory/src/test/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItemTest.java
+++ b/igor-monitor-artifactory/src/test/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItemTest.java
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.Test;
 
 class ArtifactoryItemTest {
   @Test
-  void toMatchableArtifact() {
+  void toMatchableArtifactMaven() {
     ArtifactoryItem artifact = new ArtifactoryItem();
     artifact.setName("1.0.1.pom");
     artifact.setPath("io/pivotal/spinnaker/demo/0.1.0-dev.20+d9a14fb");
     artifact.setRepo("libs-demo-local");
 
     Artifact matchableArtifact =
-        artifact.toMatchableArtifact(ArtifactoryRepositoryType.Maven, "http://localhost:8080");
+        artifact.toMatchableArtifact(ArtifactoryRepositoryType.MAVEN, "http://localhost:8080");
     assertThat(matchableArtifact).isNotNull();
     assertThat(matchableArtifact.getType()).isEqualTo("maven/file");
     assertThat(matchableArtifact.getReference())
@@ -44,6 +44,25 @@ class ArtifactoryItemTest {
         .isEqualTo(
             "http://localhost:8080/webapp/#/artifacts/browse/tree/General/libs-demo-local/io/pivotal"
                 + "/spinnaker/demo/0.1.0-dev.20+d9a14fb/1.0.1.pom");
+  }
+
+  @Test
+  void toMatchableArtifactHelm() {
+    ArtifactoryItem artifact = new ArtifactoryItem();
+    artifact.setName("my-app-0.0.1.tgz");
+    artifact.setPath(".");
+    artifact.setRepo("demo-helm-local");
+
+    Artifact matchableArtifact =
+        artifact.toMatchableArtifact(ArtifactoryRepositoryType.HELM, "http://localhost:8080");
+    assertThat(matchableArtifact).isNotNull();
+    assertThat(matchableArtifact.getType()).isEqualTo("helm/file");
+    assertThat(matchableArtifact.getVersion()).isEqualTo("0.0.1");
+    assertThat(matchableArtifact.getName()).isEqualTo("my-app-0.0.1.tgz");
+    assertThat(matchableArtifact.getLocation())
+        .isEqualTo(
+            "http://localhost:8080/webapp/#/artifacts/browse/tree/General/demo-helm-local/"
+                + "my-app-0.0.1.tgz");
   }
 
   @Test
@@ -80,7 +99,7 @@ class ArtifactoryItemTest {
     artifact.setArtifacts(artifacts);
 
     Artifact matchableArtifact =
-        artifact.toMatchableArtifact(ArtifactoryRepositoryType.Maven, null);
+        artifact.toMatchableArtifact(ArtifactoryRepositoryType.MAVEN, null);
     assertThat(matchableArtifact.getMetadata().get("build")).isEqualTo(expectedBuild);
   }
 }


### PR DESCRIPTION
This feature enhances the Artifactory Trigger to support helm artifacts. The feature works similar to the existing maven artifacts where a search is configured for a helm repo type. The enhancement introduces one new parameter in the search configuration : 

repoType: This field identifies the artifactory repository type  Maven, Helm etc

(Note there is a reference to a PR in Halyard to support new variables in search)

The search configuration looks like:
``` yaml
searches:
    -name: test-helm
     permissions: {}
     baseUrl: https://artifactory-url/artifactory
     repo: test-helm-local
     repoType: helm
     username: username
     password: ..
   -name: test-maven
    permissions: {}
    baseUrl: https://artifactory-url/artifactory
    repo: test-maven-local
    groupId: com.mycompany
    repoType: maven
    username:
```
We extended the enum ArtifactoryRepositoryType to include helm:
```java
public enum ArtifactoryRepositoryType {
  MAVEN("Maven", ".pom"),
  HELM("HELM", ".tgz");

  private final String repoTypeString;
  private final String artifactExtension;
}
```
The ArtifactorySearch.java has a new utility method that returns the artifactExtension based on the repoType configured in the search
``` java
public String getArtifactExtension() {
    return repoType.getArtifactExtension();
  }
```
The aql used to query artifactory in ArtifactoryBuildMonitor.java has been modified to match the repo and file type based on the repo type configured in search
```java
String aqlQuery =
                  "items.find({"
                      + "\"repo\":\""
                      + search.getRepo()
                      + "\","
                      + modified
                      + ","
                      + "\"path\":{\"$match\":\""
                      + (search.getGroupId() == null
                          ? ""
                          : search.getGroupId().replace('.', '/') + "/")
                      + "*\"},"
                      + "\"name\": {\"$match\":\""
                      + "*."
                      + search.getSearchPattern()
``` 
In order to match a helm artifact found during a poll , the method toMatchableArtifact in ArtifactoryItem.java has been modified to return a Artifact fortype Helm:
```java
case HELM:
        String filePath = null;
        if (baseUrl != null) {
          filePath = baseUrl + "/webapp/#/artifacts/browse/tree/General/" + repo + "/" + name;
        }

        String helmVersion = getHelmFileVersion(name);
        Artifact.ArtifactBuilder artifactBuilderHelm =
            Artifact.builder()
                .type("helm/file")
                .reference("")
                .name(name)
                .version(helmVersion)
                .provenance(repo)
                .location(filePath);
        return artifactBuilderHelm.build();
``` 
A new class ArtifactoryRepositoryTypeConverter has been introduced to convert the repoType String to a Enum
```java
public class ArtifactoryRepositoryTypeConverter
    implements Converter<String, ArtifactoryRepositoryType> {

  @Override
  public ArtifactoryRepositoryType convert(String source) {
    return ArtifactoryRepositoryType.valueOf(source.toUpperCase());
  }
}
```

We did not include logic to look build modules in Artifactory for helm charts as most of the deployment use cases we have seen are done via curl. If this is not a accurate assumption, we can rework the code.

Referenced feature request: https://github.com/spinnaker/spinnaker/issues/5074
Referenced Halyard PR to support new search fields in ArtifactorySearch.java : https://github.com/spinnaker/halyard/pull/1472