### PR TITLE
chore(logs): allow anonymous calls to jenkins to get builds and projects

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -76,6 +76,7 @@ dependencies {
     implementation "com.netflix.spinnaker.kork:kork-config"
     implementation "com.netflix.spinnaker.kork:kork-cloud-config-server"
     implementation "com.netflix.spinnaker.kork:kork-artifacts"
+    implementation "com.netflix.spinnaker.kork:kork-exceptions"
     implementation "com.netflix.spinnaker.kork:kork-web"
     implementation "com.netflix.spinnaker.kork:kork-jedis"
     implementation "com.netflix.spinnaker.kork:kork-telemetry"


### PR DESCRIPTION
to clean up warnings like:
```
2020-12-14 19:20:54.704  WARN 1 --- [   scheduling-1] c.n.s.okhttp.OkHttp3MetricsInterceptor   : Request GET:https://jenkins.<mydomain>/job/<somejob>/job/master/api/xml?exclude=/*/build/action[not(totalCount)]&tree=builds[number,url,duration,timestamp,result,building,url,fullDisplayName,actions[failCount,skipCount,totalCount]] is missing [X-SPINNAKER-USER, X-SPINNAKER-ACCOUNTS] authentication headers and will be treated as anonymous.
Request from: com.netflix.spinnaker.okhttp.MetricsInterceptor.doIntercept(MetricsInterceptor.java:95)
	at com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor.intercept(OkHttp3MetricsInterceptor.java:33)
	at com.netflix.spinnaker.igor.jenkins.service.JenkinsService.lambda$getBuilds$4(JenkinsService.java:163)
	at com.netflix.spinnaker.igor.jenkins.service.JenkinsService.getBuilds(JenkinsService.java:163)
	at com.netflix.spinnaker.igor.service.BuildOperations$getBuilds.call(Unknown Source)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor.getBuilds(JenkinsBuildMonitor.groovy:174)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor.processBuildsOfProject(JenkinsBuildMonitor.groovy:138)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor$_generateDelta_closure2$_closure10.doCall(JenkinsBuildMonitor.groovy:113)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor$_generateDelta_closure2.doCall(JenkinsBuildMonitor.groovy:113)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor$_generateDelta_closure2.doCall(JenkinsBuildMonitor.groovy)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor.generateDelta(JenkinsBuildMonitor.groovy:110)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor.generateDelta(JenkinsBuildMonitor.groovy)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.internalPollSingle(CommonPollingMonitor.java:169)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.lambda$pollSingle$2(CommonPollingMonitor.java:141)
	at com.netflix.spinnaker.kork.jedis.lock.RedisLockManager.doAcquire(RedisLockManager.java:230)
	at com.netflix.spinnaker.kork.jedis.lock.RedisLockManager.acquire(RedisLockManager.java:268)
	at com.netflix.spinnaker.kork.jedis.lock.RedisLockManager.acquireLock(RedisLockManager.java:138)
	at com.netflix.spinnaker.igor.polling.LockService.acquire(LockService.java:48)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.pollSingle(CommonPollingMonitor.java:141)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor$_poll_closure1.doCall(JenkinsBuildMonitor.groovy:96)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor.poll(JenkinsBuildMonitor.groovy:95)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.lambda$onApplicationEvent$0(CommonPollingMonitor.java:94)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.lambda$onApplicationEvent$1(CommonPollingMonitor.java:91)
```
and
```
2020-12-14 19:21:37.543  WARN 1 --- [   scheduling-1] c.n.s.okhttp.OkHttp3MetricsInterceptor   : Request GET:https://jenkins.<mydomain>/api/xml?tree=jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url],jobs[name,lastBuild[actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url]]]]]]]]]]]&exclude=/*/*/*/action[not(totalCount)] is missing [X-SPINNAKER-USER, X-SPINNAKER-ACCOUNTS] authentication headers and will be treated as anonymous.
Request from: com.netflix.spinnaker.okhttp.MetricsInterceptor.doIntercept(MetricsInterceptor.java:95)
	at com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor.intercept(OkHttp3MetricsInterceptor.java:33)
	at com.netflix.spinnaker.igor.jenkins.service.JenkinsService.lambda$getProjects$1(JenkinsService.java:115)
	at com.netflix.spinnaker.igor.jenkins.service.JenkinsService.getProjects(JenkinsService.java:113)
	at com.netflix.spinnaker.igor.jenkins.service.JenkinsService$getProjects.call(Unknown Source)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor$_generateDelta_closure2.doCall(JenkinsBuildMonitor.groovy:112)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor$_generateDelta_closure2.doCall(JenkinsBuildMonitor.groovy)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor.generateDelta(JenkinsBuildMonitor.groovy:110)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor.generateDelta(JenkinsBuildMonitor.groovy)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.internalPollSingle(CommonPollingMonitor.java:169)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.lambda$pollSingle$2(CommonPollingMonitor.java:141)
	at com.netflix.spinnaker.kork.jedis.lock.RedisLockManager.doAcquire(RedisLockManager.java:230)
	at com.netflix.spinnaker.kork.jedis.lock.RedisLockManager.acquire(RedisLockManager.java:268)
	at com.netflix.spinnaker.kork.jedis.lock.RedisLockManager.acquireLock(RedisLockManager.java:138)
	at com.netflix.spinnaker.igor.polling.LockService.acquire(LockService.java:48)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.pollSingle(CommonPollingMonitor.java:141)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor$_poll_closure1.doCall(JenkinsBuildMonitor.groovy:96)
	at com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor.poll(JenkinsBuildMonitor.groovy:95)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.lambda$onApplicationEvent$0(CommonPollingMonitor.java:94)
	at com.netflix.spinnaker.igor.polling.CommonPollingMonitor.lambda$onApplicationEvent$1(CommonPollingMonitor.java:91)
```
there are other jenkins calls in this file that could likely benefit from the same treatment, but since I haven't experienced the struggle myself, I'm leaving those alone.
