### PR TITLE
fix(retrofit): Use the retrofit log level bean from retrofit configuration in kork-web

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DockerRegistryConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DockerRegistryConfig.groovy
@@ -42,7 +42,9 @@ class DockerRegistryConfig {
     }
 
     @Bean
-    ClouddriverService dockerRegistryProxyService(OkHttpClientProvider clientProvider, IgorConfigurationProperties igorConfigurationProperties) {
+    ClouddriverService dockerRegistryProxyService(OkHttpClientProvider clientProvider,
+                                                  IgorConfigurationProperties igorConfigurationProperties,
+                                                  RestAdapter.LogLevel retrofitLogLevel) {
         def address = igorConfigurationProperties.services.clouddriver.baseUrl ?: 'none'
         if (address == 'none') {
             null
@@ -51,7 +53,7 @@ class DockerRegistryConfig {
         new RestAdapter.Builder()
                 .setEndpoint(Endpoints.newFixedEndpoint(address))
                 .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("clouddriver", address))))
-                .setLogLevel(RestAdapter.LogLevel.BASIC)
+                .setLogLevel(retrofitLogLevel)
                 .setLog(new Slf4jRetrofitLogger(ClouddriverService))
                 .build()
                 .create(ClouddriverService)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/EchoConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/EchoConfig.groovy
@@ -35,7 +35,9 @@ import retrofit.RestAdapter
 @Configuration
 class EchoConfig {
     @Bean
-    EchoService echoService(OkHttpClientProvider okHttpClientProvider, IgorConfigurationProperties igorConfigurationProperties) {
+    EchoService echoService(OkHttpClientProvider okHttpClientProvider,
+                            IgorConfigurationProperties igorConfigurationProperties,
+                            RestAdapter.LogLevel retrofitLogLevel) {
         String address = igorConfigurationProperties.services.echo.baseUrl ?: 'none'
 
         if (address == 'none') {
@@ -45,7 +47,7 @@ class EchoConfig {
         new RestAdapter.Builder()
             .setEndpoint(Endpoints.newFixedEndpoint(address))
             .setClient(new Ok3Client(okHttpClientProvider.getClient(new DefaultServiceEndpoint("echo", address))))
-            .setLogLevel(RestAdapter.LogLevel.NONE)
+            .setLogLevel(retrofitLogLevel)
             .setLog(new Slf4jRetrofitLogger(EchoService))
             .build()
             .create(EchoService)

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
@@ -52,7 +52,9 @@ public class PluginMonitorConfig {
 
   @Bean
   public PluginReleaseService pluginReleaseService(
-      OkHttpClientProvider clientProvider, IgorConfigurationProperties properties) {
+      OkHttpClientProvider clientProvider,
+      IgorConfigurationProperties properties,
+      RestAdapter.LogLevel retrofitLogLevel) {
     String address = properties.getServices().getFront50().getBaseUrl();
 
     Front50Service front50Service =
@@ -61,7 +63,7 @@ public class PluginMonitorConfig {
             .setClient(
                 new Ok3Client(
                     clientProvider.getClient(new DefaultServiceEndpoint("front50", address))))
-            .setLogLevel(RestAdapter.LogLevel.BASIC)
+            .setLogLevel(retrofitLogLevel)
             .setLog(new Slf4jRetrofitLogger(Front50Service.class))
             .build()
             .create(Front50Service.class);

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/StashConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/StashConfig.groovy
@@ -45,20 +45,21 @@ import javax.validation.Valid
 class StashConfig {
 
     @Bean
-    StashMaster stashMaster(@Valid StashProperties stashProperties) {
+    StashMaster stashMaster(@Valid StashProperties stashProperties,
+                            RestAdapter.LogLevel retrofitLogLevel) {
         log.info "bootstrapping ${stashProperties.baseUrl} as stash"
         new StashMaster(
-            stashClient: stashClient(stashProperties.baseUrl, stashProperties.username, stashProperties.password),
+            stashClient: stashClient(stashProperties.baseUrl, stashProperties.username, stashProperties.password, retrofitLogLevel),
             baseUrl: stashProperties.baseUrl)
     }
 
-    StashClient stashClient(String address, String username, String password) {
+    StashClient stashClient(String address, String username, String password, RestAdapter.LogLevel retrofitLogLevel) {
         new RestAdapter.Builder()
             .setEndpoint(Endpoints.newFixedEndpoint(address))
             .setRequestInterceptor(new BasicAuthRequestInterceptor(username, password))
             .setClient(new OkClient())
             .setConverter(new JacksonConverter())
-            .setLogLevel(RestAdapter.LogLevel.BASIC)
+            .setLogLevel(retrofitLogLevel)
             .setLog(new Slf4jRetrofitLogger(StashClient))
             .build()
             .create(StashClient)

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/HelmConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/HelmConfig.java
@@ -75,7 +75,8 @@ public class HelmConfig {
   @Bean
   HelmAccountsService helmAccountsService(
       OkHttpClientConfiguration okHttpClientConfig,
-      IgorConfigurationProperties igorConfigurationProperties) {
+      IgorConfigurationProperties igorConfigurationProperties,
+      RestAdapter.LogLevel retrofitLogLevel) {
     String address = igorConfigurationProperties.getServices().getClouddriver().getBaseUrl();
 
     if (StringUtils.isEmpty(address)) {
@@ -87,7 +88,7 @@ public class HelmConfig {
         .setEndpoint(Endpoints.newFixedEndpoint(address))
         .setClient(new OkClient(okHttpClientConfig.create()))
         .setConverter(new StringConverter())
-        .setLogLevel(RestAdapter.LogLevel.BASIC)
+        .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(HelmAccountsService.class))
         .build()
         .create(HelmAccountsService.class);

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/KeelConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/KeelConfig.java
@@ -34,12 +34,6 @@ import retrofit.converter.JacksonConverter;
 public class KeelConfig {
 
   @Bean
-  public RestAdapter.LogLevel retrofitLogLevel(
-      @Value("${retrofit.log-level:BASIC}") String retrofitLogLevel) {
-    return RestAdapter.LogLevel.valueOf(retrofitLogLevel);
-  }
-
-  @Bean
   public Endpoint keelEndpoint(@Value("${services.keel.base-url}") String keelBaseUrl) {
     return Endpoints.newFixedEndpoint(keelBaseUrl);
   }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/client/StashClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/client/StashClientSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.igor.scm.stash.client.model.DirectoryListingRespons
 import com.netflix.spinnaker.igor.scm.stash.client.model.TextLinesResponse
 import com.squareup.okhttp.mockwebserver.MockResponse
 import com.squareup.okhttp.mockwebserver.MockWebServer
+import retrofit.RestAdapter
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -53,7 +54,7 @@ class StashClientSpec extends Specification {
                 .setHeader('Content-Type', contentType)
         )
         server.start()
-        client = new StashConfig().stashClient(server.getUrl('/').toString(), 'username', 'password')
+        client = new StashConfig().stashClient(server.getUrl('/').toString(), 'username', 'password', RestAdapter.LogLevel.BASIC)
     }
 
     void 'getCompareCommits'() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerClientSpec.groovy
@@ -17,6 +17,7 @@ import com.netflix.spinnaker.igor.wercker.model.*
 import com.squareup.okhttp.mockwebserver.MockResponse
 import com.squareup.okhttp.mockwebserver.MockWebServer
 import okhttp3.OkHttpClient
+import retrofit.RestAdapter
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -100,7 +101,7 @@ class WerckerClientSpec extends Specification {
                 )
         server.start()
         def host = new WerckerHost(name: 'werckerMaster', address: server.url('/').toString())
-        client = new WerckerConfig().werckerClient(host, 30000, new OkHttpClientProvider([new InsecureOkHttpClientBuilderProvider(new OkHttpClient())]))
+        client = new WerckerConfig().werckerClient(host, 30000, new OkHttpClientProvider([new InsecureOkHttpClientBuilderProvider(new OkHttpClient())]), RestAdapter.LogLevel.BASIC)
     }
 
     String read(String fileName) {


### PR DESCRIPTION
Make it more consistent logging wise (`echo` client had logging set to NONE 😱 )
