### PR TITLE
fix(ArtifactoryPollingMonitor): Fix failing validation on lockName

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
@@ -144,7 +144,7 @@ public abstract class CommonPollingMonitor<I extends DeltaItem, T extends Pollin
       // Lock duration of the full poll interval; if the work is completed ahead of that time, it'll
       // be released.
       // If anything, this will mean builds are polled more often, rather than less.
-      final String lockName = format("%s.%s", getName(), ctx.partitionName);
+      final String lockName = getLockName(getName(), ctx.partitionName);
       lockService
           .get()
           .acquire(lockName, Duration.ofSeconds(getPollInterval()), () -> internalPollSingle(ctx));
@@ -152,6 +152,23 @@ public abstract class CommonPollingMonitor<I extends DeltaItem, T extends Pollin
       log.warn("****LOCKING NOT ENABLED***, not recommended running on more than one node.");
       internalPollSingle(ctx);
     }
+  }
+
+  /**
+   * Method to construct a lockName and sanitise it to remove special charecters as per kork
+   * validation
+   *
+   * @param name
+   * @param partition
+   * @return
+   */
+  protected String getLockName(String name, String partition) {
+
+    String lockName = format("%s.%s", name, partition);
+    if (!lockName.matches("^[a-zA-Z0-9.-]+$")) {
+      return lockName.replaceAll("[^a-zA-Z0-9.-]", "");
+    }
+    return lockName;
   }
 
   protected void internalPollSingle(PollContext ctx) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
@@ -155,7 +155,7 @@ public abstract class CommonPollingMonitor<I extends DeltaItem, T extends Pollin
   }
 
   /**
-   * Method to construct a lockName and sanitise it to remove special charecters as per kork
+   * Method to construct a lockName and sanitise it to remove special characters as per kork
    * validation
    *
    * @param name


### PR DESCRIPTION
This fix addresses a validation failure in kork when a polling agent tries to acquire a lock using the lockService. This issue can be reproduced by enabling Artifactory build trigger for maven artifacts. The search configuration looks like 

```
searches:
      - name: test-maven
        permissions: {}
        baseUrl: https://artifactory-url/artifactory
        repo: test-maven-local
        groupId: com.mycompany
        username:
```
The Artifactory polling logic fails with the following exception:
```
Caused by: com.netflix.spinnaker.kork.exceptions.ConstraintViolationException: Lock name must be alphanumeric, may contain dots
	at com.netflix.spinnaker.kork.lock.LockManager$LockOptions.validateInputs(LockManager.java:315
```
The class CommonPollingMonitor initialises the lockName variable as
```
final String lockName = format("%s.%s", getName(), ctx.partitionName);
```
which in this case will be
```
 artifactoryPublishingMonitor.https://artifactory-url/artifactory/test-maven-local
```
The issue can be fixed by validating if the lockName passed from CommonPollingMonitor.java passes the regex validation  ^[a-zA-Z0-9.-] and replacing any unacceptable characters.

Referenced issue : https://github.com/spinnaker/spinnaker/issues/5186 
