### PR TITLE
feat(travis): Adds more info to triggered Travis builds by default

### DIFF
--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
@@ -179,11 +179,15 @@ public class TravisService implements BuildOperations, BuildProperties {
     String repoSlug = cleanRepoSlug(inputRepoSlug);
     String branch = branchFromRepoSlug(inputRepoSlug);
     RepoRequest repoRequest = new RepoRequest(branch.isEmpty() ? "master" : branch);
+    String buildMessage;
     if (buildMessageKey != null && queryParameters.containsKey(buildMessageKey)) {
-      String buildMessage = queryParameters.get(buildMessageKey);
+      buildMessage = queryParameters.get(buildMessageKey);
       queryParameters.remove(buildMessageKey);
-      repoRequest.setMessage(repoRequest.getMessage() + ": " + buildMessage);
+    } else {
+      buildMessage =
+          "Application: '${execution.application}', pipeline: '${execution.name}', execution: '${execution.id}'";
     }
+    repoRequest.setMessage(repoRequest.getMessage() + ": " + buildMessage);
     repoRequest.setConfig(new Config(queryParameters));
     final TriggerResponse triggerResponse =
         travisClient.triggerBuild(getAccessToken(), repoSlug, repoRequest);


### PR DESCRIPTION
Adds some more info about the pipeline that triggered the Travis build. Piggybacking on the functionality added in #414.

Screenshot from Travis before and after the change:
![image](https://user-images.githubusercontent.com/155558/95584678-698c8900-0a3e-11eb-9fc9-70ec93afc442.png)
