### PR TITLE
Do not force nodeId configured when checking nexus webhook

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusEventPoster.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/nexus/NexusEventPoster.java
@@ -26,6 +26,8 @@ import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
 
 public class NexusEventPoster {
@@ -96,7 +98,11 @@ public class NexusEventPoster {
   }
 
   private Optional<NexusRepo> findNexusRepo(NexusAssetWebhookPayload payload) {
-    if (payload.getNodeId() != null) {
+    List<NexusRepo> repoWithId =
+        nexusProperties.getSearches().stream()
+            .filter(repo -> StringUtils.isNotBlank(repo.getNodeId()))
+            .collect(Collectors.toList());
+    if (payload.getNodeId() != null && !repoWithId.isEmpty()) {
       return nexusProperties.getSearches().stream()
           .filter(
               repo -> {


### PR DESCRIPTION
This PR addresses a problem that we do have with Nexus repositories. When you configure a nexus repository, right now you are forced to use nodeId, although it is optional, because when you configure webhooks in Nexus3, nodeId is always present. To allow this property to be really optional, we propose this PR, that checks previously if there are Nexus repositories configured with nodeId, and if there is none, check the repo name instead.

Hope you find it useful.