### PR TITLE
chore(docker): remove v1 docker tag migrator

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -75,10 +75,6 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
 
     @Override
     void poll(boolean sendEvents) {
-        if (keysMigration.isPresent() && keysMigration.get().running) {
-            log.warn("Skipping poll cycle: Keys migration is in progress")
-            return
-        }
         dockerRegistryAccounts.updateAccounts()
         dockerRegistryAccounts.accounts.forEach({ account ->
             pollSingle(new PollContext((String) account.name, account, !sendEvents))


### PR DESCRIPTION
Fix for a missed entry from https://github.com/spinnaker/igor/pull/745
