### PR TITLE
fix(events): rename the send events prop

### DIFF
--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/polling/CommonPollingMonitor.java
@@ -219,7 +219,7 @@ public abstract class CommonPollingMonitor<I extends DeltaItem, T extends Pollin
             .set(0);
       }
 
-      sendEvents = sendEvents && isSendingEventsEnabled();
+      sendEvents = sendEvents && isSendEventsEnabled();
 
       commitDelta(delta, sendEvents);
       registry
@@ -277,8 +277,8 @@ public abstract class CommonPollingMonitor<I extends DeltaItem, T extends Pollin
     return lastPoll.get();
   }
 
-  private boolean isSendingEventsEnabled() {
-    return dynamicConfigService.isEnabled("igor.build.sendEvents", true);
+  private boolean isSendEventsEnabled() {
+    return dynamicConfigService.getConfig(Boolean.class, "spinnaker.build.sendEventsEnabled", true);
   }
 
   protected @Nullable Integer getPartitionUpperThreshold(String partition) {


### PR DESCRIPTION
Follow up to feedback in https://github.com/spinnaker/igor/pull/724.
Renaming the property to `spinnaker.build.sendEventsEnabled`, this way it is symmetric to existing properties in `igor`, e.g.:

```yaml
spinnaker:
  build:
    pollingEnabled: true
    sendEventsEnabled: false
```
