### PR TITLE
fix(travis): Limit the number of returned builds

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisConfig.java
@@ -96,6 +96,7 @@ public class TravisConfig {
                           host.getBaseUrl(),
                           host.getGithubToken(),
                           host.getNumberOfJobs(),
+                          host.getBuildResultLimit(),
                           client,
                           travisCache,
                           artifactDecorator,

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/TravisProperties.java
@@ -59,6 +59,13 @@ public class TravisProperties implements BuildServerProperties<TravisProperties.
     @Deprecated private int numberOfRepositories;
     /** Defines how many jobs Igor should retrieve per polling cycle. Defaults to 100. */
     private int numberOfJobs = 100;
+    /**
+     * Defines how many builds Igor should return when querying for builds for a specific repo. This
+     * affects for instance how many builds that will be displayed in the drop down when starting a
+     * manual execution of a pipeline. If set too high, the Travis API might return an error for
+     * jobs that writes a lot of logs, which is why the default setting is a bit conservative.
+     */
+    private int buildResultLimit = 10;
 
     private Integer itemUpperThreshold;
     private Permissions.Builder permissions = new Permissions.Builder();

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
@@ -71,7 +71,8 @@ import retrofit.RetrofitError;
 
 public class TravisService implements BuildOperations, BuildProperties {
 
-  static final int TRAVIS_BUILD_RESULT_LIMIT = 100;
+  static final int TRAVIS_JOB_RESULT_LIMIT = 100;
+  static final int TRAVIS_BUILD_RESULT_LIMIT = 10;
 
   private final Logger log = LoggerFactory.getLogger(getClass());
   private final String baseUrl;
@@ -321,7 +322,7 @@ public class TravisService implements BuildOperations, BuildProperties {
                                     .collect(Collectors.joining(",")),
                                 addLogCompleteIfApplicable("job.build"),
                                 getLimit(page, limit),
-                                (page - 1) * TRAVIS_BUILD_RESULT_LIMIT))
+                                (page - 1) * TRAVIS_JOB_RESULT_LIMIT))
                     .flatMap(v3jobs -> v3jobs.getJobs().stream())
                     .sorted(Comparator.comparing(V3Job::getId))
                     .collect(Collectors.toList()),
@@ -561,8 +562,8 @@ public class TravisService implements BuildOperations, BuildProperties {
   }
 
   protected int calculatePagination(int numberOfJobs) {
-    int intermediate = numberOfJobs / TRAVIS_BUILD_RESULT_LIMIT;
-    if (numberOfJobs % TRAVIS_BUILD_RESULT_LIMIT > 0) {
+    int intermediate = numberOfJobs / TRAVIS_JOB_RESULT_LIMIT;
+    if (numberOfJobs % TRAVIS_JOB_RESULT_LIMIT > 0) {
       intermediate += 1;
     }
     return intermediate;
@@ -570,9 +571,9 @@ public class TravisService implements BuildOperations, BuildProperties {
 
   int getLimit(int page, int numberOfBuilds) {
     return page == calculatePagination(numberOfBuilds)
-            && (numberOfBuilds % TRAVIS_BUILD_RESULT_LIMIT > 0)
-        ? (numberOfBuilds % TRAVIS_BUILD_RESULT_LIMIT)
-        : TRAVIS_BUILD_RESULT_LIMIT;
+            && (numberOfBuilds % TRAVIS_JOB_RESULT_LIMIT > 0)
+        ? (numberOfBuilds % TRAVIS_JOB_RESULT_LIMIT)
+        : TRAVIS_JOB_RESULT_LIMIT;
   }
 
   private static String extractBranchFromRepoSlug(String inputRepoSlug) {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -153,7 +153,7 @@ class InfoControllerSpec extends Specification {
             new Permissions.Builder()
                 .add(Authorization.READ, ['group-1', 'group-2'])
                 .add(Authorization.WRITE, 'group-2').build())
-        TravisService travisService = new TravisService('travis-baz', null, null, 100, null, null, Optional.empty(), [], null,
+        TravisService travisService = new TravisService('travis-baz', null, null, 100, 10, null, null, Optional.empty(), [], null,
             new Permissions.Builder()
                 .add(Authorization.READ, ['group-3', 'group-4'])
                 .add(Authorization.WRITE, 'group-3').build(), false)

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -55,11 +55,13 @@ class TravisServiceSpec extends Specification {
     @Shared
     Optional<ArtifactDecorator> artifactDecorator
 
+    private static int TRAVIS_BUILD_RESULT_LIMIT = 10;
+
     void setup() {
         client = Mock()
         travisCache = Mock()
         artifactDecorator = Optional.of(new ArtifactDecorator([new DebDetailsDecorator(), new RpmDetailsDecorator()], null))
-        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', TravisService.TRAVIS_JOB_RESULT_LIMIT, client, travisCache, artifactDecorator, [], "travis.buildMessage", Permissions.EMPTY, false)
+        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', TravisService.TRAVIS_JOB_RESULT_LIMIT, TRAVIS_BUILD_RESULT_LIMIT, client, travisCache, artifactDecorator, [], "travis.buildMessage", Permissions.EMPTY, false)
 
         AccessToken accessToken = new AccessToken()
         accessToken.accessToken = "someToken"
@@ -99,7 +101,7 @@ class TravisServiceSpec extends Specification {
     @Unroll
     def "getLatestBuilds() with #numberOfJobs jobs should query Travis #expectedNumberOfPages time(s)"() {
         given:
-        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', numberOfJobs, client, travisCache, artifactDecorator, [], "travis.buildMessage", Permissions.EMPTY, false)
+        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', numberOfJobs, TRAVIS_BUILD_RESULT_LIMIT, client, travisCache, artifactDecorator, [], "travis.buildMessage", Permissions.EMPTY, false)
         AccessToken accessToken = new AccessToken()
         accessToken.accessToken = "someToken"
         service.accessToken = accessToken
@@ -303,7 +305,7 @@ class TravisServiceSpec extends Specification {
                 ])],
             content: "log"
         ])
-        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', 25, client, travisCache, artifactDecorator, [], "travis.buildMessage", Permissions.EMPTY, legacyLogFetching)
+        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', 25, TRAVIS_BUILD_RESULT_LIMIT, client, travisCache, artifactDecorator, [], "travis.buildMessage", Permissions.EMPTY, legacyLogFetching)
         AccessToken accessToken = new AccessToken()
         accessToken.accessToken = "someToken"
         service.accessToken = accessToken
@@ -312,7 +314,7 @@ class TravisServiceSpec extends Specification {
         def genericBuilds = service.getBuilds("my/slug")
 
         then:
-        1 * client.v3builds("token someToken", "my/slug", TravisService.TRAVIS_BUILD_RESULT_LIMIT,
+        1 * client.v3builds("token someToken", "my/slug", TRAVIS_BUILD_RESULT_LIMIT,
             legacyLogFetching ? null : "build.log_complete") >> new V3Builds([builds: [build]])
         (isLogCompleteFlag ? 0 : 1) * travisCache.getJobLog("travis-ci", 2) >> (isLogCached ? "log" : null)
         (!isLogCompleteFlag && !isLogCached ? 1 : 0) * client.jobLog("token someToken", 2) >> v3log

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -59,7 +59,7 @@ class TravisServiceSpec extends Specification {
         client = Mock()
         travisCache = Mock()
         artifactDecorator = Optional.of(new ArtifactDecorator([new DebDetailsDecorator(), new RpmDetailsDecorator()], null))
-        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', TravisService.TRAVIS_BUILD_RESULT_LIMIT, client, travisCache, artifactDecorator, [], "travis.buildMessage", Permissions.EMPTY, false)
+        service = new TravisService('travis-ci', 'http://my.travis.ci', 'someToken', TravisService.TRAVIS_JOB_RESULT_LIMIT, client, travisCache, artifactDecorator, [], "travis.buildMessage", Permissions.EMPTY, false)
 
         AccessToken accessToken = new AccessToken()
         accessToken.accessToken = "someToken"
@@ -106,7 +106,7 @@ class TravisServiceSpec extends Specification {
 
 
         def listOfJobs = (1..numberOfJobs).collect { createJob(it) }
-        def partitionedJobs = listOfJobs.collate(TravisService.TRAVIS_BUILD_RESULT_LIMIT).collect { partition ->
+        def partitionedJobs = listOfJobs.collate(TravisService.TRAVIS_JOB_RESULT_LIMIT).collect { partition ->
             V3Jobs jobs = new V3Jobs()
             jobs.jobs = partition
             return jobs
@@ -122,7 +122,7 @@ class TravisServiceSpec extends Specification {
                 [TravisBuildState.passed, TravisBuildState.started, TravisBuildState.errored, TravisBuildState.failed, TravisBuildState.canceled].join(","),
                 "job.build,build.log_complete",
                 service.getLimit(page, numberOfJobs),
-                (page - 1) * TravisService.TRAVIS_BUILD_RESULT_LIMIT) >> partitionedJobs[page - 1]
+                (page - 1) * TravisService.TRAVIS_JOB_RESULT_LIMIT) >> partitionedJobs[page - 1]
         }
         builds.size() == numberOfJobs
 


### PR DESCRIPTION
If you have builds that creates very large logs, the number of builds returned can cause issues or timeouts in the Travis API. Limiting the number of builds seems to mitigate the issue.

Drawbacks: This will limit the number of builds you'll see in the build drop down of a manual execution to 10 (but it won't affect the build monitor at all as it uses another endpoint).