### PR TITLE
fix(jenkins): Using null breaks the cache mechanism

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -201,7 +201,8 @@ class BuildController {
       HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).split('/').drop(4).join('/')
 
     String pendingKey = computePendingBuildKey(master, job, requestParams, startTime)
-    String buildNumber = null
+    // Initializing buildNumber to null will get it silently casted to "null" down the line
+    String buildNumber = ""
 
     PendingOperationsCache.OperationState pendingStatus = pendingOperationsCache.getAndSetOperationStatus(pendingKey, PendingOperationsCache.OperationStatus.PENDING, "")
     if (pendingStatus.status == PendingOperationsCache.OperationStatus.PENDING) {


### PR DESCRIPTION
Fix issue https://github.com/spinnaker/spinnaker/issues/6217.

Here is what happens now :

* buildNumber gets casted from null to "null" when calling `pendingOperationsCache.setOperationStatus(pendingKey, PendingOperationsCache.OperationStatus.COMPLETED, buildNumber)`
* Next call from orca evaluate `!Strings.isNullOrEmpty(pendingStatus.value)` as true and returns "null" as job identifier thus breaking the next step.
