### PR TITLE
fix(docker): use a more concrete reason for when the cache is empty

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -159,7 +159,11 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
                 if (sendEvents && item.sendEvent) {
                     postEvent(delta.cachedImages, item.image, item.imageId)
                 } else {
+                  if (!sendEvents) {
                     registry.counter(missedNotificationId.withTags("monitor", getName(), "reason", "fastForward")).increment()
+                  } else {
+                    registry.counter(missedNotificationId.withTags("monitor", getName(), "reason", "skippedDueToEmptyCache")).increment()
+                  }
                 }
             }
         }


### PR DESCRIPTION
Docker triggers might not send an event to echo if the cache was empty (e.g. instance just came)
Adding a reason to event to metric for this case
