### PR TITLE
feat(codebuild): Add API to list projects

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/codebuild/AwsCodeBuildAccount.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/codebuild/AwsCodeBuildAccount.java
@@ -22,6 +22,9 @@ import com.amazonaws.services.codebuild.AWSCodeBuildClientBuilder;
 import com.amazonaws.services.codebuild.model.BatchGetBuildsRequest;
 import com.amazonaws.services.codebuild.model.Build;
 import com.amazonaws.services.codebuild.model.BuildArtifacts;
+import com.amazonaws.services.codebuild.model.ListProjectsRequest;
+import com.amazonaws.services.codebuild.model.ListProjectsResult;
+import com.amazonaws.services.codebuild.model.ProjectSortByType;
 import com.amazonaws.services.codebuild.model.StartBuildRequest;
 import com.amazonaws.services.codebuild.model.StopBuildRequest;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
@@ -54,6 +57,25 @@ public class AwsCodeBuildAccount {
                 .withRequestHandlers(new AwsCodeBuildRequestHandler())
                 .withRegion(region)
                 .build();
+  }
+
+  // The number of projects has an upper limit of 5000 per region per account
+  // P99 latency could be high if user has more than 1000 projects
+  public List<String> getProjects() {
+    List<String> projects = new ArrayList<>();
+    String nextToken = null;
+
+    do {
+      ListProjectsResult result =
+          client.listProjects(
+              new ListProjectsRequest()
+                  .withSortBy(ProjectSortByType.NAME)
+                  .withNextToken(nextToken));
+      projects.addAll(result.getProjects());
+      nextToken = result.getNextToken();
+    } while (nextToken != null);
+
+    return projects;
   }
 
   public Build startBuild(StartBuildRequest request) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/codebuild/AwsCodeBuildController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/codebuild/AwsCodeBuildController.java
@@ -40,6 +40,11 @@ public class AwsCodeBuildController {
     return awsCodeBuildAccountRepository.getAccountNames();
   }
 
+  @RequestMapping(value = "/projects/{account}", method = RequestMethod.GET)
+  List<String> getProjects(@PathVariable String account) {
+    return awsCodeBuildAccountRepository.getAccount(account).getProjects();
+  }
+
   @RequestMapping(
       value = "/builds/start/{account}",
       method = RequestMethod.POST,


### PR DESCRIPTION
Add a new API to get all projects for specific account and region. This API
iterates over all pages and aggregates the results. The number of projects
per region per account is at most 5000. Each page contains 100 results, so
at most 50 calls will be made to fetch all projects. I was thinking about
returning the nextToken to caller and let caller do pagination. However, I
found out that none of list* APIs igor provides supports pagination. Therefore
I decide to follow the pattern to return all results in one batch. It should
be fine since the number of projects is less than 100 in most cases.