### PR TITLE
refactor(artifacts): Remove deprecate getMetadata

### DIFF
--- a/igor-monitor-artifactory/src/test/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItemTest.java
+++ b/igor-monitor-artifactory/src/test/java/com/netflix/spinnaker/igor/artifactory/model/ArtifactoryItemTest.java
@@ -102,6 +102,6 @@ class ArtifactoryItemTest {
 
     Artifact matchableArtifact =
         artifact.toMatchableArtifact(ArtifactoryRepositoryType.MAVEN, null);
-    assertThat(matchableArtifact.getMetadata().get("build")).isEqualTo(expectedBuild);
+    assertThat(matchableArtifact.getMetadata("build")).isEqualTo(expectedBuild);
   }
 }


### PR DESCRIPTION
Replaced the deprecated getMetadata with a call to getMetadata(String key) to get the specific key of interest.