### PR TITLE
fix(jenkins): Parse build number from Location header correctly

### DIFF
--- a/igor-monitor-jenkins/src/main/java/com/netflix/spinnaker/igor/jenkins/JenkinsService.java
+++ b/igor-monitor-jenkins/src/main/java/com/netflix/spinnaker/igor/jenkins/JenkinsService.java
@@ -248,7 +248,9 @@ public class JenkinsService
 
     String[] parts =
         StreamSupport.stream(QUEUED_BUILD_SPLITTER.split(queuedLocation).spliterator(), false)
+            .filter(it -> !Strings.isNullOrEmpty(it))
             .toArray(String[]::new);
+
     return Integer.parseInt(parts[parts.length - 1]);
   }
 

--- a/igor-monitor-jenkins/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsServiceSpec.groovy
+++ b/igor-monitor-jenkins/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsServiceSpec.groovy
@@ -809,4 +809,21 @@ class JenkinsServiceSpec extends Specification {
     thrown(InvalidJobParameterException)
   }
 
+  void "parses build number from response"() {
+    given:
+    Response response = new Response(
+      "whatever",
+      201,
+      "Created",
+      [new Header("Location", "https://example.net/queue/item/12/")],
+      null
+    )
+
+    when:
+    int buildNumber = JenkinsService.getBuildNumberFromResponse("hello", response)
+
+    then:
+    buildNumber == 12
+  }
+
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildEvent.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildEvent.java
@@ -17,8 +17,10 @@ package com.netflix.spinnaker.igor.gitlabci;
 
 import com.netflix.spinnaker.igor.history.model.BuildEvent;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class GitlabCiBuildEvent extends BuildEvent<GitlabCiBuildContent> {
   private GitlabCiBuildContent content;
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildEvent.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildEvent.java
@@ -18,9 +18,11 @@ package com.netflix.spinnaker.igor.wercker;
 import com.netflix.spinnaker.igor.history.model.BuildEvent;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class WerckerBuildEvent extends BuildEvent<WerckerBuildContent> {
   private WerckerBuildContent content;
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildEvent.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildEvent.java
@@ -17,8 +17,10 @@ package com.netflix.spinnaker.igor.concourse;
 
 import com.netflix.spinnaker.igor.history.model.BuildEvent;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class ConcourseBuildEvent extends BuildEvent<ConcourseBuildContent> {
   private ConcourseBuildContent content;
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildEvent.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildEvent.java
@@ -18,9 +18,11 @@ package com.netflix.spinnaker.igor.travis;
 import com.netflix.spinnaker.igor.history.model.BuildEvent;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class TravisBuildEvent extends BuildEvent<TravisBuildContent> {
   private TravisBuildContent content;
 }


### PR DESCRIPTION
Also fixed some compiler warnings.

Issue was that location headers from Jenkins include a final trailing `/`. Turns out Groovy's positional indexes on arrays are off-by-one from what Java is.