### PR TITLE
fix(concourse): backport did not include missing class

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/ConcourseClient.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/ConcourseClient.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.netflix.spinnaker.igor.concourse.client.model.ClusterInfo;
 import com.netflix.spinnaker.igor.concourse.client.model.Token;
+import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import com.squareup.okhttp.OkHttpClient;
 import com.vdurmont.semver4j.Semver;
 import java.time.ZonedDateTime;


### PR DESCRIPTION
The backport cherry-picked the fix, but `Slf4jRetrofitLogger` was added in a prior commit I guess.

Interestingly, the https://github.com/spinnaker/igor/pull/824 PR's check and build didn't catch this 🤔 