### PR TITLE
fix(jenkins): mark builds processed when fastforwarding

### DIFF
--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
@@ -199,11 +199,7 @@ public class ArtifactoryBuildMonitor
   private void postEvent(Artifact artifact, String name) {
     if (!echoService.isPresent()) {
       log.warn("Cannot send build notification: Echo is not configured");
-      registry
-          .counter(
-              missedNotificationId.withTag(
-                  "monitor", ArtifactoryBuildMonitor.class.getSimpleName()))
-          .increment();
+      registry.counter(missedNotificationId.withTag("monitor", getName())).increment();
     } else {
       if (artifact != null) {
         AuthenticatedRequest.allowAnonymous(

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/PluginsBuildMonitor.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/PluginsBuildMonitor.java
@@ -85,10 +85,7 @@ public class PluginsBuildMonitor
   private void postEvent(PluginRelease release) {
     if (!echoService.isPresent()) {
       log.warn("Cannot send new plugin notification: Echo is not configured");
-      registry
-          .counter(
-              missedNotificationId.withTag("monitor", PluginsBuildMonitor.class.getSimpleName()))
-          .increment();
+      registry.counter(missedNotificationId.withTag("monitor", getName())).increment();
     } else if (release != null) {
       AuthenticatedRequest.allowAnonymous(
           () -> echoService.get().postEvent(new PluginEvent(release)));

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -152,7 +152,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
                 if (sendEvents && item.sendEvent) {
                     postEvent(delta.cachedImages, item.image, item.imageId)
                 } else {
-                    registry.counter(missedNotificationId.withTags("monitor", getClass().simpleName, "reason", "fastForward")).increment()
+                    registry.counter(missedNotificationId.withTags("monitor", getName(), "reason", "fastForward")).increment()
                 }
             }
         }
@@ -166,7 +166,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
     void postEvent(Set<String> cachedImagesForAccount, TaggedImage image, String imageId) {
         if (!echoService.isPresent()) {
             log.warn("Cannot send tagged image notification: Echo is not enabled")
-            registry.counter(missedNotificationId.withTags("monitor", getClass().simpleName, "reason", "echoDisabled")).increment()
+            registry.counter(missedNotificationId.withTags("monitor", getName(), "reason", "echoDisabled")).increment()
             return
         }
         if (!cachedImagesForAccount) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
@@ -217,9 +217,7 @@ public class GitlabCiBuildMonitor
       String slug, Project project, Pipeline pipeline, String address, String master) {
     if (!echoService.isPresent()) {
       log.warn("Cannot send build notification: Echo is not enabled");
-      registry
-          .counter(missedNotificationId.withTag("monitor", getClass().getSimpleName()))
-          .increment();
+      registry.counter(missedNotificationId.withTag("monitor", getName())).increment();
       return;
     }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -200,8 +200,11 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
                     if (sendEvents) {
                         postEvent(new Project(name: job.name, lastBuild: build), master)
                         log.debug("[${master}:${job.name}]:${build.number} event posted")
-                        cache.setEventPosted(master, job.name, job.cursor, build.number)
+                    } else {
+                      registry.counter(missedNotificationId.withTags("monitor", getClass().simpleName, "reason", "fastForward")).increment()
                     }
+
+                    cache.setEventPosted(master, job.name, job.cursor, build.number)
                 }
             }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -201,7 +201,7 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
                         postEvent(new Project(name: job.name, lastBuild: build), master)
                         log.debug("[${master}:${job.name}]:${build.number} event posted")
                     } else {
-                      registry.counter(missedNotificationId.withTags("monitor", getClass().simpleName, "reason", "fastForward")).increment()
+                      registry.counter(missedNotificationId.withTags("monitor", getName(), "reason", "fastForward")).increment()
                     }
 
                     cache.setEventPosted(master, job.name, job.cursor, build.number)
@@ -226,7 +226,7 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
     private void postEvent(Project project, String master) {
         if (!echoService.isPresent()) {
             log.warn("Cannot send build notification: Echo is not configured")
-            registry.counter(missedNotificationId.withTag("monitor", getClass().simpleName)).increment()
+            registry.counter(missedNotificationId.withTag("monitor", getName())).increment()
             return
         }
         AuthenticatedRequest.allowAnonymous {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
@@ -260,7 +260,7 @@ class WerckerBuildMonitor extends CommonPollingMonitor<PipelineDelta, PipelinePo
     private boolean postEvent(GenericProject project, String master) {
         if (!echoService.isPresent()) {
             log.warn("Cannot send build notification: Echo is not configured")
-            registry.counter(missedNotificationId.withTag("monitor", getClass().simpleName)).increment()
+            registry.counter(missedNotificationId.withTag("monitor", getName())).increment()
             return false
         }
         AuthenticatedRequest.allowAnonymous {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
@@ -197,9 +197,7 @@ public class ConcourseBuildMonitor
     } else {
       log.warn("Cannot send build event notification: Echo is not configured");
       log.info("({}) unable to push event for :" + build.getFullDisplayName());
-      registry
-          .counter(missedNotificationId.withTag("monitor", getClass().getSimpleName()))
-          .increment();
+      registry.counter(missedNotificationId.withTag("monitor", getName())).increment();
     }
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -269,9 +269,7 @@ public class TravisBuildMonitor
                 + ":"
                 + buildDelta.getBuild().getNumber(),
             kv("master", master));
-        registry
-            .counter(missedNotificationId.withTag("monitor", getClass().getSimpleName()))
-            .increment();
+        registry.counter(missedNotificationId.withTag("monitor", getName())).increment();
       }
     }
   }


### PR DESCRIPTION
Two main changes here:
1. Add a metric for when we skip sending events (same as [`DockerMonitor`](https://github.com/spinnaker/igor/blob/master/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy#L155)
2. Mark the build processed even if we don't send an event to `echo` (because we are fast-forwarding), again same as [`DockerMonitor`](https://github.com/spinnaker/igor/blob/master/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy#L150)

The idea behind #2 is that when we have two `igor`s: one actively sending events, the other just fast-forwarding to be ready to send events if needed.
When we switch which `igor` triggers events to `echo`, we need to make sure we don't double trigger on builds in the past. Without this change, we would re-trigger the builds in the last few minutes due to the cache being fast-forwarded only when the running builds list is [empty](https://github.com/spinnaker/igor/blob/master/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy#L209)
