### PR TITLE
feat(buildLog): adding build log hook

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/ci/CiBuildService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/ci/CiBuildService.java
@@ -43,4 +43,13 @@ public interface CiBuildService {
       String buildNumber,
       String commitId,
       String completionStatus);
+
+  /**
+   * Get the build log by providing the build id. The data returned will be used in the CI view, to
+   * present the build's log.
+   *
+   * @param buildId
+   * @return a string represent the build log
+   */
+  String getBuildOutput(String buildId);
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/ci/CiController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/ci/CiController.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,6 +47,11 @@ public class CiController {
       @RequestParam(value = "commitId", required = false) String commitId,
       @RequestParam(value = "completionStatus", required = false) String completionStatus) {
     return getCiService().getBuilds(projectKey, repoSlug, buildNumber, commitId, completionStatus);
+  }
+
+  @GetMapping("/builds/{buildId}/output")
+  public String getBuildOutput(@PathVariable(value = "buildId") String buildId) {
+    return getCiService().getBuildOutput(buildId);
   }
 
   private CiBuildService getCiService() {


### PR DESCRIPTION
As a part of our effort to open source the CI view in Spinnaker, we have 2 endpoints which power this view:
1. get all builds, based on a project and repo names.
2. for each build, get the build log.

We already added the first hook (#1). This PR is adding the second hook to fetch the build log.
In order to use these hooks, you'll have to implement a `CiBuildService` in your `igor` fork, with concrete implementation to those two endpoints.

The CI view will call those endpoints from `deck` (the UI) via `gate`.