### PR TITLE
fix(stash): Pass thru any HTTP errors from stash

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmController.java
@@ -87,9 +87,8 @@ public class ManagedDeliveryScmController {
         status = HttpStatus.BAD_REQUEST;
       } else if (e instanceof RetrofitError) {
         RetrofitError re = (RetrofitError) e;
-        if (re.getKind() == RetrofitError.Kind.HTTP
-            && re.getResponse().getStatus() == HttpStatus.NOT_FOUND.value()) {
-          status = HttpStatus.NOT_FOUND;
+        if (re.getKind() == RetrofitError.Kind.HTTP) {
+          status = HttpStatus.valueOf(re.getResponse().getStatus());
           errorDetails = re.getBodyAs(Map.class);
         } else {
           errorDetails = "Error calling downstream system: " + re.getMessage();


### PR DESCRIPTION
I noticed that the UI was not showing any helpful error information when we failed to retrieve the delivery config file from SCM, say due to missing permissions in Stash. This allows any error from stash to be returned to orca so it will show up on the UI.