### PR TITLE
config(core): Push Halyard config to base

### DIFF
--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -1,0 +1,6 @@
+This directory contains skeleton igor configs to which Halyard concatenates
+its generated deployment-specific config.
+
+These configs are **deprecated** and in general should not be further updated. To
+set a default config value, either set the value in `igor-web/config/igor.yml`
+or set a default in the code reading the config property.

--- a/halconfig/igor.yml
+++ b/halconfig/igor.yml
@@ -1,6 +1,3 @@
 server:
   port: ${services.igor.port:8088}
   address: ${services.igor.host:localhost}
-
-redis:
-  connection: ${services.redis.baseUrl:redis://localhost:6379}

--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -18,6 +18,9 @@ spring.jackson.serialization.write_dates_as_timestamps: false
 
 server.port: 8088
 
+redis:
+  connection: ${services.redis.baseUrl:redis://localhost:6379}
+
 #artifact:
 #  This is a feature toggle for decoration of artifacts.
 #  decorator:


### PR DESCRIPTION
The redis url is being set in the Halyard-specific file that is concatenated to the config; let's just move that defaulting to the base igor.yml.

This should not cause any visible change to non-Halyard users, as we are defaulting back to the same localhost:6379 if the redis override is not defined. It will also not affect Halyard users as it's just changing where we set this value for them.