### PR TITLE
fix(misc): newer version of fiat api client requires url to wire up c…

### DIFF
--- a/igor-web/src/test/resources/application.properties
+++ b/igor-web/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+services.fiat.baseUrl=https://fiat.net

--- a/igor-web/src/test/resources/gcb/gcb-test.yml
+++ b/igor-web/src/test/resources/gcb/gcb-test.yml
@@ -6,3 +6,6 @@ gcb:
     jsonKey: /path/to/some/file
 locking:
   enabled: true
+services:
+  fiat:
+    baseUrl: https://fiat.net


### PR DESCRIPTION
- Newer version of fiat api client requires url and performs non null check and this change is to satisfy that constraint by supplying the necessary config while building the application contexts in unit tests. There is  a failing build of [autobump PR](https://github.com/spinnaker/igor/pull/747) due to this.