### PR TITLE
docs(travis): Use travis-ci.com rather than travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,15 +151,15 @@ travis:
   # Travis names are prefixed with travis- inside igor.
   masters:
   - name: ci # This will show as travis-ci inside spinnaker.
-    baseUrl: https://travis-ci.org
-    address: https://api.travis-ci.org
+    baseUrl: https://travis-ci.com
+    address: https://api.travis-ci.com
     githubToken: 6a7729bdba8c4f9abc58b175213d83f072d1d832
   regexes:
   - /Upload https?:\/\/.+\/(.+\.(deb|rpm))/
 ```
 
 When parsing artifact information from Travis builds, igor uses a default regex
-that will match on output from the `art` CLI tool.  Different regexes than the
+that will match on output from the `jfrog rt`/`art` CLI tool.  Different regexes than the
 default may be configured using the `regexes` list.
 
 

--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -41,8 +41,8 @@ server.port: 8088
 #  Travis names are prefixed with travis- inside igor.
 #  masters:
 #    - name: ci # This will show as travis-ci inside spinnaker.
-#      baseUrl: https://travis-ci.org
-#      address: https://api.travis-ci.org
+#      baseUrl: https://travis-ci.com
+#      address: https://api.travis-ci.com
 #      githubToken: XXXXXX
 #      numberOfRepositories: 25 # How many repositories the travis integration should fetch from the api each time the
 #                               # poller runs. Should be set a bit higher than the expected maximum number of


### PR DESCRIPTION
https://github.com/spinnaker/spinnaker/issues/5459
https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps