### PR TITLE
chore(dependencies): bump artifactory-java-client-services version to 2.9.2

### DIFF
--- a/igor-monitor-artifactory/igor-monitor-artifactory.gradle
+++ b/igor-monitor-artifactory/igor-monitor-artifactory.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
 
-  implementation "org.jfrog.artifactory.client:artifactory-java-client-services:2.8.1"
+  implementation "org.jfrog.artifactory.client:artifactory-java-client-services:2.9.2"
 
   // TODO(rz): Get rid of this dependency!
   implementation "io.spinnaker.kork:kork-jedis"


### PR DESCRIPTION
after Bintray sunset this artifact moved to Maven Central, however only version 2.9.2 is available
