### PR TITLE
chore(java11): Switch the default containers to use Java 11.

### DIFF
--- a/Dockerfile.java8
+++ b/Dockerfile.java8
@@ -1,7 +1,7 @@
-FROM ubuntu:bionic
+FROM alpine:3.10
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/igor-web/build/install/igor /opt/igor
-RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget
-RUN adduser --disabled-login --system spinnaker
+RUN apk --no-cache add --update bash openjdk8-jre
+RUN adduser -D -S spinnaker
 USER spinnaker
 CMD ["/opt/igor/bin/igor"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/igor-web/build/install/igor /opt/igor
-RUN apk --no-cache add --update bash openjdk8-jre
+RUN apk --no-cache add --update bash openjdk11-jre
 RUN adduser -D -S spinnaker
 USER spinnaker
 CMD ["/opt/igor/bin/igor"]

--- a/Dockerfile.ubuntu-java8
+++ b/Dockerfile.ubuntu-java8
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/igor-web/build/install/igor /opt/igor
-RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget
+RUN apt-get update && apt-get -y install openjdk-8-jre-headless wget
 RUN adduser --disabled-login --system spinnaker
 USER spinnaker
 CMD ["/opt/igor/bin/igor"]


### PR DESCRIPTION
Part of the [Java 11 migration effort](https://github.com/spinnaker/community/blob/master/rfc/java11.md).