### PR TITLE
feat(plugins): Add description and provider to PluginRelease

### DIFF
--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginInfo.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginInfo.java
@@ -21,10 +21,14 @@ import java.util.List;
 public class PluginInfo {
 
   final String id;
+  final String description;
+  final String provider;
   final List<Release> releases;
 
-  public PluginInfo(String id, List<Release> releases) {
+  public PluginInfo(String id, String description, String provider, List<Release> releases) {
     this.id = id;
+    this.description = description;
+    this.provider = provider;
     this.releases = releases;
   }
 

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginReleaseService.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/front50/PluginReleaseService.java
@@ -74,6 +74,8 @@ public class PluginReleaseService {
                                 release ->
                                     new PluginRelease(
                                         info.id,
+                                        info.description,
+                                        info.provider,
                                         release.version,
                                         release.date,
                                         release.requires,

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/model/PluginRelease.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/model/PluginRelease.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 public class PluginRelease {
   private final String pluginId;
+  private final String description;
+  private final String provider;
   private final String version;
   private final String releaseDate;
   private final String requires;
@@ -31,6 +33,8 @@ public class PluginRelease {
 
   public PluginRelease(
       String pluginId,
+      String description,
+      String provider,
       String version,
       String releaseDate,
       String requires,
@@ -40,6 +44,8 @@ public class PluginRelease {
       boolean preferred,
       String lastModified) {
     this.pluginId = pluginId;
+    this.description = description;
+    this.provider = provider;
     this.version = version;
     this.releaseDate = releaseDate;
     this.requires = requires;
@@ -52,6 +58,14 @@ public class PluginRelease {
 
   public String getPluginId() {
     return pluginId;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getProvider() {
+    return provider;
   }
 
   public String getVersion() {

--- a/igor-monitor-plugins/src/test/groovy/com/netflix/spinnaker/igor/plugins/front50/PluginReleaseServiceSpec.groovy
+++ b/igor-monitor-plugins/src/test/groovy/com/netflix/spinnaker/igor/plugins/front50/PluginReleaseServiceSpec.groovy
@@ -38,12 +38,12 @@ class PluginReleaseServiceSpec extends Specification {
   @Unroll
   def "gets releases since timestamp"() {
     given:
-    PluginInfo plugin1 = new PluginInfo("plugin1", [
-      release("1.0.0", clock.instant()),
-      release("1.0.1", clock.instant().plus(1, ChronoUnit.DAYS))
+    PluginInfo plugin1 = new PluginInfo("plugin1", "A pugin", "foo@example.com", [
+            release("1.0.0", clock.instant()),
+            release("1.0.1", clock.instant().plus(1, ChronoUnit.DAYS))
     ])
-    PluginInfo plugin2 = new PluginInfo("plugin2", [
-      release("2.0.0", clock.instant().plus(2, ChronoUnit.DAYS))
+    PluginInfo plugin2 = new PluginInfo("plugin2", "A pugin", "foo@example.com", [
+            release("2.0.0", clock.instant().plus(2, ChronoUnit.DAYS))
     ])
 
     and:


### PR DESCRIPTION
It will be useful to have this data on the plugin trigger.

Related to:

https://github.com/spinnaker/orca/pull/3756
https://github.com/spinnaker/echo/pull/949

