### PR TITLE
feat(ciService): add more fields to generic ci service

### DIFF
--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/build/model/GenericBuild.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/build/model/GenericBuild.java
@@ -26,6 +26,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class GenericBuild {
   private boolean building;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/ci/CiBuildService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/ci/CiBuildService.java
@@ -32,8 +32,15 @@ public interface CiBuildService {
    *
    * @param projectKey the project key
    * @param repoSlug the repository name
+   * @param buildNumber the build number
+   * @param commitId the commit id
    * @param completionStatus filter builds based on status
    * @return a list of builds
    */
-  List<GenericBuild> getBuilds(String projectKey, String repoSlug, String completionStatus);
+  List<GenericBuild> getBuilds(
+      String projectKey,
+      String repoSlug,
+      String buildNumber,
+      String commitId,
+      String completionStatus);
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/ci/CiController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/ci/CiController.java
@@ -40,10 +40,12 @@ public class CiController {
 
   @GetMapping("/builds")
   public List<GenericBuild> getBuilds(
-      @RequestParam(value = "projectKey") String projectKey,
-      @RequestParam(value = "repoSlug") String repoSlug,
+      @RequestParam(value = "projectKey", required = false) String projectKey,
+      @RequestParam(value = "repoSlug", required = false) String repoSlug,
+      @RequestParam(value = "buildNumber", required = false) String buildNumber,
+      @RequestParam(value = "commitId", required = false) String commitId,
       @RequestParam(value = "completionStatus", required = false) String completionStatus) {
-    return getCiService().getBuilds(projectKey, repoSlug, completionStatus);
+    return getCiService().getBuilds(projectKey, repoSlug, buildNumber, commitId, completionStatus);
   }
 
   private CiBuildService getCiService() {


### PR DESCRIPTION
- adding build number and commit id to generic CI service endpoint
- adding `NoArgsConstructor` and `AllArgsConstructor` to `GenericBuild`