### PR TITLE
refactor(gcb): Reduce visibility of GCB packages

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
@@ -26,6 +26,7 @@ import com.google.api.services.storage.Storage;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,8 +35,8 @@ import org.springframework.stereotype.Component;
 /** Factory for calling CloudBuild client library code to create CloudBuild objects */
 @Component
 @ConditionalOnProperty("gcb.enabled")
-@RequiredArgsConstructor
-public class CloudBuildFactory {
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+final class CloudBuildFactory {
   private final int connectTimeoutSec = 10;
   private final int readTimeoutSec = 10;
 
@@ -46,11 +47,11 @@ public class CloudBuildFactory {
   private final String overrideRootUrl;
 
   @Autowired
-  public CloudBuildFactory(HttpTransport httpTransport) {
+  CloudBuildFactory(HttpTransport httpTransport) {
     this(httpTransport, null);
   }
 
-  public CloudBuild getCloudBuild(GoogleCredentials credentials, String applicationName) {
+  CloudBuild getCloudBuild(GoogleCredentials credentials, String applicationName) {
     HttpRequestInitializer requestInitializer = getRequestInitializer(credentials);
     CloudBuild.Builder builder =
         new CloudBuild.Builder(httpTransport, jsonFactory, requestInitializer)
@@ -62,7 +63,7 @@ public class CloudBuildFactory {
     return builder.build();
   }
 
-  public Storage getCloudStorage(GoogleCredentials credentials, String applicationName) {
+  Storage getCloudStorage(GoogleCredentials credentials, String applicationName) {
     HttpRequestInitializer requestInitializer = getRequestInitializer(credentials);
     Storage.Builder builder =
         new Storage.Builder(httpTransport, jsonFactory, requestInitializer)

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/CloudBuildFactory.java
@@ -26,8 +26,7 @@ import com.google.api.services.storage.Storage;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
+import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -35,7 +34,6 @@ import org.springframework.stereotype.Component;
 /** Factory for calling CloudBuild client library code to create CloudBuild objects */
 @Component
 @ConditionalOnProperty("gcb.enabled")
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 final class CloudBuildFactory {
   private final int connectTimeoutSec = 10;
   private final int readTimeoutSec = 10;
@@ -44,11 +42,16 @@ final class CloudBuildFactory {
   private final HttpTransport httpTransport;
 
   // Override the base URL for all requests to the cloud build API; primarily for testing.
-  private final String overrideRootUrl;
+  @Nullable private final String overrideRootUrl;
 
   @Autowired
   CloudBuildFactory(HttpTransport httpTransport) {
     this(httpTransport, null);
+  }
+
+  CloudBuildFactory(HttpTransport httpTransport, @Nullable String overrideRootUrl) {
+    this.httpTransport = httpTransport;
+    this.overrideRootUrl = overrideRootUrl;
   }
 
   CloudBuild getCloudBuild(GoogleCredentials credentials, String applicationName) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -21,6 +21,7 @@ import com.google.api.services.cloudbuild.v1.model.BuildTrigger;
 import com.google.api.services.cloudbuild.v1.model.ListBuildTriggersResponse;
 import com.google.api.services.cloudbuild.v1.model.Operation;
 import com.google.api.services.cloudbuild.v1.model.RepoSource;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,7 +56,7 @@ class GoogleCloudBuildAccount {
   }
 
   private void appendTags(Build build) {
-    List<String> tags = Optional.ofNullable(build.getTags()).orElse(new ArrayList<>());
+    List<String> tags = Optional.ofNullable(build.getTags()).orElseGet(ArrayList::new);
     if (!tags.contains(BUILD_TAG)) {
       tags.add(BUILD_TAG);
     }
@@ -76,9 +77,9 @@ class GoogleCloudBuildAccount {
     return googleCloudBuildParser.parse(buildString, Build.class);
   }
 
-  List<BuildTrigger> listTriggers() {
+  ImmutableList<BuildTrigger> listTriggers() {
     ListBuildTriggersResponse listBuildTriggersResponse = client.listTriggers();
-    return listBuildTriggersResponse.getTriggers();
+    return ImmutableList.copyOf(listBuildTriggersResponse.getTriggers());
   }
 
   Build runTrigger(String triggerId, RepoSource repoSource) {
@@ -92,12 +93,12 @@ class GoogleCloudBuildAccount {
     return triggerResponse;
   }
 
-  List<Artifact> getArtifacts(String buildId) {
+  ImmutableList<Artifact> getArtifacts(String buildId) {
     Build build = getBuild(buildId);
     return googleCloudBuildArtifactFetcher.getArtifacts(build);
   }
 
-  List<Artifact> extractArtifacts(Build build) {
+  ImmutableList<Artifact> extractArtifacts(Build build) {
     return googleCloudBuildArtifactFetcher.getArtifacts(build);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -61,7 +62,7 @@ class GoogleCloudBuildAccount {
     build.setTags(tags);
   }
 
-  void updateBuild(String buildId, String status, String serializedBuild) {
+  void updateBuild(String buildId, @Nullable String status, String serializedBuild) {
     cache.updateBuild(buildId, status, serializedBuild);
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccount.java
@@ -25,14 +25,15 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 /**
  * Handles getting and updating build information for a single account. Delegates operations to
  * either the GoogleCloudBuildCache or GoogleCloudBuildClient.
  */
-@RequiredArgsConstructor
-public class GoogleCloudBuildAccount {
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+class GoogleCloudBuildAccount {
   private static final String BUILD_TAG = "started-by.spinnaker.io";
 
   private final GoogleCloudBuildClient client;
@@ -40,7 +41,7 @@ public class GoogleCloudBuildAccount {
   private final GoogleCloudBuildParser googleCloudBuildParser;
   private final GoogleCloudBuildArtifactFetcher googleCloudBuildArtifactFetcher;
 
-  public Build createBuild(Build buildRequest) {
+  Build createBuild(Build buildRequest) {
     appendTags(buildRequest);
     Operation operation = client.createBuild(buildRequest);
     Build buildResponse =
@@ -60,11 +61,11 @@ public class GoogleCloudBuildAccount {
     build.setTags(tags);
   }
 
-  public void updateBuild(String buildId, String status, String serializedBuild) {
+  void updateBuild(String buildId, String status, String serializedBuild) {
     cache.updateBuild(buildId, status, serializedBuild);
   }
 
-  public Build getBuild(String buildId) {
+  Build getBuild(String buildId) {
     String buildString = cache.getBuild(buildId);
     if (buildString == null) {
       Build build = client.getBuild(buildId);
@@ -74,12 +75,12 @@ public class GoogleCloudBuildAccount {
     return googleCloudBuildParser.parse(buildString, Build.class);
   }
 
-  public List<BuildTrigger> listTriggers() {
+  List<BuildTrigger> listTriggers() {
     ListBuildTriggersResponse listBuildTriggersResponse = client.listTriggers();
     return listBuildTriggersResponse.getTriggers();
   }
 
-  public Build runTrigger(String triggerId, RepoSource repoSource) {
+  Build runTrigger(String triggerId, RepoSource repoSource) {
     Operation operation = client.runTrigger(triggerId, repoSource);
     Build triggerResponse =
         googleCloudBuildParser.convert(operation.getMetadata().get("build"), Build.class);
@@ -90,12 +91,12 @@ public class GoogleCloudBuildAccount {
     return triggerResponse;
   }
 
-  public List<Artifact> getArtifacts(String buildId) {
+  List<Artifact> getArtifacts(String buildId) {
     Build build = getBuild(buildId);
     return googleCloudBuildArtifactFetcher.getArtifacts(build);
   }
 
-  public List<Artifact> extractArtifacts(Build build) {
+  List<Artifact> extractArtifacts(Build build) {
     return googleCloudBuildArtifactFetcher.getArtifacts(build);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.igor.gcb;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -26,14 +27,14 @@ import org.springframework.stereotype.Component;
 /** Creates GoogleCloudBuildAccounts */
 @Component
 @ConditionalOnProperty("gcb.enabled")
-@RequiredArgsConstructor
-public class GoogleCloudBuildAccountFactory {
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+final class GoogleCloudBuildAccountFactory {
   private final GoogleCredentialsService credentialService;
   private final GoogleCloudBuildClient.Factory googleCloudBuildClientFactory;
   private final GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory;
   private final GoogleCloudBuildParser googleCloudBuildParser;
 
-  public GoogleCloudBuildAccount build(GoogleCloudBuildProperties.Account account) {
+  GoogleCloudBuildAccount build(GoogleCloudBuildProperties.Account account) {
     GoogleCredentials credentials = getCredentials(account);
 
     GoogleCloudBuildClient client =

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepository.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepository.java
@@ -26,18 +26,18 @@ import java.util.stream.Collectors;
  * Keeps track of all registered instances of GoogleCloudBuildAccount and returns the appropriate
  * account when it is requested by name.
  */
-public class GoogleCloudBuildAccountRepository {
+final class GoogleCloudBuildAccountRepository {
   private final Map<String, GoogleCloudBuildAccount> accounts = new HashMap<>();
 
-  public void registerAccount(String name, GoogleCloudBuildAccount account) {
+  void registerAccount(String name, GoogleCloudBuildAccount account) {
     accounts.put(name, account);
   }
 
-  public List<String> getAccounts() {
+  List<String> getAccounts() {
     return accounts.keySet().stream().sorted().collect(Collectors.toList());
   }
 
-  public GoogleCloudBuildAccount getGoogleCloudBuild(String name) {
+  GoogleCloudBuildAccount getGoogleCloudBuild(String name) {
     GoogleCloudBuildAccount account = accounts.get(name);
     if (account == null) {
       throw new NotFoundException(

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepository.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepository.java
@@ -16,25 +16,22 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Keeps track of all registered instances of GoogleCloudBuildAccount and returns the appropriate
  * account when it is requested by name.
  */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 final class GoogleCloudBuildAccountRepository {
-  private final Map<String, GoogleCloudBuildAccount> accounts = new HashMap<>();
+  private final ImmutableSortedMap<String, GoogleCloudBuildAccount> accounts;
 
-  void registerAccount(String name, GoogleCloudBuildAccount account) {
-    accounts.put(name, account);
-  }
-
-  List<String> getAccounts() {
-    return accounts.keySet().stream().sorted().collect(Collectors.toList());
+  ImmutableList<String> getAccounts() {
+    return accounts.keySet().asList();
   }
 
   GoogleCloudBuildAccount getGoogleCloudBuild(String name) {
@@ -44,5 +41,24 @@ final class GoogleCloudBuildAccountRepository {
           String.format("No Google Cloud Build account with name %s is configured", name));
     }
     return account;
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+  static final class Builder {
+    private final ImmutableSortedMap.Builder<String, GoogleCloudBuildAccount> accounts =
+        ImmutableSortedMap.naturalOrder();
+
+    Builder registerAccount(String name, GoogleCloudBuildAccount account) {
+      accounts.put(name, account);
+      return this;
+    }
+
+    GoogleCloudBuildAccountRepository build() {
+      return new GoogleCloudBuildAccountRepository(accounts.build());
+    }
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifact.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifact.java
@@ -23,11 +23,11 @@ import lombok.Getter;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GoogleCloudBuildArtifact {
+final class GoogleCloudBuildArtifact {
   private final String location;
 
   @JsonCreator
-  public GoogleCloudBuildArtifact(@JsonProperty("location") String location) {
+  GoogleCloudBuildArtifact(@JsonProperty("location") String location) {
     this.location = location;
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifact.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifact.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.igor.gcb.model;
+package com.netflix.spinnaker.igor.gcb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
@@ -16,19 +16,19 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.BuiltImage;
 import com.google.api.services.cloudbuild.v1.model.Results;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -38,27 +38,25 @@ final class GoogleCloudBuildArtifactFetcher {
   private final GoogleCloudBuildClient client;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  List<Artifact> getArtifacts(Build build) {
-    List<Artifact> results = new ArrayList<>();
-
-    results.addAll(getDockerArtifacts(build));
-    results.addAll(getGoogleCloudStorageArtifacts(build));
-
-    return results;
+  ImmutableList<Artifact> getArtifacts(Build build) {
+    return ImmutableList.<Artifact>builder()
+        .addAll(getDockerArtifacts(build))
+        .addAll(getGoogleCloudStorageArtifacts(build))
+        .build();
   }
 
-  private List<Artifact> getDockerArtifacts(Build build) {
+  private ImmutableList<Artifact> getDockerArtifacts(Build build) {
     Results results = build.getResults();
     if (results == null) {
-      return Collections.emptyList();
+      return ImmutableList.of();
     }
 
     List<BuiltImage> images = results.getImages();
     if (images == null) {
-      return Collections.emptyList();
+      return ImmutableList.of();
     }
 
-    return images.stream().map(this::parseBuiltImage).collect(Collectors.toList());
+    return images.stream().map(this::parseBuiltImage).collect(toImmutableList());
   }
 
   private Artifact parseBuiltImage(BuiltImage image) {
@@ -71,17 +69,17 @@ final class GoogleCloudBuildArtifactFetcher {
         .build();
   }
 
-  private List<Artifact> getGoogleCloudStorageArtifacts(Build build) {
+  private ImmutableList<Artifact> getGoogleCloudStorageArtifacts(Build build) {
     GoogleCloudStorageObject manifest = getGoogleCloudStorageManifest(build);
     if (manifest == null) {
-      return Collections.emptyList();
+      return ImmutableList.of();
     }
 
     try {
       return readGoogleCloudStorageManifest(manifest).stream()
           .map(this::parseGoogleCloudBuildArtifact)
           .distinct()
-          .collect(Collectors.toList());
+          .collect(toImmutableList());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -113,9 +111,9 @@ final class GoogleCloudBuildArtifactFetcher {
     return GoogleCloudStorageObject.fromReference(artifactManifest);
   }
 
-  private List<GoogleCloudBuildArtifact> readGoogleCloudStorageManifest(
+  private ImmutableList<GoogleCloudBuildArtifact> readGoogleCloudStorageManifest(
       GoogleCloudStorageObject manifest) throws IOException {
-    List<GoogleCloudBuildArtifact> results = new ArrayList<>();
+    ImmutableList.Builder<GoogleCloudBuildArtifact> results = ImmutableList.builder();
     InputStream is =
         client.fetchStorageObject(
             manifest.getBucket(), manifest.getObject(), manifest.getVersion());
@@ -125,6 +123,6 @@ final class GoogleCloudBuildArtifactFetcher {
         results.add(objectMapper.readValue(line, GoogleCloudBuildArtifact.class));
       }
     }
-    return results;
+    return results.build();
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -97,6 +98,7 @@ final class GoogleCloudBuildArtifactFetcher {
         .build();
   }
 
+  @Nullable
   private GoogleCloudStorageObject getGoogleCloudStorageManifest(Build build) {
     Results results = build.getResults();
     if (results == null) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.BuiltImage;
 import com.google.api.services.cloudbuild.v1.model.Results;
-import com.netflix.spinnaker.igor.gcb.model.GoogleCloudBuildArtifact;
-import com.netflix.spinnaker.igor.gcb.model.GoogleCloudStorageObject;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
@@ -29,14 +29,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
-public class GoogleCloudBuildArtifactFetcher {
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+final class GoogleCloudBuildArtifactFetcher {
   private final GoogleCloudBuildClient client;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  public List<Artifact> getArtifacts(Build build) {
+  List<Artifact> getArtifacts(Build build) {
     List<Artifact> results = new ArrayList<>();
 
     results.addAll(getDockerArtifacts(build));

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildArtifactFetcher.java
@@ -28,6 +28,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.util.List;
 import javax.annotation.Nullable;
 import lombok.AccessLevel;
@@ -81,7 +82,7 @@ final class GoogleCloudBuildArtifactFetcher {
           .distinct()
           .collect(toImmutableList());
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCache.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCache.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.igor.polling.LockService;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
 import java.time.Duration;
 import java.util.Map;
+import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +54,7 @@ class GoogleCloudBuildCache {
     }
   }
 
+  @Nullable
   String getBuild(String buildId) {
     String key = new GoogleCloudBuildKey(keyPrefix, buildId).toString();
     return redisClientDelegate.withCommandsClient(
@@ -62,7 +64,7 @@ class GoogleCloudBuildCache {
         });
   }
 
-  private void internalUpdateBuild(String buildId, String status, String build) {
+  private void internalUpdateBuild(String buildId, @Nullable String status, String build) {
     String key = new GoogleCloudBuildKey(keyPrefix, buildId).toString();
     redisClientDelegate.withCommandsClient(
         c -> {
@@ -92,7 +94,7 @@ class GoogleCloudBuildCache {
 
   // As we may be processing build notifications out of order, only allow an update of the cache if
   // the incoming build status is newer than the status that we currently have cached.
-  private boolean allowUpdate(String oldStatusString, String newStatusString) {
+  private boolean allowUpdate(@Nullable String oldStatusString, @Nullable String newStatusString) {
     if (oldStatusString == null) {
       return true;
     }
@@ -111,7 +113,7 @@ class GoogleCloudBuildCache {
     }
   }
 
-  void updateBuild(String buildId, String status, String build) {
+  void updateBuild(String buildId, @Nullable String status, String build) {
     String lockName = String.format("%s.%s", lockPrefix, buildId);
     lockService.acquire(
         lockName,

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCache.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildCache.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
-public class GoogleCloudBuildCache {
+class GoogleCloudBuildCache {
   private static final int inProgressTtlSeconds = 60 * 10;
   private static final int completedTtlSeconds = 60 * 60 * 24;
 
@@ -39,21 +39,21 @@ public class GoogleCloudBuildCache {
   private final String keyPrefix;
   private final String lockPrefix;
 
-  @RequiredArgsConstructor
-  public static class Factory {
+  @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+  static class Factory {
     private final LockService lockService;
     private final RedisClientDelegate redisClientDelegate;
     private final String baseKeyPrefix;
     private static final String baseLockPrefix = "googleCloudBuild";
 
-    public GoogleCloudBuildCache create(String accountName) {
+    GoogleCloudBuildCache create(String accountName) {
       String keyPrefix = String.format("%s:%s", baseKeyPrefix, accountName);
       String lockPrefix = String.format("%s.%s", baseLockPrefix, accountName);
       return new GoogleCloudBuildCache(lockService, redisClientDelegate, keyPrefix, lockPrefix);
     }
   }
 
-  public String getBuild(String buildId) {
+  String getBuild(String buildId) {
     String key = new GoogleCloudBuildKey(keyPrefix, buildId).toString();
     return redisClientDelegate.withCommandsClient(
         c -> {
@@ -111,7 +111,7 @@ public class GoogleCloudBuildCache {
     }
   }
 
-  public void updateBuild(String buildId, String status, String build) {
+  void updateBuild(String buildId, String status, String build) {
     String lockName = String.format("%s.%s", lockPrefix, buildId);
     lockService.acquire(
         lockName,
@@ -121,8 +121,8 @@ public class GoogleCloudBuildCache {
         });
   }
 
-  @RequiredArgsConstructor
-  static class GoogleCloudBuildKey {
+  @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+  static final class GoogleCloudBuildKey {
     private final String prefix;
     private final String id;
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
@@ -25,6 +25,7 @@ import com.google.api.services.storage.Storage;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -69,7 +70,8 @@ class GoogleCloudBuildClient {
         () -> cloudBuild.projects().triggers().run(projectId, triggerId, repoSource));
   }
 
-  InputStream fetchStorageObject(String bucket, String object, Long version) throws IOException {
+  InputStream fetchStorageObject(String bucket, String object, @Nullable Long version)
+      throws IOException {
     Storage.Objects.Get getRequest = cloudStorage.objects().get(bucket, object);
     if (version != null) {
       getRequest.setGeneration(version);

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildClient.java
@@ -33,44 +33,43 @@ import lombok.RequiredArgsConstructor;
  * delegating to GoogleCloudBuildExecutor to execute these requests.
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class GoogleCloudBuildClient {
+class GoogleCloudBuildClient {
   private final String projectId;
   private final CloudBuild cloudBuild;
   private final Storage cloudStorage;
   private final GoogleCloudBuildExecutor executor;
 
-  @RequiredArgsConstructor
-  public static class Factory {
+  @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+  static class Factory {
     private final CloudBuildFactory cloudBuildFactory;
     private final GoogleCloudBuildExecutor executor;
     private final String applicationName;
 
-    public GoogleCloudBuildClient create(GoogleCredentials credentials, String projectId) {
+    GoogleCloudBuildClient create(GoogleCredentials credentials, String projectId) {
       CloudBuild cloudBuild = cloudBuildFactory.getCloudBuild(credentials, applicationName);
       Storage cloudStorage = cloudBuildFactory.getCloudStorage(credentials, applicationName);
       return new GoogleCloudBuildClient(projectId, cloudBuild, cloudStorage, executor);
     }
   }
 
-  public Operation createBuild(Build build) {
+  Operation createBuild(Build build) {
     return executor.execute(() -> cloudBuild.projects().builds().create(projectId, build));
   }
 
-  public Build getBuild(String buildId) {
+  Build getBuild(String buildId) {
     return executor.execute(() -> cloudBuild.projects().builds().get(projectId, buildId));
   }
 
-  public ListBuildTriggersResponse listTriggers() {
+  ListBuildTriggersResponse listTriggers() {
     return executor.execute(() -> cloudBuild.projects().triggers().list(projectId));
   }
 
-  public Operation runTrigger(String triggerId, RepoSource repoSource) {
+  Operation runTrigger(String triggerId, RepoSource repoSource) {
     return executor.execute(
         () -> cloudBuild.projects().triggers().run(projectId, triggerId, repoSource));
   }
 
-  public InputStream fetchStorageObject(String bucket, String object, Long version)
-      throws IOException {
+  InputStream fetchStorageObject(String bucket, String object, Long version) throws IOException {
     Storage.Objects.Get getRequest = cloudStorage.objects().get(bucket, object);
     if (version != null) {
       getRequest.setGeneration(version);

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildConfig.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.igor.config;
+package com.netflix.spinnaker.igor.gcb;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.netflix.spinnaker.igor.IgorConfigurationProperties;
-import com.netflix.spinnaker.igor.gcb.*;
+import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
 import com.netflix.spinnaker.igor.polling.LockService;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
 import java.io.IOException;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildConfig.java
@@ -48,15 +48,15 @@ class GoogleCloudBuildConfig {
   GoogleCloudBuildAccountRepository googleCloudBuildAccountRepository(
       GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory,
       GoogleCloudBuildProperties googleCloudBuildProperties) {
-    GoogleCloudBuildAccountRepository credentials = new GoogleCloudBuildAccountRepository();
+    GoogleCloudBuildAccountRepository.Builder builder = GoogleCloudBuildAccountRepository.builder();
     googleCloudBuildProperties
         .getAccounts()
         .forEach(
             a -> {
               GoogleCloudBuildAccount account = googleCloudBuildAccountFactory.build(a);
-              credentials.registerAccount(a.getName(), account);
+              builder.registerAccount(a.getName(), account);
             });
-    return credentials;
+    return builder.build();
   }
 
   @Bean

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildConfig.java
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.Configuration;
   GoogleCloudBuildProperties.class,
   IgorConfigurationProperties.class
 })
-public class GoogleCloudBuildConfig {
+class GoogleCloudBuildConfig {
   @Bean
   HttpTransport httpTransport() throws IOException, GeneralSecurityException {
     return GoogleNetHttpTransport.newTrustedTransport();

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.igor.gcb;
 import com.google.api.services.cloudbuild.v1.model.Build;
 import com.google.api.services.cloudbuild.v1.model.BuildTrigger;
 import com.google.api.services.cloudbuild.v1.model.RepoSource;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
@@ -39,7 +39,7 @@ public class GoogleCloudBuildController {
 
   @RequestMapping(value = "/accounts", method = RequestMethod.GET)
   @PostFilter("hasPermission(filterObject, 'BUILD_SERVICE', 'READ')")
-  public List<String> getAccounts() {
+  public ImmutableList<String> getAccounts() {
     return googleCloudBuildAccountRepository.getAccounts();
   }
 
@@ -75,7 +75,8 @@ public class GoogleCloudBuildController {
 
   @RequestMapping(value = "/builds/{account}/{buildId}/artifacts", method = RequestMethod.GET)
   @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'READ')")
-  public List<Artifact> getArtifacts(@PathVariable String account, @PathVariable String buildId) {
+  public ImmutableList<Artifact> getArtifacts(
+      @PathVariable String account, @PathVariable String buildId) {
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getArtifacts(buildId);
   }
 
@@ -83,7 +84,7 @@ public class GoogleCloudBuildController {
       value = "/artifacts/extract/{account}",
       method = RequestMethod.PUT,
       consumes = MediaType.APPLICATION_JSON_VALUE)
-  public List<Artifact> extractArtifacts(
+  public ImmutableList<Artifact> extractArtifacts(
       @PathVariable String account, @RequestBody String serializedBuild) {
     Build build = googleCloudBuildParser.parse(serializedBuild, Build.class);
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).extractArtifacts(build);
@@ -91,7 +92,7 @@ public class GoogleCloudBuildController {
 
   @RequestMapping(value = "/triggers/{account}", method = RequestMethod.GET)
   @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'READ')")
-  public List<BuildTrigger> listTriggers(@PathVariable String account) {
+  public ImmutableList<BuildTrigger> listTriggers(@PathVariable String account) {
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).listTriggers();
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildController.java
@@ -39,7 +39,7 @@ public class GoogleCloudBuildController {
 
   @RequestMapping(value = "/accounts", method = RequestMethod.GET)
   @PostFilter("hasPermission(filterObject, 'BUILD_SERVICE', 'READ')")
-  List<String> getAccounts() {
+  public List<String> getAccounts() {
     return googleCloudBuildAccountRepository.getAccounts();
   }
 
@@ -48,7 +48,7 @@ public class GoogleCloudBuildController {
       method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'WRITE')")
-  Build createBuild(@PathVariable String account, @RequestBody String buildString) {
+  public Build createBuild(@PathVariable String account, @RequestBody String buildString) {
     Build build = googleCloudBuildParser.parse(buildString, Build.class);
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).createBuild(build);
   }
@@ -57,7 +57,7 @@ public class GoogleCloudBuildController {
       value = "/builds/{account}/{buildId}",
       method = RequestMethod.PUT,
       consumes = MediaType.APPLICATION_JSON_VALUE)
-  void updateBuild(
+  public void updateBuild(
       @PathVariable String account,
       @PathVariable String buildId,
       @Query("status") String status,
@@ -69,13 +69,13 @@ public class GoogleCloudBuildController {
 
   @RequestMapping(value = "/builds/{account}/{buildId}", method = RequestMethod.GET)
   @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'READ')")
-  Build getBuild(@PathVariable String account, @PathVariable String buildId) {
+  public Build getBuild(@PathVariable String account, @PathVariable String buildId) {
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getBuild(buildId);
   }
 
   @RequestMapping(value = "/builds/{account}/{buildId}/artifacts", method = RequestMethod.GET)
   @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'READ')")
-  List<Artifact> getArtifacts(@PathVariable String account, @PathVariable String buildId) {
+  public List<Artifact> getArtifacts(@PathVariable String account, @PathVariable String buildId) {
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).getArtifacts(buildId);
   }
 
@@ -83,7 +83,7 @@ public class GoogleCloudBuildController {
       value = "/artifacts/extract/{account}",
       method = RequestMethod.PUT,
       consumes = MediaType.APPLICATION_JSON_VALUE)
-  List<Artifact> extractArtifacts(
+  public List<Artifact> extractArtifacts(
       @PathVariable String account, @RequestBody String serializedBuild) {
     Build build = googleCloudBuildParser.parse(serializedBuild, Build.class);
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).extractArtifacts(build);
@@ -91,7 +91,7 @@ public class GoogleCloudBuildController {
 
   @RequestMapping(value = "/triggers/{account}", method = RequestMethod.GET)
   @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'READ')")
-  List<BuildTrigger> listTriggers(@PathVariable String account) {
+  public List<BuildTrigger> listTriggers(@PathVariable String account) {
     return googleCloudBuildAccountRepository.getGoogleCloudBuild(account).listTriggers();
   }
 
@@ -100,7 +100,7 @@ public class GoogleCloudBuildController {
       method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasPermission(#account, 'BUILD_SERVICE', 'WRITE')")
-  Build runTrigger(
+  public Build runTrigger(
       @PathVariable String account,
       @PathVariable String triggerId,
       @RequestBody String repoSourceString) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
@@ -21,6 +21,7 @@ import com.google.api.services.cloudbuild.v1.CloudBuildRequest;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -44,9 +45,9 @@ final class GoogleCloudBuildExecutor {
       } else if (e.getStatusCode() == 404) {
         throw new NotFoundException(e.getMessage());
       }
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
@@ -32,9 +32,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty("gcb.enabled")
 @Slf4j
-public class GoogleCloudBuildExecutor {
+final class GoogleCloudBuildExecutor {
   // TODO(ezimanyi): Consider adding retry logic here
-  public <T> T execute(RequestFactory<T> requestFactory) {
+  <T> T execute(RequestFactory<T> requestFactory) {
     try {
       CloudBuildRequest<T> request = requestFactory.get();
       return request.execute();

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutor.java
@@ -34,10 +34,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 final class GoogleCloudBuildExecutor {
   // TODO(ezimanyi): Consider adding retry logic here
-  <T> T execute(RequestFactory<T> requestFactory) {
+  <T> T execute(RequestFactory<? extends T> requestFactory) {
     try {
-      CloudBuildRequest<T> request = requestFactory.get();
-      return request.execute();
+      return requestFactory.get().execute();
     } catch (GoogleJsonResponseException e) {
       if (e.getStatusCode() == 400) {
         log.error(e.getMessage());
@@ -51,6 +50,9 @@ final class GoogleCloudBuildExecutor {
     }
   }
 
+  // This is effectively a Supplier<CloudBuildRequest<T>> except that it allows an IOException to be
+  // thrown by the get() method.
+  @FunctionalInterface
   interface RequestFactory<T> {
     CloudBuildRequest<T> get() throws IOException;
   }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
@@ -20,6 +20,7 @@ import com.google.api.client.json.JsonGenerator;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -39,7 +40,7 @@ final class GoogleCloudBuildParser {
     try {
       return jacksonFactory.createJsonParser(input).parse(destinationClass);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 
@@ -53,7 +54,7 @@ final class GoogleCloudBuildParser {
     try (JsonGenerator generator = jacksonFactory.createJsonGenerator(writer)) {
       generator.serialize(input);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
     return writer.toString();
   }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
@@ -32,10 +32,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConditionalOnProperty("gcb.enabled")
-public class GoogleCloudBuildParser {
+final class GoogleCloudBuildParser {
   private final JacksonFactory jacksonFactory = JacksonFactory.getDefaultInstance();
 
-  public final <T> T parse(String input, Class<T> destinationClass) {
+  <T> T parse(String input, Class<T> destinationClass) {
     try {
       return jacksonFactory.createJsonParser(input).parse(destinationClass);
     } catch (IOException e) {
@@ -43,12 +43,12 @@ public class GoogleCloudBuildParser {
     }
   }
 
-  public final <T> T convert(Object input, Class<T> destinationClass) {
+  <T> T convert(Object input, Class<T> destinationClass) {
     String inputString = serialize(input);
     return parse(inputString, destinationClass);
   }
 
-  public final String serialize(Object input) {
+  String serialize(Object input) {
     try {
       Writer writer = new StringWriter();
       JsonGenerator generator = jacksonFactory.createJsonGenerator(writer);

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildParser.java
@@ -49,14 +49,12 @@ final class GoogleCloudBuildParser {
   }
 
   String serialize(Object input) {
-    try {
-      Writer writer = new StringWriter();
-      JsonGenerator generator = jacksonFactory.createJsonGenerator(writer);
+    Writer writer = new StringWriter();
+    try (JsonGenerator generator = jacksonFactory.createJsonGenerator(writer)) {
       generator.serialize(input);
-      generator.flush();
-      return writer.toString();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+    return writer.toString();
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
@@ -20,7 +20,7 @@ package com.netflix.spinnaker.igor.gcb;
  * An enum of possible statuses of a GCB build. One of the primary purposes of this enum is to
  * handle ordering of statuses to allow us to order build notifications.
  */
-public enum GoogleCloudBuildStatus {
+enum GoogleCloudBuildStatus {
   STATUS_UNKNOWN(StatusType.UNKNOWN),
   QUEUED(StatusType.QUEUED),
   WORKING(StatusType.WORKING),
@@ -36,11 +36,11 @@ public enum GoogleCloudBuildStatus {
     this.statusType = statusType;
   }
 
-  public boolean greaterThanOrEqualTo(GoogleCloudBuildStatus other) {
+  boolean greaterThanOrEqualTo(GoogleCloudBuildStatus other) {
     return this.statusType.compareTo(other.statusType) >= 0;
   }
 
-  public boolean isComplete() {
+  boolean isComplete() {
     return statusType == StatusType.COMPLETE;
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildStatus.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
+import javax.annotation.Nullable;
+
 /**
  * An enum of possible statuses of a GCB build. One of the primary purposes of this enum is to
  * handle ordering of statuses to allow us to order build notifications.
@@ -42,6 +44,13 @@ enum GoogleCloudBuildStatus {
 
   boolean isComplete() {
     return statusType == StatusType.COMPLETE;
+  }
+
+  static GoogleCloudBuildStatus valueOfNullable(@Nullable String name) {
+    if (name == null) {
+      return STATUS_UNKNOWN;
+    }
+    return valueOf(name);
   }
 
   private enum StatusType {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudStorageObject.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudStorageObject.java
@@ -22,13 +22,13 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class GoogleCloudStorageObject {
+final class GoogleCloudStorageObject {
   private static final String PREFIX = "gs://";
   private final String bucket;
   private final String object;
   private final Long version;
 
-  public static GoogleCloudStorageObject fromReference(String reference) {
+  static GoogleCloudStorageObject fromReference(String reference) {
     String working = reference;
     String bucket;
     String object;
@@ -67,14 +67,14 @@ public class GoogleCloudStorageObject {
     return new GoogleCloudStorageObject(bucket, object, version);
   }
 
-  public String getVersionString() {
+  String getVersionString() {
     if (version == null) {
       return null;
     }
     return version.toString();
   }
 
-  public String getReference() {
+  String getReference() {
     String path = getName();
     if (version == null) {
       return path;
@@ -83,7 +83,7 @@ public class GoogleCloudStorageObject {
     return String.format("%s#%s", path, version);
   }
 
-  public String getName() {
+  String getName() {
     return String.format("gs://%s/%s", bucket, object);
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudStorageObject.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudStorageObject.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
+import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,7 @@ final class GoogleCloudStorageObject {
   private static final String PREFIX = "gs://";
   private final String bucket;
   private final String object;
-  private final Long version;
+  @Nullable private final Long version;
 
   static GoogleCloudStorageObject fromReference(String reference) {
     String working = reference;
@@ -67,6 +68,7 @@ final class GoogleCloudStorageObject {
     return new GoogleCloudStorageObject(bucket, object, version);
   }
 
+  @Nullable
   String getVersionString() {
     if (version == null) {
       return null;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudStorageObject.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudStorageObject.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.igor.gcb.model;
+package com.netflix.spinnaker.igor.gcb;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCredentialsService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCredentialsService.java
@@ -21,6 +21,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -36,7 +37,7 @@ class GoogleCredentialsService {
       InputStream stream = getCredentialAsStream(jsonPath);
       return loadCredential(stream);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 
@@ -48,7 +49,7 @@ class GoogleCredentialsService {
           ? credentials.createScoped(CloudBuildScopes.all())
           : credentials;
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCredentialsService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCredentialsService.java
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConditionalOnProperty("gcb.enabled")
-public class GoogleCredentialsService {
+class GoogleCredentialsService {
   GoogleCredentials getFromKey(String jsonPath) {
     try {
       InputStream stream = getCredentialAsStream(jsonPath);

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/NonnullByDefault.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/NonnullByDefault.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.gcb;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+
+/**
+ * Defaults all fields, methods, and method parameters to @Nonnull by default. TODO(ezimanyi): Move
+ * this to kork-annotations as it is likely useful outside of igor
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Nonnull
+@TypeQualifierDefault({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+public @interface NonnullByDefault {}

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/package-info.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonnullByDefault
+package com.netflix.spinnaker.igor.gcb;

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
@@ -26,17 +26,18 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GoogleCloudBuildAccountFactoryTest {
-  private GoogleCredentialsService googleCredentialsService = mock(GoogleCredentialsService.class);
-  private GoogleCloudBuildClient.Factory googleCloudBuildClientFactory =
+  private final GoogleCredentialsService googleCredentialsService =
+      mock(GoogleCredentialsService.class);
+  private final GoogleCloudBuildClient.Factory googleCloudBuildClientFactory =
       mock(GoogleCloudBuildClient.Factory.class);
-  private GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory =
+  private final GoogleCloudBuildCache.Factory googleCloudBuildCacheFactory =
       mock(GoogleCloudBuildCache.Factory.class);
-  private GoogleCloudBuildParser googleCloudBuildParser = new GoogleCloudBuildParser();
+  private final GoogleCloudBuildParser googleCloudBuildParser = new GoogleCloudBuildParser();
 
-  private GoogleCredentials googleCredentials = mock(GoogleCredentials.class);
-  private GoogleCloudBuildClient googleCloudBuildClient = mock(GoogleCloudBuildClient.class);
+  private final GoogleCredentials googleCredentials = mock(GoogleCredentials.class);
+  private final GoogleCloudBuildClient googleCloudBuildClient = mock(GoogleCloudBuildClient.class);
 
-  private GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory =
+  private final GoogleCloudBuildAccountFactory googleCloudBuildAccountFactory =
       new GoogleCloudBuildAccountFactory(
           googleCredentialsService,
           googleCloudBuildClientFactory,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepositoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepositoryTest.java
@@ -16,58 +16,66 @@
 
 package com.netflix.spinnaker.igor.gcb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
-import java.util.Collections;
-import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GoogleCloudBuildAccountRepositoryTest {
-
-  @Test(expected = NotFoundException.class)
+  @Test
   public void emptyRepository() {
-    GoogleCloudBuildAccountRepository repository = new GoogleCloudBuildAccountRepository();
-    repository.getGoogleCloudBuild("missing");
+    GoogleCloudBuildAccountRepository repository =
+        GoogleCloudBuildAccountRepository.builder().build();
+
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> repository.getGoogleCloudBuild("missing"));
   }
 
-  @Test(expected = NotFoundException.class)
+  @Test
   public void missingAccount() {
-    GoogleCloudBuildAccountRepository repository = new GoogleCloudBuildAccountRepository();
-
     GoogleCloudBuildAccount presentAccount = mock(GoogleCloudBuildAccount.class);
-    repository.registerAccount("present", presentAccount);
+    GoogleCloudBuildAccountRepository repository =
+        GoogleCloudBuildAccountRepository.builder()
+            .registerAccount("present", presentAccount)
+            .build();
 
-    repository.getGoogleCloudBuild("missing");
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> repository.getGoogleCloudBuild("missing"));
   }
 
   @Test
   public void presentAccount() {
-    GoogleCloudBuildAccountRepository repository = new GoogleCloudBuildAccountRepository();
-
     GoogleCloudBuildAccount presentAccount = mock(GoogleCloudBuildAccount.class);
-    repository.registerAccount("present", presentAccount);
+    GoogleCloudBuildAccountRepository repository =
+        GoogleCloudBuildAccountRepository.builder()
+            .registerAccount("present", presentAccount)
+            .build();
 
-    GoogleCloudBuildAccount retrievedAccount = repository.getGoogleCloudBuild("present");
-    assertSame(presentAccount, retrievedAccount);
+    assertThat(repository.getGoogleCloudBuild("present")).isEqualTo(presentAccount);
   }
 
   @Test
-  public void getAccounts() {
-    GoogleCloudBuildAccountRepository repository = new GoogleCloudBuildAccountRepository();
+  public void getAccountsEmpty() {
+    GoogleCloudBuildAccountRepository repository =
+        GoogleCloudBuildAccountRepository.builder().build();
 
+    assertThat(repository.getAccounts()).isEmpty();
+  }
+
+  @Test
+  public void getAccountsNotEmpty() {
     GoogleCloudBuildAccount presentAccount = mock(GoogleCloudBuildAccount.class);
+    GoogleCloudBuildAccountRepository repository =
+        GoogleCloudBuildAccountRepository.builder()
+            .registerAccount("present", presentAccount)
+            .build();
 
-    List<String> accountsBefore = repository.getAccounts();
-    assertTrue(accountsBefore.isEmpty());
-
-    repository.registerAccount("present", presentAccount);
-
-    List<String> accountsAfter = repository.getAccounts();
-    assertEquals(accountsAfter, Collections.singletonList("present"));
+    assertThat(repository.getAccounts()).containsExactly("present");
   }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
@@ -38,7 +38,6 @@ import com.google.api.services.cloudbuild.v1.model.ListBuildTriggersResponse;
 import com.google.api.services.cloudbuild.v1.model.Operation;
 import com.google.api.services.cloudbuild.v1.model.RepoSource;
 import com.netflix.spinnaker.igor.RedisConfig;
-import com.netflix.spinnaker.igor.config.GoogleCloudBuildConfig;
 import com.netflix.spinnaker.igor.config.LockManagerConfig;
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers;
 import java.util.ArrayList;

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTestConfig.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTestConfig.java
@@ -65,7 +65,7 @@ public class GoogleCloudBuildTestConfig {
       @Override
       GoogleCredentials getFromKey(String jsonPath) {
         if (!jsonPath.equals("/path/to/some/file")) {
-          return null;
+          throw new RuntimeException("Could not generate GoogleCredentials");
         }
         // Create a mock credential whose bearer token is always "test-token"
         try {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudStorageObjectSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudStorageObjectSpec.groovy
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.igor.gcb.model
+package com.netflix.spinnaker.igor.gcb
 
+import com.netflix.spinnaker.igor.gcb.GoogleCloudStorageObject
 import spock.lang.Specification
 import spock.lang.Unroll
 


### PR DESCRIPTION
* refactor(gcb): Move all GCB files into the same package 

  The GoolgeCloudBuildArtifact and GoolgeCloudBuildConfig classes were in different packages; by moving these to the same package as the other GCB classes we'll be able to reduce the visibility of many GCB classes to package-private.

* refactor(gcb): Make packages package-private and final where possible 

  The only external contract the com.netflix.spinnaker.igor.gcb package intends to provide is the GoogleCloudBuildController component; everything else is an implementation detail.

  To better communicate and enforce this:
  * Make the controller (and all mapped methods) public; some of these were package-private before which works because Spring uses reflection to call controllers, but we should document them accurately as being called outside of the package.
  * Make all other classes (and methods) that were public package-private

  Finally (no pun intended), none of the classes in this package were designed for inheritance so mark them final wherever possible. The cases where it is not possible are:
  * Classes that are mocked in tests as a final class cannot be mocked; in this case, we'll rely on the fact that the class is package-private so at least can't be subclassed outside the package.
  * Spring controller and configuration classes aren't allowed to be final

* refactor(gcb): Add nullity annotations 

  Add default Nonnull to all methods, parameters and fields across the package, and annotate the few exceptions with Nullable.

  This does surface a few places where we could consider replacing a null with either an Optional or an appropriate null object, but this PR does not tackle any of those refactors.

* refactor(gcb): A few minor refactors 

  * Replace statement lambda with expression lambda
  * Make GoogleCloudBuildExecutor nicer to clients by adding type bounds.
  * Clean up the null checks of build status by using a null-safe valueOf that returns UNKNOWN. (This keeps the existing behavior as UNKNOWN status has the lowest priority, so null status continues to have the lowest priority).
  * Use try-with-resources on JsonGenerator so that it always gets closed before we use the underlying writer, avoiding the need to explicitly flush.

* refactor(gcb): Make GCB account repository immutable 

  As we never add/remove accounts after startup, the repository should be immutable. Maybe at some point if we support dynamic accounts we should change this (but at that point we'd need to think about thread safety anyway).

  This commit also makes a few changes to the tests on that class; they had to be updated anyway to use the new Builder class, and while I was there I improved the assertions to make them more clear.

* refactor(gcb): Update GCB controller to return immutable lists 

  Return immutable lists from the controller, and convert dependent code to also use immutable lists.