### PR TITLE
feat(includeDetails): changing includeDetails flag to true

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -101,10 +101,11 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
         Set<String> cachedImages = cache.getImages(account)
 
         long startTime = System.currentTimeMillis()
-        List<TaggedImage> images = AuthenticatedRequest.allowAnonymous { dockerRegistryAccounts.service.getImagesByAccount(account, null) }
+        //Netflix is adding `includeDetails` flag to `getImagesByAccount`, in order to get a detailed response from the resgistry
+        List<TaggedImage> images = AuthenticatedRequest.allowAnonymous { dockerRegistryAccounts.service.getImagesByAccount(account, true) }
 
         long endTime = System.currentTimeMillis()
-        log.debug("Executed generateDelta:DockerMonitor with includeData=false in {}ms", endTime - startTime);
+        log.debug("Executed generateDelta:DockerMonitor with includeData=true in {}ms", endTime - startTime);
 
         registry.timer("pollingMonitor.docker.retrieveImagesByAccount", [new BasicTag("account", account)])
             .record(System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
Netflix is adding a flag called `includeDetails` to `getImagesByAccount` endpoint, in order to get a detailed response from the docker registry (with details like commit id, build number etc. that we are currently caching).

This would not effect the current behavior of `getImagesByAccount`, as this is an optional query param.