### PR TITLE
fix(docker): Log imageIds when logging new images found

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -119,7 +119,7 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
             }
         }
 
-        log.info("Found {} new images for {}", delta.size(), account)
+        log.info("Found {} new images for {}. Images: {}", delta.size(), account, delta.collect {[imageId: it.imageId, sendEvent: it.sendEvent] })
 
         return new DockerPollingDelta(items: delta, cachedImages: cachedImages)
     }


### PR DESCRIPTION
We have seen an intermittent issue wherein the same docker image is found as new and thus Igor sends multiple events to Echo.  Adding this log here should help verify the theory that we are indeed seeing the same image as new multiple times.
