### PR TITLE
feat(monitor): Add plugins monitor

### DIFF
--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/IgorConfigurationProperties.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/IgorConfigurationProperties.java
@@ -156,6 +156,8 @@ public class IgorConfigurationProperties {
     /** Config for keel connectivity. */
     @NestedConfigurationProperty private ServiceConfiguration keel = new ServiceConfiguration();
 
+    @NestedConfigurationProperty private ServiceConfiguration front50 = new ServiceConfiguration();
+
     @Data
     public static class ServiceConfiguration {
       /**

--- a/igor-monitor-plugins/igor-monitor-plugins.gradle
+++ b/igor-monitor-plugins/igor-monitor-plugins.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+dependencies {
+  implementation project(":igor-core")
+
+  implementation "com.netflix.spinnaker.kork:kork-artifacts"
+  implementation "com.netflix.spinnaker.kork:kork-core"
+  implementation "com.netflix.spinnaker.kork:kork-jedis"
+  implementation "com.netflix.spinnaker.kork:kork-security"
+
+  implementation "org.springframework.boot:spring-boot-starter-actuator"
+
+  implementation "com.squareup.retrofit:retrofit"
+}

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/PluginCache.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/PluginCache.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.plugins;
+
+import com.netflix.spinnaker.igor.IgorConfigurationProperties;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import java.time.Instant;
+import jline.internal.Nullable;
+
+/** TODO(rz): Currently only supports front50 as a repository. */
+public class PluginCache {
+
+  private static final String ID = "plugins";
+  private static final String FRONT50_REPOSITORY = "front50";
+
+  private final RedisClientDelegate redisClientDelegate;
+  private final IgorConfigurationProperties igorConfigurationProperties;
+
+  public PluginCache(
+      RedisClientDelegate redisClientDelegate,
+      IgorConfigurationProperties igorConfigurationProperties) {
+    this.redisClientDelegate = redisClientDelegate;
+    this.igorConfigurationProperties = igorConfigurationProperties;
+  }
+
+  public void setLastPollCycleTimestamp(Instant timestamp) {
+    redisClientDelegate.withCommandsClient(
+        c -> {
+          c.hset(key(), FRONT50_REPOSITORY, String.valueOf(timestamp.toEpochMilli()));
+        });
+  }
+
+  @Nullable
+  public Instant getLastPollCycleTimestamp() {
+    return redisClientDelegate.withCommandsClient(
+        c -> {
+          String timestamp = c.hget(key(), FRONT50_REPOSITORY);
+          if (timestamp == null) {
+            return null;
+          } else {
+            return Instant.ofEpochMilli(Long.parseLong(timestamp));
+          }
+        });
+  }
+
+  private String key() {
+    return igorConfigurationProperties.getSpinnaker().getJedis().getPrefix() + ":" + ID;
+  }
+}

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/PluginsBuildMonitor.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/PluginsBuildMonitor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.plugins;
+
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.igor.IgorConfigurationProperties;
+import com.netflix.spinnaker.igor.history.EchoService;
+import com.netflix.spinnaker.igor.plugins.front50.PluginReleaseService;
+import com.netflix.spinnaker.igor.plugins.model.PluginEvent;
+import com.netflix.spinnaker.igor.plugins.model.PluginRelease;
+import com.netflix.spinnaker.igor.polling.*;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.Data;
+
+public class PluginsBuildMonitor
+    extends CommonPollingMonitor<
+        PluginsBuildMonitor.PluginDelta, PluginsBuildMonitor.PluginPollingDelta> {
+
+  private final PluginReleaseService pluginInfoService;
+  private final PluginCache cache;
+  private final Optional<EchoService> echoService;
+
+  public PluginsBuildMonitor(
+      IgorConfigurationProperties igorProperties,
+      Registry registry,
+      DynamicConfigService dynamicConfigService,
+      Optional<DiscoveryClient> discoveryClient,
+      Optional<LockService> lockService,
+      PluginReleaseService pluginInfoService,
+      PluginCache cache,
+      Optional<EchoService> echoService) {
+    super(igorProperties, registry, dynamicConfigService, discoveryClient, lockService);
+    this.pluginInfoService = pluginInfoService;
+    this.cache = cache;
+    this.echoService = echoService;
+  }
+
+  @Override
+  protected PluginPollingDelta generateDelta(PollContext ctx) {
+    return new PluginPollingDelta(
+        pluginInfoService.getPluginReleasesSince(cache.getLastPollCycleTimestamp()).stream()
+            .map(PluginDelta::new)
+            .collect(Collectors.toList()));
+  }
+
+  @Override
+  protected void commitDelta(PluginPollingDelta delta, boolean sendEvents) {
+    delta.items.forEach(
+        item -> {
+          if (sendEvents) {
+            postEvent(item.pluginRelease);
+            log.debug("{} event posted", item.pluginRelease);
+          }
+        });
+
+    delta.items.stream()
+        .map(it -> Instant.parse(it.pluginRelease.getTimestamp()))
+        .max(Comparator.naturalOrder())
+        .ifPresent(cache::setLastPollCycleTimestamp);
+  }
+
+  private void postEvent(PluginRelease release) {
+    if (!echoService.isPresent()) {
+      log.warn("Cannot send new plugin notification: Echo is not configured");
+      registry.counter(
+          missedNotificationId.withTag("monitor", PluginsBuildMonitor.class.getSimpleName()));
+    } else if (release != null) {
+      AuthenticatedRequest.allowAnonymous(
+          () -> echoService.get().postEvent(new PluginEvent(release)));
+    }
+  }
+
+  @Override
+  public void poll(boolean sendEvents) {
+    pollSingle(new PollContext("front50"));
+  }
+
+  @Override
+  public String getName() {
+    return "pluginsMonitor";
+  }
+
+  @Data
+  static class PluginDelta implements DeltaItem {
+    private final PluginRelease pluginRelease;
+  }
+
+  @Data
+  static class PluginPollingDelta implements PollingDelta<PluginDelta> {
+    private final List<PluginDelta> items;
+  }
+}

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/Front50Service.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/Front50Service.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.plugins.front50;
+
+import java.util.List;
+import retrofit.http.GET;
+
+public interface Front50Service {
+
+  @GET("/pluginInfo")
+  List<PluginInfo> listPluginInfo();
+}

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginInfo.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.plugins.front50;
+
+import java.util.List;
+
+public class PluginInfo {
+
+  final String id;
+  final List<Release> releases;
+
+  public PluginInfo(String id, List<Release> releases) {
+    this.id = id;
+    this.releases = releases;
+  }
+
+  static class Release {
+    final String version;
+    final String date;
+    final String requires;
+    final String url;
+    final boolean preferred;
+    final String lastModified;
+
+    public Release(
+        String version,
+        String date,
+        String requires,
+        String url,
+        boolean preferred,
+        String lastModified) {
+      this.version = version;
+      this.date = date;
+      this.requires = requires;
+      this.url = url;
+      this.preferred = preferred;
+      this.lastModified = lastModified;
+    }
+  }
+}

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginReleaseService.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginReleaseService.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.plugins.front50;
+
+import com.netflix.spinnaker.igor.plugins.model.PluginRelease;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PluginReleaseService {
+
+  private static final Logger log = LoggerFactory.getLogger(PluginReleaseService.class);
+
+  private final Front50Service front50Service;
+
+  public PluginReleaseService(Front50Service front50Service) {
+    this.front50Service = front50Service;
+  }
+
+  public List<PluginRelease> getPluginReleasesSince(Instant timestamp) {
+    if (timestamp == null) {
+      return getPluginReleases();
+    }
+
+    return getPluginReleases().stream()
+        .filter(
+            r -> {
+              try {
+                return Instant.parse(r.getTimestamp()).isAfter(timestamp);
+              } catch (DateTimeParseException e) {
+                log.error(
+                    "Failed parsing plugin timestamp for '{}': '{}', cannot index plugin",
+                    r.getPluginId(),
+                    getTimestamp(r));
+                return false;
+              }
+            })
+        .collect(Collectors.toList());
+  }
+
+  private List<PluginRelease> getPluginReleases() {
+    return AuthenticatedRequest.allowAnonymous(
+        () ->
+            front50Service.listPluginInfo().stream()
+                .flatMap(
+                    info ->
+                        info.releases.stream()
+                            .map(
+                                release ->
+                                    new PluginRelease(
+                                        info.id,
+                                        release.version,
+                                        release.date,
+                                        PluginRequiresParser.parseRequires(release.requires),
+                                        release.url,
+                                        release.preferred,
+                                        release.lastModified)))
+                .collect(Collectors.toList()));
+  }
+
+  private String getTimestamp(PluginRelease release) {
+    return Optional.ofNullable(release.getLastModified()).orElse(release.getReleaseDate());
+  }
+}

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginRequiresParser.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginRequiresParser.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.plugins.front50;
+
+import com.google.common.base.Splitter;
+import com.netflix.spinnaker.igor.plugins.model.PluginRelease;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class PluginRequiresParser {
+
+  private static final Logger log = LoggerFactory.getLogger(PluginRequiresParser.class);
+
+  private static final Splitter SPLITTER = Splitter.on(",");
+  private static final Pattern PATTERN =
+      Pattern.compile(
+          "^(?<service>[\\w\\-]+)(?<operator>[><=]{1,2})(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)$");
+
+  static List<PluginRelease.ServiceRequirement> parseRequires(String requires) {
+    List<String> requirements = SPLITTER.splitToList(requires);
+
+    return requirements.stream()
+        .map(
+            r -> {
+              Matcher m = PATTERN.matcher(r);
+              if (!m.matches()) {
+                log.error("Failed parsing plugin requires field '{}'", r);
+                return null;
+              }
+              return new PluginRelease.ServiceRequirement(
+                  m.group("service"), m.group("operator"), m.group("version"));
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+}

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/model/PluginEvent.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/model/PluginEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.plugins.model;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.igor.history.model.Event;
+import java.util.Map;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class PluginEvent extends Event {
+
+  private final PluginRelease content;
+  private final Map<String, String> details =
+      ImmutableMap.<String, String>builder().put("type", "plugin").put("source", "front50").build();
+
+  public PluginEvent(PluginRelease pluginRelease) {
+    this.content = pluginRelease;
+  }
+}

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/model/PluginRelease.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/model/PluginRelease.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.plugins.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.List;
+import java.util.Optional;
+
+public class PluginRelease {
+  private final String pluginId;
+  private final String version;
+  private final String releaseDate;
+  private final List<ServiceRequirement> requires;
+  private final String binaryUrl;
+  private final boolean preferred;
+  private final String lastModified;
+
+  public PluginRelease(
+      String pluginId,
+      String version,
+      String releaseDate,
+      List<ServiceRequirement> requires,
+      String binaryUrl,
+      boolean preferred,
+      String lastModified) {
+    this.pluginId = pluginId;
+    this.version = version;
+    this.releaseDate = releaseDate;
+    this.requires = requires;
+    this.binaryUrl = binaryUrl;
+    this.preferred = preferred;
+    this.lastModified = lastModified;
+  }
+
+  public String getPluginId() {
+    return pluginId;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getReleaseDate() {
+    return releaseDate;
+  }
+
+  public List<ServiceRequirement> getRequires() {
+    return requires;
+  }
+
+  public String getBinaryUrl() {
+    return binaryUrl;
+  }
+
+  public boolean isPreferred() {
+    return preferred;
+  }
+
+  public String getLastModified() {
+    return lastModified;
+  }
+
+  @JsonIgnore
+  public String getTimestamp() {
+    return Optional.ofNullable(lastModified).orElse(releaseDate);
+  }
+
+  public static class ServiceRequirement {
+    private final String service;
+    private final String operator;
+    private final String version;
+
+    public ServiceRequirement(String service, String operator, String version) {
+      this.service = service;
+      this.operator = operator;
+      this.version = version;
+    }
+
+    public String getService() {
+      return service;
+    }
+
+    public String getOperator() {
+      return operator;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+  }
+}

--- a/igor-monitor-plugins/src/test/groovy/com/netflix/spinnaker/igor/plugins/front50/PluginReleaseServiceSpec.groovy
+++ b/igor-monitor-plugins/src/test/groovy/com/netflix/spinnaker/igor/plugins/front50/PluginReleaseServiceSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.igor.plugins.front50
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+class PluginReleaseServiceSpec extends Specification {
+
+  @Shared
+  Clock clock = Clock.fixed(Instant.EPOCH.plus(1, ChronoUnit.DAYS), ZoneId.systemDefault())
+
+  Front50Service front50Service = Mock()
+  @Subject PluginReleaseService subject = new PluginReleaseService(front50Service)
+
+  @Unroll
+  def "gets releases since timestamp"() {
+    given:
+    PluginInfo plugin1 = new PluginInfo("plugin1", [
+      release("1.0.0", clock.instant()),
+      release("1.0.1", clock.instant().plus(1, ChronoUnit.DAYS))
+    ])
+
+    when:
+    def result = subject.getPluginReleasesSince(timestamp)
+
+    then:
+    result*.version == expectedVersions
+    1 * front50Service.listPluginInfo() >> [plugin1]
+
+    where:
+    timestamp                                  || expectedVersions
+    null                                       || ["1.0.0", "1.0.1"]
+    clock.instant().minus(1, ChronoUnit.HOURS) || ["1.0.0", "1.0.1"]
+    clock.instant()                            || ["1.0.1"]
+    clock.instant().plus(1, ChronoUnit.HOURS)  || ["1.0.1"]
+    clock.instant().plus(2, ChronoUnit.DAYS)   || []
+  }
+
+  private PluginInfo.Release release(String version, Instant lastModified) {
+    return new PluginInfo.Release(
+      version,
+      clock.instant().toString(),
+      "orca>=0.0.0",
+      "http://example.com/file.zip",
+      true,
+      lastModified.toString(),
+    )
+  }
+}

--- a/igor-monitor-plugins/src/test/groovy/com/netflix/spinnaker/igor/plugins/front50/PluginRequiresParserSpec.groovy
+++ b/igor-monitor-plugins/src/test/groovy/com/netflix/spinnaker/igor/plugins/front50/PluginRequiresParserSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.igor.plugins.front50
+
+import com.netflix.spinnaker.igor.plugins.model.PluginRelease
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PluginRequiresParserSpec extends Specification {
+
+  def "parses a requires spec"() {
+    given:
+    String requires = "orca>=1.0.0,deck>=0.0.0"
+
+    when:
+    List<PluginRelease.ServiceRequirement> result = PluginRequiresParser.parseRequires(requires)
+
+    then:
+    result*.service == ["orca", "deck"]
+    result*.operator == [">=", ">="]
+    result*.version == ["1.0.0", "0.0.0"]
+  }
+}

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -18,6 +18,7 @@ test {
 dependencies {
     implementation project(":igor-core")
     implementation project(":igor-monitor-artifactory")
+    implementation project(":igor-monitor-plugins")
 
     implementation platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
     compileOnly "org.projectlombok:lombok"

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/Front50Config.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/Front50Config.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.config;
+
+import com.netflix.spinnaker.config.OkHttpClientConfiguration;
+import com.netflix.spinnaker.igor.IgorConfigurationProperties;
+import com.netflix.spinnaker.igor.plugins.front50.Front50Service;
+import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
+import com.squareup.okhttp.OkHttpClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import retrofit.Endpoints;
+import retrofit.RestAdapter;
+import retrofit.client.OkClient;
+
+@Configuration
+@ConditionalOnProperty("services.front50.base-url")
+public class Front50Config {
+
+  @Bean
+  Front50Service front50Service(
+      OkHttpClientConfiguration okHttpClientConfiguration, IgorConfigurationProperties properties) {
+    String address = properties.getServices().getFront50().getBaseUrl();
+
+    OkHttpClient client = okHttpClientConfiguration.create();
+
+    return new RestAdapter.Builder()
+        .setEndpoint(Endpoints.newFixedEndpoint(address))
+        .setClient(new OkClient(client))
+        .setLogLevel(RestAdapter.LogLevel.BASIC)
+        .setLog(new Slf4jRetrofitLogger(Front50Service.class))
+        .build()
+        .create(Front50Service.class);
+  }
+}

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.igor.config;
+
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.igor.IgorConfigurationProperties;
+import com.netflix.spinnaker.igor.history.EchoService;
+import com.netflix.spinnaker.igor.plugins.PluginCache;
+import com.netflix.spinnaker.igor.plugins.PluginsBuildMonitor;
+import com.netflix.spinnaker.igor.plugins.front50.Front50Service;
+import com.netflix.spinnaker.igor.plugins.front50.PluginReleaseService;
+import com.netflix.spinnaker.igor.polling.LockService;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnBean(Front50Service.class)
+public class PluginMonitorConfig {
+
+  @Bean
+  public PluginCache pluginCache(
+      RedisClientDelegate redisClientDelegate, IgorConfigurationProperties properties) {
+    return new PluginCache(redisClientDelegate, properties);
+  }
+
+  @Bean
+  public PluginReleaseService pluginReleaseService(Front50Service front50Service) {
+    return new PluginReleaseService(front50Service);
+  }
+
+  @Bean
+  public PluginsBuildMonitor pluginsBuildMonitor(
+      IgorConfigurationProperties properties,
+      Registry registry,
+      DynamicConfigService dynamicConfigService,
+      Optional<DiscoveryClient> discoveryClient,
+      Optional<LockService> lockService,
+      PluginReleaseService pluginReleaseService,
+      PluginCache pluginCache,
+      Optional<EchoService> echoService) {
+    return new PluginsBuildMonitor(
+        properties,
+        registry,
+        dynamicConfigService,
+        discoveryClient,
+        lockService,
+        pluginReleaseService,
+        pluginCache,
+        echoService);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,7 @@ rootProject.name='igor'
 include 'igor-bom',
   'igor-core',
   'igor-monitor-artifactory',
+  'igor-monitor-plugins',
   'igor-web'
 
 def setBuildFile(project) {


### PR DESCRIPTION
First step towards triggering pipelines off of new plugins. The initial implementation only supports looking at front50 as a plugin repository, but the storage schema supports future enhancements for PF4J's more general UpdateRepository format as well.