### PR TITLE
refactor(gcb): Make GCB account immutable and null-safe

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -87,6 +87,7 @@ dependencies {
 
     implementation "io.projectreactor:reactor-core"
     implementation "com.google.code.gson:gson"
+    implementation "com.google.guava:guava"
 
     testImplementation "com.squareup.okhttp:mockwebserver"
     testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactory.java
@@ -20,7 +20,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -47,11 +46,10 @@ final class GoogleCloudBuildAccountFactory {
   }
 
   private GoogleCredentials getCredentials(GoogleCloudBuildProperties.Account account) {
-    String jsonKey = account.getJsonKey();
-    if (StringUtils.isEmpty(jsonKey)) {
+    if (account.getJsonKey().isEmpty()) {
       return credentialService.getApplicationDefault();
     } else {
-      return credentialService.getFromKey(jsonKey);
+      return credentialService.getFromKey(account.getJsonKey());
     }
   }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -83,10 +83,10 @@ class InfoControllerSpec extends Specification {
     }
 
     GoogleCloudBuildProperties.Account createGCBAccount(String name) {
-      GoogleCloudBuildProperties.Account account = new GoogleCloudBuildProperties.Account()
-      account.setName(name)
-      account.setProject('blah')
-      return account
+      return GoogleCloudBuildProperties.Account.builder()
+        .name(name)
+        .project('blah')
+        .build()
     }
 
     void 'is able to get a list of jenkins buildMasters'() {
@@ -158,11 +158,14 @@ class InfoControllerSpec extends Specification {
                 .add(Authorization.READ, ['group-3', 'group-4'])
                 .add(Authorization.WRITE, 'group-3').build(), false)
 
-        GoogleCloudBuildProperties.Account gcbAccount = createGCBAccount('gcbAccount');
-        gcbAccount.setPermissions(new Permissions.Builder()
-          .add(Authorization.READ, ['group-5', 'group-6'])
-          .add(Authorization.WRITE, ['group-5'])
-        )
+        GoogleCloudBuildProperties.Account gcbAccount = GoogleCloudBuildProperties.Account.builder()
+          .name("gcbAccount")
+          .project('blah')
+          .permissions(
+            new Permissions.Builder()
+              .add(Authorization.READ, ['group-5', 'group-6'])
+              .add(Authorization.WRITE, ['group-5'])
+          ).build()
 
         createMocks([
             'jenkins-foo': jenkinsService1,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
@@ -46,8 +46,12 @@ public class GoogleCloudBuildAccountFactoryTest {
 
   @Test
   public void applicationDefaultCredentials() {
-    GoogleCloudBuildProperties.Account accountConfig = getBaseAccount();
-    accountConfig.setJsonKey("");
+    GoogleCloudBuildProperties.Account accountConfig =
+        GoogleCloudBuildProperties.Account.builder()
+            .name("test-account")
+            .project("test-project")
+            .jsonKey("")
+            .build();
 
     when(googleCredentialsService.getApplicationDefault()).thenReturn(googleCredentials);
     when(googleCloudBuildClientFactory.create(eq(googleCredentials), any(String.class)))
@@ -62,8 +66,12 @@ public class GoogleCloudBuildAccountFactoryTest {
 
   @Test
   public void jsonCredentials() {
-    GoogleCloudBuildProperties.Account accountConfig = getBaseAccount();
-    accountConfig.setJsonKey("/path/to/file");
+    GoogleCloudBuildProperties.Account accountConfig =
+        GoogleCloudBuildProperties.Account.builder()
+            .name("test-account")
+            .project("test-project")
+            .jsonKey("/path/to/file")
+            .build();
 
     when(googleCredentialsService.getFromKey("/path/to/file")).thenReturn(googleCredentials);
     when(googleCloudBuildClientFactory.create(eq(googleCredentials), any(String.class)))
@@ -74,12 +82,5 @@ public class GoogleCloudBuildAccountFactoryTest {
     verify(googleCredentialsService, never()).getApplicationDefault();
     verify(googleCredentialsService).getFromKey("/path/to/file");
     verify(googleCloudBuildClientFactory).create(eq(googleCredentials), any(String.class));
-  }
-
-  private GoogleCloudBuildProperties.Account getBaseAccount() {
-    GoogleCloudBuildProperties.Account accountConfig = new GoogleCloudBuildProperties.Account();
-    accountConfig.setName("test-account");
-    accountConfig.setProject("test-project");
-    return accountConfig;
   }
 }


### PR DESCRIPTION
This commit moves the GoogleCloudBuildProperties.Account class to be immutable and use constructor binding. It also makes the minor change of storing the result of Permissions.build() instead of the raw builder, rather than calling Permissions.build() every time we ask for the permissions.

It also annotates the class as NonnullByDefault, and handles any necessary null defaulting in the constructor.