### PR TITLE
fix(concourse): support old and new concourse auth (#762)

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation "com.sun.xml.bind:jaxb-core:2.3.0.1"
     implementation "com.sun.xml.bind:jaxb-impl:2.3.2"
 
+    implementation "com.vdurmont:semver4j:3.1.0"
+
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation "org.spockframework:spock-core"
     testImplementation "org.spockframework:spock-spring"

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/ClusterInfoService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/ClusterInfoService.java
@@ -16,15 +16,10 @@
 
 package com.netflix.spinnaker.igor.concourse.client;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.netflix.spinnaker.igor.concourse.client.model.ClusterInfo;
+import retrofit.http.GET;
 
-import java.net.UnknownHostException;
-import org.junit.jupiter.api.Test;
-
-class ConcourseClientTest {
-  @Test
-  void connectException() {
-    assertThatThrownBy(() -> new ConcourseClient("http://does.not.exist", "test", "test"))
-        .hasRootCauseInstanceOf(UnknownHostException.class);
-  }
+public interface ClusterInfoService {
+  @GET("/api/v1/info")
+  ClusterInfo clusterInfo();
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/ConcourseClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/ConcourseClient.java
@@ -20,13 +20,16 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.netflix.spinnaker.igor.concourse.client.model.ClusterInfo;
 import com.netflix.spinnaker.igor.concourse.client.model.Token;
 import com.squareup.okhttp.OkHttpClient;
+import com.vdurmont.semver4j.Semver;
 import java.time.ZonedDateTime;
 import lombok.Getter;
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 import retrofit.client.OkClient;
+import retrofit.client.Response;
 import retrofit.converter.JacksonConverter;
 
 public class ConcourseClient {
@@ -35,7 +38,12 @@ public class ConcourseClient {
   private final String password;
   private final OkHttpClient okHttpClient;
 
-  @Getter private TokenService tokenService;
+  private final SkyService skyServiceV1;
+  private final SkyServiceV2 skyServiceV2;
+  private final TokenService tokenServiceV1;
+  private final TokenServiceV2 tokenServiceV2;
+
+  @Getter private ClusterInfoService clusterInfoService;
 
   @Getter private BuildService buildService;
 
@@ -47,11 +55,9 @@ public class ConcourseClient {
 
   @Getter private PipelineService pipelineService;
 
-  @Getter private SkyService skyService;
-
   @Getter private ResourceService resourceService;
 
-  private volatile ZonedDateTime tokenExpiration = ZonedDateTime.now();
+  private volatile ZonedDateTime tokenExpiration = ZonedDateTime.now().minusSeconds(1);
   private volatile Token token;
 
   private JacksonConverter jacksonConverter;
@@ -79,7 +85,7 @@ public class ConcourseClient {
     this.okHttpClient = OkHttpClientBuilder.retryingClient(this::refreshToken);
     this.jacksonConverter = new JacksonConverter(mapper);
 
-    this.tokenService =
+    RestAdapter.Builder tokenRestBuilder =
         new RestAdapter.Builder()
             .setEndpoint(host)
             .setClient(new OkClient(okHttpClient))
@@ -87,16 +93,47 @@ public class ConcourseClient {
             .setRequestInterceptor(
                 request -> {
                   request.addHeader("Authorization", "Basic Zmx5OlpteDU=");
-                })
+                });
+
+    this.clusterInfoService =
+        new RestAdapter.Builder()
+            .setEndpoint(host)
+            .setClient(new OkClient(okHttpClient))
+            .setConverter(jacksonConverter)
+            .setLog(new Slf4jRetrofitLogger(ClusterInfoService.class))
             .build()
-            .create(TokenService.class);
+            .create(ClusterInfoService.class);
+
+    ClusterInfo clusterInfo = this.clusterInfoService.clusterInfo();
+
+    Semver ver = new Semver("6.1.0");
+    if (ver.isGreaterThan(clusterInfo.getVersion())) {
+      this.tokenServiceV1 =
+          tokenRestBuilder
+              .setLog(new Slf4jRetrofitLogger(TokenService.class))
+              .build()
+              .create(TokenService.class);
+      this.tokenServiceV2 = null;
+
+      this.skyServiceV1 = createService(SkyService.class);
+      this.skyServiceV2 = null;
+    } else {
+      this.tokenServiceV1 = null;
+      this.tokenServiceV2 =
+          tokenRestBuilder
+              .setLog(new Slf4jRetrofitLogger(TokenServiceV2.class))
+              .build()
+              .create(TokenServiceV2.class);
+
+      this.skyServiceV1 = null;
+      this.skyServiceV2 = createService(SkyServiceV2.class);
+    }
 
     this.buildService = createService(BuildService.class);
     this.jobService = createService(JobService.class);
     this.teamService = createService(TeamService.class);
     this.pipelineService = createService(PipelineService.class);
     this.resourceService = createService(ResourceService.class);
-    this.skyService = createService(SkyService.class);
     this.eventService = new EventService(host, this::refreshToken, mapper);
   }
 
@@ -108,10 +145,18 @@ public class ConcourseClient {
 
   private Token refreshToken() {
     token =
-        tokenService.passwordToken(
-            "password", user, password, "openid profile email federated:id groups");
+        tokenServiceV1 != null
+            ? tokenServiceV1.passwordToken(
+                "password", user, password, "openid profile email federated:id groups")
+            : tokenServiceV2.passwordToken(
+                "password", user, password, "openid profile email federated:id groups");
+
     tokenExpiration = token.getExpiry();
     return token;
+  }
+
+  public Response userInfo() {
+    return skyServiceV1 != null ? skyServiceV1.userInfo() : skyServiceV2.userInfo();
   }
 
   private <S> S createService(Class<S> serviceClass) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/SkyServiceV2.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/SkyServiceV2.java
@@ -16,15 +16,10 @@
 
 package com.netflix.spinnaker.igor.concourse.client;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import retrofit.client.Response;
+import retrofit.http.GET;
 
-import java.net.UnknownHostException;
-import org.junit.jupiter.api.Test;
-
-class ConcourseClientTest {
-  @Test
-  void connectException() {
-    assertThatThrownBy(() -> new ConcourseClient("http://does.not.exist", "test", "test"))
-        .hasRootCauseInstanceOf(UnknownHostException.class);
-  }
+public interface SkyServiceV2 {
+  @GET("/api/v1/user")
+  Response userInfo();
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/TokenServiceV2.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/TokenServiceV2.java
@@ -16,15 +16,17 @@
 
 package com.netflix.spinnaker.igor.concourse.client;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.netflix.spinnaker.igor.concourse.client.model.TokenV2;
+import retrofit.http.Field;
+import retrofit.http.FormUrlEncoded;
+import retrofit.http.POST;
 
-import java.net.UnknownHostException;
-import org.junit.jupiter.api.Test;
-
-class ConcourseClientTest {
-  @Test
-  void connectException() {
-    assertThatThrownBy(() -> new ConcourseClient("http://does.not.exist", "test", "test"))
-        .hasRootCauseInstanceOf(UnknownHostException.class);
-  }
+public interface TokenServiceV2 {
+  @FormUrlEncoded
+  @POST("/sky/issuer/token")
+  TokenV2 passwordToken(
+      @Field("grant_type") String grantType,
+      @Field("username") String username,
+      @Field("password") String password,
+      @Field("scope") String scope);
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/ClusterInfo.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/ClusterInfo.java
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.igor.concourse.client;
+package com.netflix.spinnaker.igor.concourse.client.model;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import lombok.Data;
 
-import java.net.UnknownHostException;
-import org.junit.jupiter.api.Test;
-
-class ConcourseClientTest {
-  @Test
-  void connectException() {
-    assertThatThrownBy(() -> new ConcourseClient("http://does.not.exist", "test", "test"))
-        .hasRootCauseInstanceOf(UnknownHostException.class);
-  }
+@Data
+public class ClusterInfo {
+  private String clusterName;
+  private String externalUrl;
+  private String version;
+  private String workerVersion;
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/TokenV2.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/TokenV2.java
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.igor.concourse.client;
+package com.netflix.spinnaker.igor.concourse.client.model;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.ZonedDateTime;
 
-import java.net.UnknownHostException;
-import org.junit.jupiter.api.Test;
+public class TokenV2 extends Token {
 
-class ConcourseClientTest {
-  @Test
-  void connectException() {
-    assertThatThrownBy(() -> new ConcourseClient("http://does.not.exist", "test", "test"))
-        .hasRootCauseInstanceOf(UnknownHostException.class);
+  @Override
+  @JsonProperty("id_token")
+  public void setAccessToken(String idToken) {
+    super.setAccessToken(idToken);
+  }
+
+  @Override
+  public ZonedDateTime getExpiry() {
+    return ZonedDateTime.now();
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
@@ -363,6 +363,6 @@ public class ConcourseService implements BuildOperations, BuildProperties {
   private void refreshTokenIfNecessary() {
     // returns a 401 on expired/invalid token, which because of retry logic causes the token to be
     // refreshed.
-    client.getSkyService().userInfo();
+    client.userInfo();
   }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/concourse/client/ConcourseClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/concourse/client/ConcourseClientSpec.groovy
@@ -1,0 +1,114 @@
+package com.netflix.spinnaker.igor.concourse.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.igor.concourse.client.ConcourseClient
+import com.netflix.spinnaker.igor.concourse.client.SkyService
+import com.netflix.spinnaker.igor.concourse.client.SkyServiceV2
+import com.netflix.spinnaker.igor.concourse.client.TokenService
+import com.netflix.spinnaker.igor.concourse.client.TokenServiceV2
+import com.netflix.spinnaker.igor.concourse.client.model.Token
+import com.squareup.okhttp.mockwebserver.MockResponse
+import com.squareup.okhttp.mockwebserver.MockWebServer
+import com.squareup.okhttp.mockwebserver.RecordedRequest
+import retrofit.client.Response;
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.ZonedDateTime
+
+class ConcourseClientSpec extends Specification {
+
+    @Shared
+    ConcourseClient client
+
+    @Shared
+    MockWebServer server
+
+    void setup() {
+        server = new MockWebServer()
+    }
+
+    void cleanup() {
+        server.shutdown()
+    }
+
+    def "it uses v1 auth for concourse versions < 6.1.0"() {
+        given:
+        def expiry = java.time.ZonedDateTime.now().plusSeconds(60).toString()
+        setResponse '''{
+                "cluster_name": "mycluster",
+                "external_url": "https://mycluster.example.com",
+                "version": "6.0.0",
+                "worker_version": "2.2"
+            }''',
+            """{
+                "access_token": "my_token",
+                "expiry": "${expiry}"
+            }""",
+            '''{
+                "name": "jsmith"
+            }'''
+
+        when:
+        Response resp = client.userInfo()
+        RecordedRequest req1 = server.takeRequest()
+        RecordedRequest req2 = server.takeRequest()
+        RecordedRequest req3 = server.takeRequest()
+
+        then:
+        req1.path == '/api/v1/info'
+
+        req2.path == '/sky/token'
+        req2.getHeader('Authorization') == "Basic Zmx5OlpteDU="
+
+        req3.path == '/sky/userinfo'
+        req3.getHeader('Authorization') == "bearer my_token"
+
+        resp.status == 200
+    }
+
+    def "it uses v2 auth for concourse versions >= 6.1.0"() {
+        given:
+        setResponse '''{
+                "cluster_name": "mycluster",
+                "external_url": "https://mycluster.example.com",
+                "version": "6.1.0",
+                "worker_version": "2.2"
+            }''',
+            """{
+                "id_token": "my_id_token"
+            }""",
+            '''{
+                "name": "jsmith"
+            }'''
+
+        when:
+        Response resp = client.userInfo()
+        RecordedRequest req1 = server.takeRequest()
+        RecordedRequest req2 = server.takeRequest()
+        RecordedRequest req3 = server.takeRequest()
+
+        then:
+        req1.path == '/api/v1/info'
+
+        req2.path == '/sky/issuer/token'
+        req2.getHeader('Authorization') == "Basic Zmx5OlpteDU="
+
+        req3.path == '/api/v1/user'
+        req3.getHeader('Authorization') == "bearer my_id_token"
+
+        resp.status == 200
+    }
+
+    private void setResponse(String... body) {
+        for(int i = 0; i < body.length; i++) {
+            server.enqueue(
+                new MockResponse()
+                    .setBody(body[i])
+                    .setHeader('Content-Type', 'application/json;charset=utf-8')
+            )
+        }
+        server.start()
+        client = new ConcourseClient(server.getUrl('/').toString(), "test-username", "test-password")
+    }
+}

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitorTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitorTest.java
@@ -44,7 +44,12 @@ class ConcourseBuildMonitorTest {
   private MockWebServer mockConcourse = new MockWebServer();
 
   @BeforeEach
-  void before() {
+  void before() throws Exception {
+    mockConcourse.enqueue(
+        new MockResponse()
+            .setBody("{\"version\": \"6.0.0\"}")
+            .setHeader("Content-Type", "application/json;charset=utf-8"));
+
     ConcourseProperties.Host host = new ConcourseProperties.Host();
     host.setName("test");
     host.setUrl(mockConcourse.url("").toString());


### PR DESCRIPTION
* fix(concourse): support old and new concourse auth

Fixes concourse authentication for clusters >= v6.1.0 by detecting version and providing different implementation accordingly.

Addresses issue: https://github.com/spinnaker/spinnaker/issues/5797

* fix(concourse): support old and new concourse auth

Sending basic auth header to /info endpoint causes 401

Addresses issue: https://github.com/spinnaker/spinnaker/issues/5797

Co-authored-by: Jared Stehler <jared.stehler@edgenuity.com>

