### PR TITLE
chore(release): Add weekly release

### DIFF
--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -1,0 +1,57 @@
+name: Weekly Release
+
+on:
+  schedule:
+    # Every Tuesday at 10 PM UTC (2 PM PST)
+    - cron: "0 22 * * 2"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch: {}
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Prepare changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: "false"
+          skip-version-file: "true"
+          skip-commit: "true"
+
+      - name: Release build
+        env:
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+          RELEASE_VERSION: ${{ steps.changelog.outputs.version }}
+        run: |
+          echo "Building release ${RELEASE_VERSION}"
+          ./gradlew --info -Pversion="${RELEASE_VERSION}" -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" -PbintrayPublishDebEnabled=false publish
+
+      - name: Create release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ github.event.repository.name }} ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          draft: false
+          prerelease: true

--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -37,12 +37,15 @@ jobs:
 
       - name: Release build
         env:
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-          RELEASE_VERSION: ${{ steps.changelog.outputs.version }}
+          ORG_GRADLE_PROJECT_version:  ${{ steps.changelog.outputs.version }}
+          ORG_GRADLE_PROJECT_nexusPublishEnabled: true
+          ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_nexusPgpSigningKey: ${{ secrets.NEXUS_PGP_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_nexusPgpSigningPassword: ${{ secrets.NEXUS_PGP_SIGNING_PASSWORD }}
         run: |
           echo "Building release ${RELEASE_VERSION}"
-          ./gradlew --info -Pversion="${RELEASE_VERSION}" -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" -PbintrayPublishDebEnabled=false publish
+          ./gradlew --info publishToNexus closeAndReleaseNexusStagingRepository
 
       - name: Create release
         uses: actions/create-release@v1


### PR DESCRIPTION
Similarly to what we've done for Keel recently, this PR adds a new GitHub action to automatically trigger a weekly release for Igor such that we don't have to manually cut releases. This is intended to enable other organizations consuming releases outside of Netflix.