### PR TITLE
fix(jenkins): Stop or delete from queue

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -144,19 +144,19 @@ class BuildController {
             if (buildNumber != 0 &&
                 buildService.metaClass.respondsTo(buildService, 'stopRunningBuild')) {
                 buildService.stopRunningBuild(jobName, buildNumber)
-            }
-
-            // The jenkins api for removing a job from the queue (http://<Jenkins_URL>/queue/cancelItem?id=<queuedBuild>)
-            // always returns a 404. This try catch block insures that the exception is eaten instead
-            // of being handled by the handleOtherException handler and returning a 500 to orca
-            try {
+            } else {
+              // The jenkins api for removing a job from the queue (http://<Jenkins_URL>/queue/cancelItem?id=<queuedBuild>)
+              // always returns a 404. This try catch block insures that the exception is eaten instead
+              // of being handled by the handleOtherException handler and returning a 500 to orca
+              try {
                 if (buildService.metaClass.respondsTo(buildService, 'stopQueuedBuild')) {
-                    buildService.stopQueuedBuild(queuedBuild)
+                  buildService.stopQueuedBuild(queuedBuild)
                 }
-            } catch (RetrofitError e) {
+              } catch (RetrofitError e) {
                 if (e.response?.status != NOT_FOUND.value()) {
-                    throw e
+                  throw e
                 }
+              }
             }
         }
 


### PR DESCRIPTION
Stop a build can mean a) stopping it or b) removing it from the queue if hasn't started.
Today, igor, will attempt both if the build has been started. This can cause a 500 from jenkins server which is propagated to orca which then fails to actually complete the cancellation of a pipeline.
(it's mostly harmless but it can cause issues and it also generates a bunch of exception noise)

This change stops the build if it was started OR removes it from the queue if it wasn't started not both
