### PR TITLE
fix(events): Add dynamic config service to send events

### DIFF
--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.igor.polling.LockService;
 import com.netflix.spinnaker.igor.polling.PollContext;
 import com.netflix.spinnaker.igor.polling.PollingDelta;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.io.IOException;
 import java.time.Instant;
@@ -63,12 +64,13 @@ public class ArtifactoryBuildMonitor
   public ArtifactoryBuildMonitor(
       IgorConfigurationProperties properties,
       Registry registry,
+      DynamicConfigService dynamicConfigService,
       Optional<DiscoveryClient> discoveryClient,
       Optional<LockService> lockService,
       Optional<EchoService> echoService,
       ArtifactoryCache cache,
       ArtifactoryProperties artifactoryProperties) {
-    super(properties, registry, discoveryClient, lockService);
+    super(properties, registry, dynamicConfigService, discoveryClient, lockService);
     this.cache = cache;
     this.artifactoryProperties = artifactoryProperties;
     this.echoService = echoService;

--- a/igor-monitor-artifactory/src/test/groovy/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitorSpec.groovy
+++ b/igor-monitor-artifactory/src/test/groovy/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitorSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.igor.artifactory.model.ArtifactorySearch
 import com.netflix.spinnaker.igor.config.ArtifactoryProperties
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.polling.LockService
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.squareup.okhttp.mockwebserver.MockResponse
 import com.squareup.okhttp.mockwebserver.MockWebServer
 import rx.schedulers.Schedulers
@@ -41,6 +42,7 @@ class ArtifactoryBuildMonitorSpec extends Specification {
     monitor = new ArtifactoryBuildMonitor(
       igorConfigurationProperties,
       new NoopRegistry(),
+      new DynamicConfigService.NoopDynamicConfig(),
       Optional.empty(),
       Optional.ofNullable(lockService),
       Optional.of(echoService),

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.igor.polling.LockService
 import com.netflix.spinnaker.igor.polling.PollContext
 import com.netflix.spinnaker.igor.polling.PollingDelta
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -57,6 +58,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
     @Autowired
     DockerMonitor(IgorConfigurationProperties properties,
                   Registry registry,
+                  DynamicConfigService dynamicConfigService,
                   Optional<DiscoveryClient> discoveryClient,
                   Optional<LockService> lockService,
                   DockerRegistryCache cache,
@@ -65,7 +67,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
                   Optional<KeelService> keelService,
                   Optional<DockerRegistryCacheV2KeysMigration> keysMigration,
                   DockerRegistryProperties dockerRegistryProperties) {
-        super(properties, registry, discoveryClient, lockService)
+        super(properties, registry, dynamicConfigService, discoveryClient, lockService)
         this.cache = cache
         this.dockerRegistryAccounts = dockerRegistryAccounts
         this.echoService = echoService

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
@@ -38,6 +38,7 @@ import com.netflix.spinnaker.igor.polling.LockService;
 import com.netflix.spinnaker.igor.polling.PollContext;
 import com.netflix.spinnaker.igor.polling.PollingDelta;
 import com.netflix.spinnaker.igor.service.BuildServices;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.util.ArrayList;
 import java.util.Date;
@@ -66,13 +67,14 @@ public class GitlabCiBuildMonitor
   public GitlabCiBuildMonitor(
       IgorConfigurationProperties properties,
       Registry registry,
+      DynamicConfigService dynamicConfigService,
       Optional<DiscoveryClient> discoveryClient,
       Optional<LockService> lockService,
       BuildCache buildCache,
       BuildServices buildServices,
       GitlabCiProperties gitlabCiProperties,
       Optional<EchoService> echoService) {
-    super(properties, registry, discoveryClient, lockService);
+    super(properties, registry, dynamicConfigService, discoveryClient, lockService);
     this.buildCache = buildCache;
     this.buildServices = buildServices;
     this.gitlabCiProperties = gitlabCiProperties;

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.igor.polling.LockService
 import com.netflix.spinnaker.igor.polling.PollContext
 import com.netflix.spinnaker.igor.polling.PollingDelta
 import com.netflix.spinnaker.igor.service.BuildServices
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.time.TimeCategory
 import org.springframework.beans.factory.annotation.Autowired
@@ -61,6 +62,7 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
     @Autowired
     JenkinsBuildMonitor(IgorConfigurationProperties properties,
                         Registry registry,
+                        DynamicConfigService dynamicConfigService,
                         Optional<DiscoveryClient> discoveryClient,
                         Optional<LockService> lockService,
                         JenkinsCache cache,
@@ -68,7 +70,7 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
                         @Value('${jenkins.polling.enabled:true}') boolean pollingEnabled,
                         Optional<EchoService> echoService,
                         JenkinsProperties jenkinsProperties) {
-        super(properties, registry, discoveryClient, lockService)
+        super(properties, registry, dynamicConfigService, discoveryClient, lockService)
         this.cache = cache
         this.buildServices = buildServices
         this.pollingEnabled = pollingEnabled

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
@@ -8,6 +8,7 @@
  */
 package com.netflix.spinnaker.igor.wercker
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.security.AuthenticatedRequest
 
 import static com.netflix.spinnaker.igor.wercker.model.Run.finishedAtComparator
@@ -61,16 +62,17 @@ class WerckerBuildMonitor extends CommonPollingMonitor<PipelineDelta, PipelinePo
 
     @Autowired
     WerckerBuildMonitor(
-        IgorConfigurationProperties properties,
-        Registry registry,
-        Optional<DiscoveryClient> discoveryClient,
-        Optional<LockService> lockService,
-        WerckerCache cache,
-        BuildServices buildServices,
-        @Value('${wercker.polling.enabled:true}') boolean pollingEnabled,
-        Optional<EchoService> echoService,
-        WerckerProperties werckerProperties) {
-        super(properties, registry, discoveryClient, lockService)
+      IgorConfigurationProperties properties,
+      Registry registry,
+      DynamicConfigService dynamicConfigService,
+      Optional<DiscoveryClient> discoveryClient,
+      Optional<LockService> lockService,
+      WerckerCache cache,
+      BuildServices buildServices,
+      @Value('${wercker.polling.enabled:true}') boolean pollingEnabled,
+      Optional<EchoService> echoService,
+      WerckerProperties werckerProperties) {
+        super(properties, registry, dynamicConfigService, discoveryClient, lockService)
         this.cache = cache
         this.buildServices = buildServices
         this.pollingEnabled = pollingEnabled

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.igor.history.model.GenericBuildContent;
 import com.netflix.spinnaker.igor.history.model.GenericBuildEvent;
 import com.netflix.spinnaker.igor.polling.*;
 import com.netflix.spinnaker.igor.service.BuildServices;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.util.Date;
 import java.util.List;
@@ -57,13 +58,14 @@ public class ConcourseBuildMonitor
   public ConcourseBuildMonitor(
       IgorConfigurationProperties properties,
       Registry registry,
+      DynamicConfigService dynamicConfigService,
       Optional<DiscoveryClient> discoveryClient,
       Optional<LockService> lockService,
       Optional<EchoService> echoService,
       BuildServices buildServices,
       ConcourseCache cache,
       ConcourseProperties concourseProperties) {
-    super(properties, registry, discoveryClient, lockService);
+    super(properties, registry, dynamicConfigService, discoveryClient, lockService);
     this.buildServices = buildServices;
     this.cache = cache;
     this.concourseProperties = concourseProperties;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -39,6 +39,7 @@ import com.netflix.spinnaker.igor.service.BuildServices;
 import com.netflix.spinnaker.igor.travis.client.model.v3.TravisBuildState;
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Build;
 import com.netflix.spinnaker.igor.travis.service.TravisService;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.time.Duration;
 import java.time.Instant;
@@ -72,13 +73,14 @@ public class TravisBuildMonitor
   public TravisBuildMonitor(
       IgorConfigurationProperties properties,
       Registry registry,
+      DynamicConfigService dynamicConfigService,
       Optional<DiscoveryClient> discoveryClient,
       BuildCache buildCache,
       BuildServices buildServices,
       TravisProperties travisProperties,
       Optional<EchoService> echoService,
       Optional<LockService> lockService) {
-    super(properties, registry, discoveryClient, lockService);
+    super(properties, registry, dynamicConfigService, discoveryClient, lockService);
     this.buildCache = buildCache;
     this.buildServices = buildServices;
     this.travisProperties = travisProperties;

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/docker/DockerMonitorSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.history.model.DockerEvent
 import com.netflix.spinnaker.igor.keel.KeelService
 import com.netflix.spinnaker.igor.polling.LockService
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -34,6 +35,7 @@ class DockerMonitorSpec extends Specification {
 
     def properties = new IgorConfigurationProperties()
     def registry = new NoopRegistry()
+    def dynamicConfig = new DynamicConfigService.NoopDynamicConfig()
     Optional<DiscoveryClient> discoveryClient = Optional.empty()
     Optional<LockService> lockService = Optional.empty()
     def dockerRegistryCache = Mock(DockerRegistryCache)
@@ -55,7 +57,7 @@ class DockerMonitorSpec extends Specification {
         )
 
         when:
-        new DockerMonitor(properties, registry, discoveryClient, lockService, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.of(keelService), Optional.empty(), dockerRegistryProperties)
+        new DockerMonitor(properties, registry, dynamicConfig, discoveryClient, lockService, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.of(keelService), Optional.empty(), dockerRegistryProperties)
             .postEvent(cachedImages, taggedImage, "imageId")
 
         then:
@@ -172,7 +174,7 @@ class DockerMonitorSpec extends Specification {
     }
 
     private DockerMonitor createSubject() {
-        return new DockerMonitor(properties, registry, discoveryClient, lockService, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.of(keelService), keysMigration, dockerRegistryProperties)
+        return new DockerMonitor(properties, registry, dynamicConfig, discoveryClient, lockService, dockerRegistryCache, dockerRegistryAccounts, Optional.of(echoService), Optional.of(keelService), keysMigration, dockerRegistryProperties)
     }
 
     private static String keyFromTaggedImage(TaggedImage taggedImage) {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitorSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.igor.gitlabci.service.GitlabCiService
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.polling.PollContext
 import com.netflix.spinnaker.igor.service.BuildServices
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -47,6 +48,7 @@ class GitlabCiBuildMonitorSpec extends Specification {
         buildMonitor = new GitlabCiBuildMonitor(
             new IgorConfigurationProperties(),
             new NoopRegistry(),
+            new DynamicConfigService.NoopDynamicConfig(),
             Optional.empty(),
             Optional.empty(),
             buildCache,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.igor.jenkins.client.model.ProjectsList
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.service.BuildServices
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 import rx.schedulers.TestScheduler
 import spock.lang.Specification
@@ -52,6 +53,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
         monitor = new JenkinsBuildMonitor(
             cfg,
             new NoopRegistry(),
+            new DynamicConfigService.NoopDynamicConfig(),
             Optional.empty(),
             Optional.empty(),
             cache,
@@ -102,6 +104,7 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
         monitor = new JenkinsBuildMonitor(
             cfg,
             new NoopRegistry(),
+            new DynamicConfigService.NoopDynamicConfig(),
             Optional.empty(),
             Optional.empty(),
             cache,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.igor.jenkins.client.model.ProjectsList
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.polling.PollContext
 import com.netflix.spinnaker.igor.service.BuildServices
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import org.slf4j.Logger
 import retrofit.RetrofitError
 import rx.schedulers.Schedulers
@@ -51,6 +52,7 @@ class JenkinsBuildMonitorSpec extends Specification {
         monitor = new JenkinsBuildMonitor(
             igorConfigurationProperties,
             new NoopRegistry(),
+            new DynamicConfigService.NoopDynamicConfig(),
             Optional.empty(),
             Optional.empty(),
             cache,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.igor.travis.client.model.v3.V3Commit
 import com.netflix.spinnaker.igor.travis.client.model.v3.V3Repository
 import com.netflix.spinnaker.igor.travis.service.TravisBuildConverter
 import com.netflix.spinnaker.igor.travis.service.TravisService
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import spock.lang.Specification
 
 class TravisBuildMonitorSpec extends Specification {
@@ -48,6 +49,7 @@ class TravisBuildMonitorSpec extends Specification {
         travisBuildMonitor = new TravisBuildMonitor(
             new IgorConfigurationProperties(),
             new NoopRegistry(),
+            new DynamicConfigService.NoopDynamicConfig(),
             Optional.empty(),
             buildCache,
             buildServices,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSchedulingSpec.groovy
@@ -13,6 +13,7 @@ import com.netflix.spinnaker.igor.IgorConfigurationProperties
 import com.netflix.spinnaker.igor.config.WerckerProperties
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
 import com.netflix.spinnaker.igor.service.BuildServices
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 
 import java.util.concurrent.TimeUnit
@@ -43,6 +44,7 @@ class WerckerBuildMonitorSchedulingSpec extends Specification {
         monitor = new WerckerBuildMonitor(
                 cfg,
                 new NoopRegistry(),
+                new DynamicConfigService.NoopDynamicConfig(),
                 Optional.empty(),
                 Optional.empty(),
                 cache,
@@ -92,6 +94,7 @@ class WerckerBuildMonitorSchedulingSpec extends Specification {
         monitor = new WerckerBuildMonitor(
                 cfg,
                 new NoopRegistry(),
+                new DynamicConfigService.NoopDynamicConfig(),
                 Optional.empty(),
                 Optional.empty(),
                 cache,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSpec.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.igor.wercker.model.Application
 import com.netflix.spinnaker.igor.wercker.model.Owner
 import com.netflix.spinnaker.igor.wercker.model.Pipeline
 import com.netflix.spinnaker.igor.wercker.model.Run
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 
 import java.util.concurrent.TimeUnit
@@ -219,6 +220,7 @@ class WerckerBuildMonitorSpec extends Specification {
         return new WerckerBuildMonitor(
                 cfg,
                 new NoopRegistry(),
+                new DynamicConfigService.NoopDynamicConfig(),
                 Optional.empty(),
                 Optional.empty(),
                 cache,

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitorTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitorTest.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.igor.config.ConcourseProperties;
 import com.netflix.spinnaker.igor.history.EchoService;
 import com.netflix.spinnaker.igor.service.ArtifactDecorator;
 import com.netflix.spinnaker.igor.service.BuildServices;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import java.util.Collections;
@@ -62,6 +63,7 @@ class ConcourseBuildMonitorTest {
         new ConcourseBuildMonitor(
             igorConfigurationProperties,
             new NoopRegistry(),
+            new DynamicConfigService.NoopDynamicConfig(),
             Optional.empty(),
             Optional.empty(),
             Optional.of(echoService),


### PR DESCRIPTION
It's not currently possible to start/stop `igor` from sending events of completed builds/newly published images to `echo`.
It is useful to have this functionality because igor should always be "polling" to have a local cache of "triggered" builds/images.

This change allows an operator to:
* have two clusters of `igor` both polling but only one sending events (i.e. triggering pipeline)
* switch which cluster is sending events without generating duplicate events/double triggering
