### PR TITLE
refactor(igor): Rename master to controller

### DIFF
--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/config/BuildServerProperties.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/config/BuildServerProperties.java
@@ -26,7 +26,7 @@ import java.util.List;
  *
  * <pre>{@code
  * someProvider:
- *   masters:
+ *   controllers:
  *   - name: someProvider-host1
  *     address: https://foo.com/api
  *     permissions:
@@ -46,9 +46,18 @@ public interface BuildServerProperties<T extends BuildServerProperties.Host> {
   /**
    * Returns a list of the build service hosts configured with this provider
    *
+   * @deprecated
    * @return The build service hosts
    */
+  @Deprecated(forRemoval = true)
   List<T> getMasters();
+
+  /**
+   * Returns a list of the build service hosts configured with this provider
+   *
+   * @return The build service hosts
+   */
+  List<T> getControllers();
 
   /** Interface for representing the properties of a specific build service host */
   interface Host {
@@ -75,7 +84,7 @@ public interface BuildServerProperties<T extends BuildServerProperties.Host> {
      *
      * <pre>{@code
      * someProvider:
-     *   masters:
+     *   controllers:
      *   - name: someProvider-host1
      *     address: https://foo.com/api
      *     permissions:

--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/history/model/GenericBuildContent.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/history/model/GenericBuildContent.java
@@ -22,6 +22,20 @@ import lombok.Data;
 @Data
 public class GenericBuildContent {
   private GenericProject project;
+
+  @Deprecated(forRemoval = true)
   private String master;
+
+  @Deprecated(forRemoval = true)
+  public String getMaster() {
+    return controller;
+  }
+
+  @Deprecated(forRemoval = true)
+  public void setMaster(String controller) {
+    this.controller = controller;
+  }
+
+  private String controller;
   private String type;
 }

--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/service/BuildOperations.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/service/BuildOperations.java
@@ -77,8 +77,8 @@ public interface BuildOperations extends BuildService {
 
   JobConfiguration getJobConfig(String jobName);
 
-  default Object queuedBuild(String master, int item) {
+  default Object queuedBuild(String controller, int item) {
     throw new UnsupportedOperationException(
-        String.format("Queued builds are not supported for build service %s", master));
+        String.format("Queued builds are not supported for build service %s", controller));
   }
 }

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
@@ -47,11 +47,11 @@ public class TravisCache {
     this.igorConfigurationProperties = igorConfigurationProperties;
   }
 
-  public Map<String, Integer> getQueuedJob(String master, int queueNumber) {
+  public Map<String, Integer> getQueuedJob(String controller, int queueNumber) {
     Map<String, String> result =
         redisClientDelegate.withCommandsClient(
             c -> {
-              return c.hgetAll(makeKey(QUEUE_TYPE, master, queueNumber));
+              return c.hgetAll(makeKey(QUEUE_TYPE, controller, queueNumber));
             });
 
     if (result.isEmpty()) {
@@ -65,8 +65,8 @@ public class TravisCache {
     return converted;
   }
 
-  public int setQueuedJob(String master, int repositoryId, int requestId) {
-    String key = makeKey(QUEUE_TYPE, master, requestId);
+  public int setQueuedJob(String controller, int repositoryId, int requestId) {
+    String key = makeKey(QUEUE_TYPE, controller, requestId);
     redisClientDelegate.withCommandsClient(
         c -> {
           c.hset(key, "requestId", Integer.toString(requestId));
@@ -75,31 +75,31 @@ public class TravisCache {
     return requestId;
   }
 
-  public void removeQuededJob(String master, int queueId) {
+  public void removeQuededJob(String controller, int queueId) {
     redisClientDelegate.withCommandsClient(
         c -> {
-          c.del(makeKey(QUEUE_TYPE, master, queueId));
+          c.del(makeKey(QUEUE_TYPE, controller, queueId));
         });
   }
 
-  public void setJobLog(String master, int jobId, String log) {
-    String key = makeKey(LOG_TYPE, master, jobId);
+  public void setJobLog(String controller, int jobId, String log) {
+    String key = makeKey(LOG_TYPE, controller, jobId);
     redisClientDelegate.withCommandsClient(
         c -> {
           c.setex(key, LOG_EXPIRE_SECONDS, log);
         });
   }
 
-  public String getJobLog(String master, int jobId) {
-    String key = makeKey(LOG_TYPE, master, jobId);
+  public String getJobLog(String controller, int jobId) {
+    String key = makeKey(LOG_TYPE, controller, jobId);
     return redisClientDelegate.withCommandsClient(
         c -> {
           return c.get(key);
         });
   }
 
-  private String makeKey(String type, String master, int id) {
-    return baseKey() + ":" + type + ":" + master + ":" + id;
+  private String makeKey(String type, String controller, int id) {
+    return baseKey() + ":" + type + ":" + controller + ":" + id;
   }
 
   private String baseKey() {

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/TravisControllers.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/TravisControllers.java
@@ -1,8 +1,9 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2018 Schibsted ASA.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ *
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
@@ -14,15 +15,19 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.igor.jenkins.client
+package com.netflix.spinnaker.igor.travis.client;
 
-import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
+import com.netflix.spinnaker.igor.travis.service.TravisService;
+import java.util.Map;
 
-/**
- * Wrapper class for a collection of jenkins clients
- */
-class JenkinsMasters {
+public class TravisControllers {
+  private Map<String, TravisService> map;
 
-    Map<String, JenkinsService> map
+  public Map<String, TravisService> getMap() {
+    return map;
+  }
 
+  public void setMap(Map<String, TravisService> map) {
+    this.map = map;
+  }
 }

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisConfig.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisConfig.java
@@ -57,7 +57,7 @@ import retrofit.converter.JacksonConverter;
 public class TravisConfig {
 
   @Bean
-  public Map<String, TravisService> travisMasters(
+  public Map<String, TravisService> travisControllers(
       BuildServices buildServices,
       TravisCache travisCache,
       IgorConfigurationProperties igorConfigurationProperties,
@@ -65,12 +65,12 @@ public class TravisConfig {
       ObjectMapper objectMapper,
       Optional<ArtifactDecorator> artifactDecorator,
       CircuitBreakerRegistry circuitBreakerRegistry) {
-    log.info("creating travisMasters");
+    log.info("creating travisControllers");
 
-    Map<String, TravisService> travisMasters =
+    Map<String, TravisService> travisControllers =
         (travisProperties == null
                 ? new ArrayList<TravisProperties.TravisHost>()
-                : travisProperties.getMasters())
+                : travisProperties.getControllers())
             .stream()
                 .map(
                     host -> {
@@ -112,8 +112,8 @@ public class TravisConfig {
                     })
                 .collect(Collectors.toMap(TravisService::getGroupKey, Function.identity()));
 
-    buildServices.addServices(travisMasters);
-    return travisMasters;
+    buildServices.addServices(travisControllers);
+    return travisControllers;
   }
 
   public static TravisClient travisClient(String address, int timeout, ObjectMapper objectMapper) {

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisProperties.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisProperties.java
@@ -35,7 +35,8 @@ public class TravisProperties implements BuildServerProperties<TravisProperties.
   @Deprecated private long newBuildGracePeriodSeconds;
   private boolean repositorySyncEnabled = false;
   private int cachedJobTTLDays = 60;
-  @Valid private List<TravisHost> masters;
+  @Deprecated @Valid private List<TravisHost> masters;
+  @Valid private List<TravisHost> controllers;
   @Valid private List<String> regexes;
   /**
    * Lets you customize the build message used when Spinnaker triggers builds in Travis. If you set
@@ -45,6 +46,19 @@ public class TravisProperties implements BuildServerProperties<TravisProperties.
    * not customizable.
    */
   private String buildMessageKey = "travis.buildMessage";
+
+  @Deprecated(forRemoval = true)
+  public List<TravisHost> getMasters() {
+    return this.controllers;
+  }
+
+  @Deprecated(forRemoval = true)
+  public void setMasters(List<TravisHost> controllers) {
+    log.warn(
+        "The 'travis.masters' property is no longer in use and the value will be ignored. "
+            + "The new option 'travis.controllers' will let you define controllers.");
+    this.controllers = controllers;
+  }
 
   @Deprecated
   public void setNewBuildGracePeriodSeconds(long newBuildGracePeriodSeconds) {
@@ -80,7 +94,7 @@ public class TravisProperties implements BuildServerProperties<TravisProperties.
       log.warn(
           "The 'travis.numberOfRepositories' property is no longer in use and the value will be ignored. "
               + "If you want to limit the number of builds retrieved per polling cycle, you can use the property "
-              + "'travis.[master].numberOfJobs' (default: 100).");
+              + "'travis.[controller].numberOfJobs' (default: 100).");
       this.numberOfRepositories = numberOfRepositories;
     }
   }

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
@@ -508,7 +508,7 @@ public class TravisService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  public Map<String, Integer> queuedBuild(String master, int queueId) {
+  public Map<String, Integer> queuedBuild(String controller, int queueId) {
     Map<String, Integer> queuedJob = travisCache.getQueuedJob(groupKey, queueId);
     Request requestResponse =
         travisClient.request(

--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -44,7 +44,7 @@ redis:
 #  newBuildGracePeriodSeconds: 10
 #
 #  Travis names are prefixed with travis- inside igor.
-#  masters:
+#  controllers:
 #    - name: ci # This will show as travis-ci inside spinnaker.
 #      baseUrl: https://travis-ci.com
 #      address: https://api.travis-ci.com

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/admin/AdminController.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/admin/AdminController.java
@@ -47,8 +47,8 @@ public class AdminController {
    * Silently fast-forwards a poller. Fast-forwarding means that all pending cache state will be
    * polled and saved, but will not send Echo notifications.
    *
-   * <p>By default all partitions (ex: masters) will be fast-forwarded, however specific partition
-   * names should be used whenever possible.
+   * <p>By default all partitions (ex: controllers) will be fast-forwarded, however specific
+   * partition names should be used whenever possible.
    *
    * @param monitorName The polling monitor name (ex: "DockerMonitor")
    * @param partition The partition name, if not provided, method will re-index the entire monitor

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/BitBucketConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/BitBucketConfig.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.igor.config
 
 import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketClient
-import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketMaster
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketController
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
 import com.squareup.okhttp.Credentials
 import groovy.transform.CompileStatic
@@ -44,9 +44,9 @@ import javax.validation.Valid
 class BitBucketConfig {
 
   @Bean
-  BitBucketMaster bitBucketMaster(@Valid BitBucketProperties bitBucketProperties) {
+  BitBucketController bitBucketController(@Valid BitBucketProperties bitBucketProperties) {
     log.info "bootstrapping ${bitBucketProperties.baseUrl} as bitbucket"
-    new BitBucketMaster(
+    new BitBucketController(
       bitBucketClient: bitBucketClient(bitBucketProperties.baseUrl, bitBucketProperties.username, bitBucketProperties.password),
       baseUrl: bitBucketProperties.baseUrl)
   }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/BitBucketProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/BitBucketProperties.groovy
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import javax.validation.constraints.NotNull
 
 /**
- * Helper class to map masters in properties file into a validated property map
+ * Helper class to map controllers in properties file into a validated property map
  */
 @ConditionalOnProperty('bitbucket.base-url')
 @CompileStatic

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitHubConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitHubConfig.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.igor.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.igor.scm.github.client.GitHubClient
-import com.netflix.spinnaker.igor.scm.github.client.GitHubMaster
+import com.netflix.spinnaker.igor.scm.github.client.GitHubController
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -45,9 +45,9 @@ import javax.validation.Valid
 class GitHubConfig {
 
     @Bean
-    GitHubMaster gitHubMasters(@Valid GitHubProperties gitHubProperties, ObjectMapper mapper) {
+    GitHubController gitHubControllers(@Valid GitHubProperties gitHubProperties, ObjectMapper mapper) {
         log.info "bootstrapping ${gitHubProperties.baseUrl} as github"
-        new GitHubMaster(gitHubClient: gitHubClient(gitHubProperties.baseUrl, gitHubProperties.accessToken, mapper), baseUrl: gitHubProperties.baseUrl)
+        new GitHubController(gitHubClient: gitHubClient(gitHubProperties.baseUrl, gitHubProperties.accessToken, mapper), baseUrl: gitHubProperties.baseUrl)
     }
 
     GitHubClient gitHubClient(String address, String accessToken, ObjectMapper mapper = new ObjectMapper()) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitHubProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitHubProperties.groovy
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import javax.validation.constraints.NotNull
 
 /**
- * Helper class to map masters in properties file into a validated property map
+ * Helper class to map controllers in properties file into a validated property map
  */
 @ConditionalOnProperty('github.base-url')
 @CompileStatic

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitLabConfig.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitLabConfig.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.igor.config;
 
 import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabClient;
-import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabMaster;
+import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabController;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import javax.validation.Valid;
 import org.slf4j.Logger;
@@ -39,9 +39,9 @@ public class GitLabConfig {
   private static final Logger log = LoggerFactory.getLogger(GitLabConfig.class);
 
   @Bean
-  public GitLabMaster gitLabMasters(@Valid GitLabProperties gitLabProperties) {
+  public GitLabController gitLabControllers(@Valid GitLabProperties gitLabProperties) {
     log.info("bootstrapping {} as gitlab", gitLabProperties.getBaseUrl());
-    return new GitLabMaster(
+    return new GitLabController(
         gitLabClient(gitLabProperties.getBaseUrl(), gitLabProperties.getPrivateToken()),
         gitLabProperties.getBaseUrl());
   }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitLabProperties.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitLabProperties.java
@@ -21,7 +21,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Helper class to map masters in properties file into a validated property map. */
+/** Helper class to map controllers in properties file into a validated property map. */
 @ConditionalOnProperty("gitlab.base-url")
 @ConfigurationProperties(prefix = "gitlab")
 public class GitLabProperties {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiConfig.java
@@ -46,14 +46,14 @@ public class GitlabCiConfig {
   private static final Logger log = LoggerFactory.getLogger(GitlabCiConfig.class);
 
   @Bean
-  public Map<String, GitlabCiService> gitlabCiMasters(
+  public Map<String, GitlabCiService> gitlabCiControllers(
       BuildServices buildServices,
       final IgorConfigurationProperties igorConfigurationProperties,
       GitlabCiProperties gitlabCiProperties,
       ObjectMapper objectMapper) {
-    log.info("creating gitlabCiMasters");
-    Map<String, GitlabCiService> gitlabCiMasters =
-        gitlabCiProperties.getMasters().stream()
+    log.info("creating gitlabCiControllers");
+    Map<String, GitlabCiService> gitlabCiControllers =
+        gitlabCiProperties.getControllers().stream()
             .map(
                 gitlabCiHost ->
                     gitlabCiService(
@@ -62,8 +62,8 @@ public class GitlabCiConfig {
                         gitlabCiHost,
                         objectMapper))
             .collect(Collectors.toMap(GitlabCiService::getName, Function.identity()));
-    buildServices.addServices(gitlabCiMasters);
-    return gitlabCiMasters;
+    buildServices.addServices(gitlabCiControllers);
+    return gitlabCiControllers;
   }
 
   private static GitlabCiService gitlabCiService(

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.java
@@ -28,7 +28,7 @@ import org.springframework.validation.annotation.Validated;
 public class GitlabCiProperties implements BuildServerProperties<GitlabCiProperties.GitlabCiHost> {
   private int cachedJobTTLDays = 60;
 
-  @Valid private List<GitlabCiHost> masters = new ArrayList<>();
+  @Valid private List<GitlabCiHost> controllers = new ArrayList<>();
 
   public int getCachedJobTTLDays() {
     return cachedJobTTLDays;
@@ -38,12 +38,22 @@ public class GitlabCiProperties implements BuildServerProperties<GitlabCiPropert
     this.cachedJobTTLDays = cachedJobTTLDays;
   }
 
+  @Deprecated(forRemoval = true)
   public List<GitlabCiHost> getMasters() {
-    return masters;
+    return controllers;
   }
 
-  public void setMasters(List<GitlabCiHost> masters) {
-    this.masters = masters;
+  @Deprecated(forRemoval = true)
+  public void setMasters(List<GitlabCiHost> controllers) {
+    this.controllers = controllers;
+  }
+
+  public List<GitlabCiHost> getControllers() {
+    return controllers;
+  }
+
+  public void setControllers(List<GitlabCiHost> controllers) {
+    this.controllers = controllers;
   }
 
   public static class GitlabCiHost implements BuildServerProperties.Host {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsConfig.groovy
@@ -81,7 +81,7 @@ class JenkinsConfig {
     }
 
     @Bean
-    Map<String, JenkinsService> jenkinsMasters(BuildServices buildServices,
+    Map<String, JenkinsService> jenkinsControllers(BuildServices buildServices,
                                                IgorConfigurationProperties igorConfigurationProperties,
                                                @Valid JenkinsProperties jenkinsProperties,
                                                JenkinsOkHttpClientProvider jenkinsOkHttpClientProvider,
@@ -89,8 +89,8 @@ class JenkinsConfig {
                                                Registry registry,
                                                CircuitBreakerRegistry circuitBreakerRegistry,
                                                RestAdapter.LogLevel retrofitLogLevel) {
-        log.info "creating jenkinsMasters"
-        Map<String, JenkinsService> jenkinsMasters = jenkinsProperties?.masters?.collectEntries { JenkinsProperties.JenkinsHost host ->
+        log.info "creating jenkinsControllers"
+        Map<String, JenkinsService> jenkinsControllers = jenkinsProperties?.controllers?.collectEntries { JenkinsProperties.JenkinsHost host ->
             log.info "bootstrapping ${host.address} as ${host.name}"
             [(host.name): jenkinsService(
                 host.name,
@@ -108,8 +108,8 @@ class JenkinsConfig {
             )]
         }
 
-        buildServices.addServices(jenkinsMasters)
-        jenkinsMasters
+        buildServices.addServices(jenkinsControllers)
+        jenkinsControllers
     }
 
     static JenkinsService jenkinsService(

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.igor.config
 
 import com.netflix.spinnaker.fiat.model.resources.Permissions
 import groovy.transform.CompileStatic
-import org.hibernate.validator.constraints.NotEmpty
+import javax.validation.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.validation.annotation.Validated
 
@@ -32,8 +32,19 @@ import java.security.KeyStore
 @ConfigurationProperties(prefix = 'jenkins')
 @Validated
 class JenkinsProperties implements BuildServerProperties<JenkinsProperties.JenkinsHost> {
+    @Deprecated(forRemoval = true)
     @Valid
     List<JenkinsHost> masters
+
+    @Deprecated(forRemoval = true)
+    public List<JenkinsProperties.JenkinsHost> getMasters() { return controllers; }
+
+
+    @Deprecated(forRemoval = true)
+    public void setMasters(List<JenkinsProperties.JenkinsHost> controllers) { this.controllers = controllers; }
+
+    @Valid
+    List<JenkinsHost> controllers
 
     static class JenkinsHost implements BuildServerProperties.Host {
         @NotEmpty

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/StashConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/StashConfig.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.igor.config
 
 import com.netflix.spinnaker.igor.scm.stash.client.StashClient
-import com.netflix.spinnaker.igor.scm.stash.client.StashMaster
+import com.netflix.spinnaker.igor.scm.stash.client.StashController
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
 import com.squareup.okhttp.Credentials
 import groovy.transform.CompileStatic
@@ -45,10 +45,10 @@ import javax.validation.Valid
 class StashConfig {
 
     @Bean
-    StashMaster stashMaster(@Valid StashProperties stashProperties,
-                            RestAdapter.LogLevel retrofitLogLevel) {
+    StashController stashController(@Valid StashProperties stashProperties,
+                                RestAdapter.LogLevel retrofitLogLevel) {
         log.info "bootstrapping ${stashProperties.baseUrl} as stash"
-        new StashMaster(
+        new StashController(
             stashClient: stashClient(stashProperties.baseUrl, stashProperties.username, stashProperties.password, retrofitLogLevel),
             baseUrl: stashProperties.baseUrl)
     }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/StashProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/StashProperties.groovy
@@ -21,7 +21,7 @@ import org.hibernate.validator.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * Helper class to map masters in properties file into a validated property map
+ * Helper class to map controllers in properties file into a validated property map
  */
 @CompileStatic
 @ConfigurationProperties(prefix = 'stash')

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/WerckerConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/WerckerConfig.groovy
@@ -41,21 +41,21 @@ import retrofit.RestAdapter
 @EnableConfigurationProperties(WerckerProperties)
 class WerckerConfig {
     @Bean
-    Map<String, WerckerService> werckerMasters(
+    Map<String, WerckerService> werckerControllers(
         BuildServices buildServices,
         WerckerCache cache,
         IgorConfigurationProperties igorConfigurationProperties,
         OkHttpClientProvider clientProvider,
         @Valid WerckerProperties werckerProperties,
         RestAdapter.LogLevel retrofitLogLevel) {
-        log.debug "creating werckerMasters"
-        Map<String, WerckerService> werckerMasters = werckerProperties?.masters?.collectEntries { WerckerHost host ->
+        log.debug "creating werckerControllers"
+        Map<String, WerckerService> werckerControllers = werckerProperties?.controllers?.collectEntries { WerckerHost host ->
             log.debug "bootstrapping Wercker ${host.address} as ${host.name}"
             [(host.name): new WerckerService(host, cache, werckerClient(host, igorConfigurationProperties.getClient().timeout, clientProvider, retrofitLogLevel), host.permissions.build())]
         }
 
-        buildServices.addServices(werckerMasters)
-        werckerMasters
+        buildServices.addServices(werckerControllers)
+        werckerControllers
     }
 
     static WerckerClient werckerClient(WerckerHost host, int timeout = 30000, OkHttpClientProvider clientProvider, RestAdapter.LogLevel retrofitLogLevel) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/WerckerProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/WerckerProperties.groovy
@@ -21,8 +21,18 @@ import javax.validation.Valid
 @CompileStatic
 @ConfigurationProperties(prefix = 'wercker')
 class WerckerProperties implements BuildServerProperties<WerckerProperties.WerckerHost> {
+    @Deprecated(forRemoval = true)
     @Valid
     List<WerckerHost> masters
+
+    @Deprecated(forRemoval = true)
+    public List<WerckerProperties.WerckerHost> getMasters() { return controllers; }
+
+    @Deprecated(forRemoval = true)
+    public void setMasters(List<WerckerProperties.WerckerHost> controllers) { this.controllers = controllers; }
+
+    @Valid
+    List<WerckerHost> controllers
 
     static class WerckerHost implements BuildServerProperties.Host {
         @NotEmpty

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/exceptions/ArtifactNotFoundException.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/exceptions/ArtifactNotFoundException.java
@@ -24,10 +24,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(NOT_FOUND)
 public class ArtifactNotFoundException extends NotFoundException {
   public ArtifactNotFoundException(
-      String master, String job, Integer buildNumber, String fileName) {
+      String controller, String job, Integer buildNumber, String fileName) {
     super(
         String.format(
             "Could not find build artifact matching requested filename '%s' on '%s/%s' build %s",
-            fileName, master, job, buildNumber));
+            fileName, controller, job, buildNumber));
   }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/BuildContent.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/history/model/BuildContent.groovy
@@ -25,5 +25,5 @@ import com.netflix.spinnaker.igor.jenkins.client.model.Project
  */
 class BuildContent {
     Project project
-    String master
+    String controller
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsControllers.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsControllers.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2014 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.igor.scm;
+package com.netflix.spinnaker.igor.jenkins.client
 
-import java.util.List;
+import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 
-/** Abstracts underlying implementation details of each SCM system under a common interface. */
-public interface ScmMaster {
-  String DEFAULT_GIT_REF = "refs/heads/master";
+/**
+ * Wrapper class for a collection of jenkins clients
+ */
+class JenkinsControllers {
 
-  List<String> listDirectory(String projectKey, String repositorySlug, String path, String ref);
+    Map<String, JenkinsService> map
 
-  String getTextFileContents(String projectKey, String repositorySlug, String path, String ref);
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
@@ -237,13 +237,13 @@ public class JenkinsService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  public QueuedJob queuedBuild(String master, int item) {
+  public QueuedJob queuedBuild(String controller, int item) {
     try {
       return circuitBreaker.executeSupplier(() -> jenkinsClient.getQueuedItem(item));
     } catch (RetrofitError e) {
       if (e.getResponse() != null && e.getResponse().getStatus() == NOT_FOUND.value()) {
         throw new NotFoundException(
-            String.format("Queued job '%s' not found for master '%s'.", item, master));
+            String.format("Queued job '%s' not found for controller '%s'.", item, controller));
       }
       throw e;
     }
@@ -317,7 +317,7 @@ public class JenkinsService implements BuildOperations, BuildProperties {
                       log.error(
                           "Unable to get igorProperties: Could not find build artifact matching requested filename '{}' on '{}' build '{}",
                           kv("fileName", fileName),
-                          kv("master", serviceName),
+                          kv("controller", serviceName),
                           kv("buildNumber", buildNumber));
                       return new ArtifactNotFoundException(serviceName, job, buildNumber, fileName);
                     }),

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/ScmInfoController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/ScmInfoController.groovy
@@ -16,10 +16,10 @@
 
 package com.netflix.spinnaker.igor.scm
 
-import com.netflix.spinnaker.igor.scm.github.client.GitHubMaster
-import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabMaster
-import com.netflix.spinnaker.igor.scm.stash.client.StashMaster
-import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketMaster
+import com.netflix.spinnaker.igor.scm.github.client.GitHubController
+import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabController
+import com.netflix.spinnaker.igor.scm.stash.client.StashController
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketController
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.RequestMapping
@@ -34,31 +34,37 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/scm")
 class ScmInfoController {
     @Autowired(required = false)
-    StashMaster stashMaster
+    StashController stashController
 
     @Autowired(required = false)
-    GitHubMaster gitHubMaster
+    GitHubController gitHubController
 
     @Autowired(required = false)
-    GitLabMaster gitLabMaster
+    GitLabController gitLabController
 
     @Autowired(required = false)
-    BitBucketMaster bitBucketMaster
+    BitBucketController bitBucketController
 
+    @Deprecated(forRemoval = true)
     @RequestMapping(value = '/masters', method = RequestMethod.GET)
     Map listMasters() {
-        def result = [:]
-        if(stashMaster)
-            result << [stash : stashMaster.baseUrl]
-
-        if(gitHubMaster)
-            result << [gitHub : gitHubMaster.baseUrl]
-
-        if(gitLabMaster)
-            result << [gitLab : gitLabMaster.baseUrl]
-
-        if(bitBucketMaster)
-            result << [bitBucket : bitBucketMaster.baseUrl]
-        result
+        listControllers()
     }
+
+  @RequestMapping(value = '/controllers', method = RequestMethod.GET)
+  Map listControllers() {
+    def result = [:]
+    if(stashController)
+      result << [stash : stashController.baseUrl]
+
+    if(gitHubController)
+      result << [gitHub : gitHubController.baseUrl]
+
+    if(gitLabController)
+      result << [gitLab : gitLabController.baseUrl]
+
+    if(bitBucketController)
+      result << [bitBucket : bitBucketController.baseUrl]
+    result
+  }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/BitBucketController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/bitbucket/client/BitBucketController.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.igor.scm.bitbucket.client
 
 import com.netflix.spinnaker.igor.config.BitBucketProperties
-import com.netflix.spinnaker.igor.scm.AbstractScmMaster
+import com.netflix.spinnaker.igor.scm.AbstractScmController
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
 import com.squareup.okhttp.Credentials
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -32,15 +32,15 @@ import javax.validation.Valid
 /**
  * Wrapper class for a collection of BitBucket clients
  */
-class BitBucketMaster extends AbstractScmMaster {
+class BitBucketController extends AbstractScmController {
   BitBucketClient bitBucketClient
   String baseUrl
 
   @Bean
   @ConditionalOnProperty('bitbucket.base-url')
-  BitBucketMaster bitBucketMaster(@Valid BitBucketProperties bitBucketProperties) {
+  BitBucketController bitBucketController(@Valid BitBucketProperties bitBucketProperties) {
     log.info "bootstrapping ${bitBucketProperties.baseUrl}"
-    new BitBucketMaster(
+    new BitBucketController(
         bitBucketClient : bitBucketClient(bitBucketProperties.baseUrl, bitBucketProperties.username, bitBucketProperties.password),
         baseUrl: bitBucketProperties.baseUrl)
   }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/github/CommitController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/github/CommitController.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.igor.scm.github
 
 import com.netflix.spinnaker.igor.config.GitHubProperties
 import com.netflix.spinnaker.igor.scm.AbstractCommitController
-import com.netflix.spinnaker.igor.scm.github.client.GitHubMaster
+import com.netflix.spinnaker.igor.scm.github.client.GitHubController
 import com.netflix.spinnaker.igor.scm.github.client.model.CompareCommitsResponse
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import groovy.util.logging.Slf4j
@@ -37,7 +37,7 @@ import retrofit.RetrofitError
 @RequestMapping("/github")
 class CommitController extends AbstractCommitController {
     @Autowired
-    GitHubMaster master
+    GitHubController controller
 
     @Autowired
     GitHubProperties gitHubProperties
@@ -49,15 +49,15 @@ class CommitController extends AbstractCommitController {
         List result = []
 
         try {
-            commitsResponse = master.gitHubClient.getCompareCommits(projectKey, repositorySlug, requestParams.to, requestParams.from)
+            commitsResponse = controller.gitHubClient.getCompareCommits(projectKey, repositorySlug, requestParams.to, requestParams.from)
         } catch (RetrofitError e) {
             if(e.getKind() == RetrofitError.Kind.NETWORK) {
-                throw new NotFoundException("Could not find the server ${master.baseUrl}")
+                throw new NotFoundException("Could not find the server ${controller.baseUrl}")
             } else if(e.response.status == 404) {
-                return getNotFoundCommitsResponse(projectKey, repositorySlug, requestParams.to, requestParams.from, master.baseUrl)
+                return getNotFoundCommitsResponse(projectKey, repositorySlug, requestParams.to, requestParams.from, controller.baseUrl)
             }
             log.error("Unhandled error response, acting like commit response was not found", e)
-            return getNotFoundCommitsResponse(projectKey, repositorySlug, requestParams.to, requestParams.from, master.baseUrl)
+            return getNotFoundCommitsResponse(projectKey, repositorySlug, requestParams.to, requestParams.from, controller.baseUrl)
         }
 
         commitsResponse.commits.each {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/github/client/GitHubController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/github/client/GitHubController.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.igor.scm.github.client
 
 
-import com.netflix.spinnaker.igor.scm.AbstractScmMaster
+import com.netflix.spinnaker.igor.scm.AbstractScmController
 import com.netflix.spinnaker.igor.scm.github.client.model.Commit
 import com.netflix.spinnaker.igor.scm.github.client.model.GetRepositoryContentResponse
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
@@ -30,7 +30,7 @@ import java.util.stream.Collectors
  * Wrapper class for a collection of GitHub clients
  */
 @Slf4j
-class GitHubMaster extends AbstractScmMaster {
+class GitHubController extends AbstractScmController {
 
   private static final String FILE_CONTENT_TYPE = "file";
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/gitlab/CommitController.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/gitlab/CommitController.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.igor.scm.gitlab;
 
 import com.netflix.spinnaker.igor.config.GitLabProperties;
 import com.netflix.spinnaker.igor.scm.AbstractCommitController;
-import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabMaster;
+import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabController;
 import com.netflix.spinnaker.igor.scm.gitlab.client.model.CompareCommitsResponse;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.util.HashMap;
@@ -37,12 +37,12 @@ import retrofit.RetrofitError;
 @RequestMapping("/gitlab")
 public class CommitController extends AbstractCommitController {
   private static final Logger log = LoggerFactory.getLogger(CommitController.class);
-  private final GitLabMaster gitLabMaster;
+  private final GitLabController gitLabController;
   private final GitLabProperties gitLabProperties;
 
   @Autowired
-  public CommitController(GitLabMaster gitLabMaster, GitLabProperties gitLabProperties) {
-    this.gitLabMaster = gitLabMaster;
+  public CommitController(GitLabController gitLabController, GitLabProperties gitLabProperties) {
+    this.gitLabController = gitLabController;
     this.gitLabProperties = gitLabProperties;
   }
 
@@ -65,17 +65,19 @@ public class CommitController extends AbstractCommitController {
       queryMap.put("to", toParam);
       queryMap.put("from", fromParam);
       commitsResponse =
-          gitLabMaster.getGitLabClient().getCompareCommits(projectKey, repositorySlug, queryMap);
+          gitLabController
+              .getGitLabClient()
+              .getCompareCommits(projectKey, repositorySlug, queryMap);
     } catch (RetrofitError e) {
       if (e.getKind() == RetrofitError.Kind.NETWORK) {
-        throw new NotFoundException("Could not find the server " + gitLabMaster.getBaseUrl());
+        throw new NotFoundException("Could not find the server " + gitLabController.getBaseUrl());
       } else if (e.getResponse().getStatus() == 404) {
         return getNotFoundCommitsResponse(
-            projectKey, repositorySlug, toParam, fromParam, gitLabMaster.getBaseUrl());
+            projectKey, repositorySlug, toParam, fromParam, gitLabController.getBaseUrl());
       }
       log.error("Unhandled error response, acting like commit response was not found", e);
       return getNotFoundCommitsResponse(
-          projectKey, repositorySlug, toParam, fromParam, gitLabMaster.getBaseUrl());
+          projectKey, repositorySlug, toParam, fromParam, gitLabController.getBaseUrl());
     }
 
     return commitsResponse.commits.stream()

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/gitlab/client/GitLabController.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/gitlab/client/GitLabController.java
@@ -16,14 +16,14 @@
 
 package com.netflix.spinnaker.igor.scm.gitlab.client;
 
-import com.netflix.spinnaker.igor.scm.AbstractScmMaster;
+import com.netflix.spinnaker.igor.scm.AbstractScmController;
 
 /** Wrapper class for a collection of GitLab clients */
-public class GitLabMaster extends AbstractScmMaster {
+public class GitLabController extends AbstractScmController {
   private final GitLabClient gitLabClient;
   private final String baseUrl;
 
-  public GitLabMaster(GitLabClient gitLabClient, String baseUrl) {
+  public GitLabController(GitLabClient gitLabClient, String baseUrl) {
     this.gitLabClient = gitLabClient;
     this.baseUrl = baseUrl;
   }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/stash/client/StashController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/scm/stash/client/StashController.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.igor.scm.stash.client
 
-import com.netflix.spinnaker.igor.scm.AbstractScmMaster
+import com.netflix.spinnaker.igor.scm.AbstractScmController
 import com.netflix.spinnaker.igor.scm.stash.client.model.TextLinesResponse
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import groovy.util.logging.Slf4j
@@ -26,7 +26,7 @@ import retrofit.RetrofitError
  * Wrapper class for a collection of Stash clients
  */
 @Slf4j
-class StashMaster extends AbstractScmMaster {
+class StashController extends AbstractScmController {
   public static final int DEFAULT_PAGED_RESPONSE_LIMIT = 500
 
   StashClient stashClient

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerCache.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerCache.java
@@ -40,52 +40,52 @@ public class WerckerCache {
     this.igorConfigurationProperties = igorConfigurationProperties;
   }
 
-  public void setLastPollCycleTimestamp(String master, String pipeline, Long timestamp) {
-    String key = makeKey(master, pipeline);
+  public void setLastPollCycleTimestamp(String controller, String pipeline, Long timestamp) {
+    String key = makeKey(controller, pipeline);
     redisClientDelegate.withCommandsClient(
         c -> {
           c.hset(key, POLL_STAMP, Long.toString(timestamp));
         });
   }
 
-  public Long getLastPollCycleTimestamp(String master, String pipeline) {
+  public Long getLastPollCycleTimestamp(String controller, String pipeline) {
     return redisClientDelegate.withCommandsClient(
         c -> {
-          String ts = c.hget(makeKey(master, pipeline), POLL_STAMP);
+          String ts = c.hget(makeKey(controller, pipeline), POLL_STAMP);
           return ts == null ? null : Long.parseLong(ts);
         });
   }
 
-  public String getPipelineID(String master, String pipeline) {
+  public String getPipelineID(String controller, String pipeline) {
     return redisClientDelegate.withCommandsClient(
         c -> {
-          return c.hget(makeKey(master, pipeline), PIPELINE_ID);
+          return c.hget(makeKey(controller, pipeline), PIPELINE_ID);
         });
   }
 
-  public String getPipelineName(String master, String id) {
+  public String getPipelineName(String controller, String id) {
     return redisClientDelegate.withCommandsClient(
         c -> {
-          return c.hget(nameKey(master, id), PIPELINE_NAME);
+          return c.hget(nameKey(controller, id), PIPELINE_NAME);
         });
   }
 
-  public void setPipelineID(String master, String pipeline, String id) {
-    String key = makeKey(master, pipeline);
+  public void setPipelineID(String controller, String pipeline, String id) {
+    String key = makeKey(controller, pipeline);
     redisClientDelegate.withCommandsClient(
         c -> {
           c.hset(key, PIPELINE_ID, id);
         });
 
-    String nameKey = nameKey(master, id);
+    String nameKey = nameKey(controller, id);
     redisClientDelegate.withCommandsClient(
         c -> {
           c.hset(nameKey, PIPELINE_NAME, pipeline);
         });
   }
 
-  public String getRunID(String master, String pipeline, final int buildNumber) {
-    String key = makeKey(master, pipeline) + ":runs";
+  public String getRunID(String controller, String pipeline, final int buildNumber) {
+    String key = makeKey(controller, pipeline) + ":runs";
     final Map<String, String> existing =
         redisClientDelegate.withCommandsClient(
             c -> {
@@ -107,14 +107,14 @@ public class WerckerCache {
    * Creates entries in Redis for each run in the runs list (except if the run id already exists)
    * and generates build numbers for each run id (ordered by startedAt date)
    *
-   * @param master
+   * @param controller
    * @param appAndPipelineName
    * @param runs
    * @return a map containing the generated build numbers for each run created, keyed by run id
    */
   public Map<String, Integer> updateBuildNumbers(
-      String master, String appAndPipelineName, List<Run> runs) {
-    String key = makeKey(master, appAndPipelineName) + ":runs";
+      String controller, String appAndPipelineName, List<Run> runs) {
+    String key = makeKey(controller, appAndPipelineName) + ":runs";
     final Map<String, String> existing =
         redisClientDelegate.withCommandsClient(
             c -> {
@@ -135,66 +135,66 @@ public class WerckerCache {
     newRuns.sort(startedAtComparator);
     for (int i = 0; i < newRuns.size(); i++) {
       int buildNum = startNumber + i;
-      setBuildNumber(master, appAndPipelineName, newRuns.get(i).getId(), buildNum);
+      setBuildNumber(controller, appAndPipelineName, newRuns.get(i).getId(), buildNum);
       runIdToBuildNumber.put(newRuns.get(i).getId(), buildNum);
     }
     return runIdToBuildNumber;
   }
 
-  public void setBuildNumber(String master, String pipeline, String runID, int number) {
-    String key = makeKey(master, pipeline) + ":runs";
+  public void setBuildNumber(String controller, String pipeline, String runID, int number) {
+    String key = makeKey(controller, pipeline) + ":runs";
     redisClientDelegate.withCommandsClient(
         c -> {
           c.hset(key, runID, Integer.toString(number));
         });
   }
 
-  public Long getBuildNumber(String master, String pipeline, String runID) {
+  public Long getBuildNumber(String controller, String pipeline, String runID) {
     return redisClientDelegate.withCommandsClient(
         c -> {
-          String ts = c.hget(makeKey(master, pipeline) + ":runs", runID);
+          String ts = c.hget(makeKey(controller, pipeline) + ":runs", runID);
           return ts == null ? null : Long.parseLong(ts);
         });
   }
 
-  public Boolean getEventPosted(String master, String job, String runID) {
-    String key = makeEventsKey(master, job);
+  public Boolean getEventPosted(String controller, String job, String runID) {
+    String key = makeEventsKey(controller, job);
     return redisClientDelegate.withCommandsClient(c -> c.hget(key, runID) != null);
   }
 
-  public void setEventPosted(String master, String job, String runID) {
-    String key = makeEventsKey(master, job);
+  public void setEventPosted(String controller, String job, String runID) {
+    String key = makeEventsKey(controller, job);
     redisClientDelegate.withCommandsClient(
         c -> {
           c.hset(key, runID, "POSTED");
         });
   }
 
-  public void pruneOldMarkers(String master, String job, Long cursor) {
-    remove(master, job);
+  public void pruneOldMarkers(String controller, String job, Long cursor) {
+    remove(controller, job);
     redisClientDelegate.withCommandsClient(
         c -> {
-          c.del(makeEventsKey(master, job));
+          c.del(makeEventsKey(controller, job));
         });
   }
 
-  public void remove(String master, String job) {
+  public void remove(String controller, String job) {
     redisClientDelegate.withCommandsClient(
         c -> {
-          c.del(makeKey(master, job));
+          c.del(makeKey(controller, job));
         });
   }
 
-  private String makeEventsKey(String master, String job) {
-    return makeKey(master, job) + ":" + POLL_STAMP + ":events";
+  private String makeEventsKey(String controller, String job) {
+    return makeKey(controller, job) + ":" + POLL_STAMP + ":events";
   }
 
-  private String makeKey(String master, String job) {
-    return prefix() + ":" + master + ":" + job.toUpperCase() + ":" + job;
+  private String makeKey(String controller, String job) {
+    return prefix() + ":" + controller + ":" + job.toUpperCase() + ":" + job;
   }
 
-  private String nameKey(String master, String pipelineId) {
-    return prefix() + ":" + master + ":all_pipelines:" + pipelineId;
+  private String nameKey(String controller, String pipelineId) {
+    return prefix() + ":" + controller + ":all_pipelines:" + pipelineId;
   }
 
   private String prefix() {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerService.groovy
@@ -41,7 +41,7 @@ class WerckerService implements BuildOperations {
     String token
     String authHeaderValue
     String address
-    String master
+    String controller
     WerckerCache cache
     final Permissions permissions
 
@@ -54,7 +54,7 @@ class WerckerService implements BuildOperations {
         this.user = wercker.user
         this.cache = cache
         this.address = address
-        this.master = wercker.name
+        this.controller = wercker.name
         this.setToken(token)
         this.address = wercker.address
         this.setToken(wercker.token)
@@ -163,7 +163,7 @@ class WerckerService implements BuildOperations {
                 //Create an entry in the WerckerCache for this new run. This will also generate
                 //an integer build number for the run
                 Map<String, Integer> runIdBuildNumbers = cache.updateBuildNumbers(
-                        master, appAndPipelineName, Collections.singletonList(run))
+                        controller, appAndPipelineName, Collections.singletonList(run))
 
                 log.info("Triggered run {} at URL {} with build number {}",
                         kv("runId", run.id), kv("url", run.url),
@@ -244,7 +244,7 @@ class WerckerService implements BuildOperations {
     }
 
     /**
-     * A CommandKey should be unique per group (to ensure broken circuits do not span Wercker masters)
+     * A CommandKey should be unique per group (to ensure broken circuits do not span Wercker controllers)
      */
     private String buildCommandKey(String id) {
         return "${groupKey}-${id}"

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
@@ -87,7 +87,7 @@ public class ConcourseBuildMonitor
   @Override
   protected JobPollingDelta generateDelta(PollContext ctx) {
     ConcourseProperties.Host host =
-        concourseProperties.getMasters().stream()
+        concourseProperties.getControllers().stream()
             .filter(h -> h.getName().equals(ctx.partitionName))
             .findFirst()
             .orElseThrow(
@@ -199,7 +199,7 @@ public class ConcourseBuildMonitor
 
       GenericBuildContent content = new GenericBuildContent();
       content.setProject(project);
-      content.setMaster("concourse-" + host.getName());
+      content.setController("concourse-" + host.getName());
       content.setType("concourse");
 
       GenericBuildEvent event = new GenericBuildEvent();
@@ -215,7 +215,7 @@ public class ConcourseBuildMonitor
 
   @Override
   public void poll(boolean sendEvents) {
-    for (ConcourseProperties.Host host : concourseProperties.getMasters()) {
+    for (ConcourseProperties.Host host : concourseProperties.getControllers()) {
       pollSingle(new PollContext(host.getName(), !sendEvents));
     }
   }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseController.java
@@ -42,19 +42,19 @@ public class ConcourseController {
     this.buildServices = buildServices;
   }
 
-  @GetMapping("/{buildMaster}/teams")
-  public List<String> getTeams(@PathVariable("buildMaster") String buildMaster) {
-    return getService(buildMaster)
+  @GetMapping("/{buildController}/teams")
+  public List<String> getTeams(@PathVariable("buildController") String buildController) {
+    return getService(buildController)
         .map(
             service ->
                 service.teams().stream().map(Team::getName).sorted().collect(Collectors.toList()))
         .orElse(emptyList());
   }
 
-  @GetMapping("/{buildMaster}/teams/{team}/pipelines")
+  @GetMapping("/{buildController}/teams/{team}/pipelines")
   public List<String> getPipelines(
-      @PathVariable("buildMaster") String buildMaster, @PathVariable("team") String team) {
-    return getService(buildMaster)
+      @PathVariable("buildController") String buildController, @PathVariable("team") String team) {
+    return getService(buildController)
         .map(
             service ->
                 service.pipelines().stream()
@@ -65,13 +65,13 @@ public class ConcourseController {
         .orElse(emptyList());
   }
 
-  @GetMapping("/{buildMaster}/teams/{team}/pipelines/{pipeline}/jobs")
+  @GetMapping("/{buildController}/teams/{team}/pipelines/{pipeline}/jobs")
   public List<String> getJobs(
-      @PathVariable("buildMaster") String buildMaster,
+      @PathVariable("buildController") String buildController,
       @PathVariable("team") String team,
       @PathVariable("pipeline") String pipeline) {
     // don't sort so that we leave the jobs in the order in which they appear in the pipeline
-    return getService(buildMaster)
+    return getService(buildController)
         .map(
             service ->
                 service.getJobs().stream()
@@ -82,12 +82,12 @@ public class ConcourseController {
         .orElse(emptyList());
   }
 
-  @GetMapping("/{buildMaster}/teams/{team}/pipelines/{pipeline}/resources")
+  @GetMapping("/{buildController}/teams/{team}/pipelines/{pipeline}/resources")
   public List<String> getResourceNames(
-      @PathVariable("buildMaster") String buildMaster,
+      @PathVariable("buildController") String buildController,
       @PathVariable("team") String team,
       @PathVariable("pipeline") String pipeline) {
-    return getService(buildMaster)
+    return getService(buildController)
         .map(
             service ->
                 service.getResourceNames(team, pipeline).stream()
@@ -96,7 +96,7 @@ public class ConcourseController {
         .orElse(emptyList());
   }
 
-  private Optional<ConcourseService> getService(String buildMaster) {
-    return Optional.ofNullable((ConcourseService) buildServices.getService(buildMaster));
+  private Optional<ConcourseService> getService(String buildController) {
+    return Optional.ofNullable((ConcourseService) buildServices.getService(buildController));
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
@@ -92,13 +92,18 @@ public class ConcourseService implements BuildOperations, BuildProperties {
     this.permissions = host.getPermissions().build();
   }
 
+  @Deprecated(forRemoval = true)
   public String getMaster() {
+    return getController();
+  }
+
+  public String getController() {
     return "concourse-" + host.getName();
   }
 
   @Override
   public String getName() {
-    return getMaster();
+    return getController();
   }
 
   @Override

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ConcourseConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ConcourseConfig.java
@@ -22,23 +22,23 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(ConcourseProperties.class)
 public class ConcourseConfig {
   @Bean
-  public Map<String, ConcourseService> concourseMasters(
+  public Map<String, ConcourseService> concourseControllers(
       BuildServices buildServices,
       ConcourseCache concourseCache,
       Optional<ArtifactDecorator> artifactDecorator,
       IgorConfigurationProperties igorConfigurationProperties,
       @Valid ConcourseProperties concourseProperties) {
-    List<ConcourseProperties.Host> masters = concourseProperties.getMasters();
-    if (masters == null) {
+    List<ConcourseProperties.Host> controllers = concourseProperties.getControllers();
+    if (controllers == null) {
       return Collections.emptyMap();
     }
 
-    Map<String, ConcourseService> concourseMasters =
-        masters.stream()
+    Map<String, ConcourseService> concourseControllers =
+        controllers.stream()
             .map(m -> new ConcourseService(m, artifactDecorator))
-            .collect(Collectors.toMap(ConcourseService::getMaster, Function.identity()));
+            .collect(Collectors.toMap(ConcourseService::getController, Function.identity()));
 
-    buildServices.addServices(concourseMasters);
-    return concourseMasters;
+    buildServices.addServices(concourseControllers);
+    return concourseControllers;
   }
 }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ConcourseProperties.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/ConcourseProperties.java
@@ -25,7 +25,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties(prefix = "concourse")
 public class ConcourseProperties {
+  @Deprecated(forRemoval = true)
   private List<Host> masters;
+
+  @Deprecated(forRemoval = true)
+  public List<Host> getMasters() {
+    return controllers;
+  }
+
+  @Deprecated(forRemoval = true)
+  public void setMasters(List<Host> controllers) {
+    this.controllers = controllers;
+  }
+
+  private List<Host> controllers;
 
   @Data
   public static class Host {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/IgorConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/IgorConfig.java
@@ -63,7 +63,7 @@ public class IgorConfig implements WebMvcConfigurer {
         new MetricsInterceptor(
             this.registry,
             "controller.invocations",
-            Collections.singletonList("master"),
+            Collections.singletonList("controller"),
             null,
             Collections.singletonList("BasicErrorController")));
   }

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/health/EchoServiceHealthIndicator.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/health/EchoServiceHealthIndicator.java
@@ -94,7 +94,7 @@ public class EchoServiceHealthIndicator implements HealthIndicator {
     final GenericBuildEvent event = new GenericBuildEvent();
     final GenericBuildContent buildContent = new GenericBuildContent();
     final GenericProject project = new GenericProject("spinnaker", new GenericBuild());
-    buildContent.setMaster("IgorHealthCheck");
+    buildContent.setController("IgorHealthCheck");
     buildContent.setProject(project);
     event.setContent(buildContent);
     return event;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/AbstractScmController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/AbstractScmController.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.igor.scm;
 
 import java.util.List;
 
-public class AbstractScmMaster implements ScmMaster {
+public class AbstractScmController implements ScmController {
   public List<String> listDirectory(
       String projectKey, String repositorySlug, String path, String ref) {
     throw new UnsupportedOperationException("Not implemented");
@@ -30,7 +30,7 @@ public class AbstractScmMaster implements ScmMaster {
   }
 
   public String getTextFileContents(String projectKey, String repositorySlug, String path) {
-    return getTextFileContents(projectKey, repositorySlug, path, ScmMaster.DEFAULT_GIT_REF);
+    return getTextFileContents(projectKey, repositorySlug, path, ScmController.DEFAULT_GIT_REF);
   }
 
   public Object getCommitDetails(String projectKey, String repositorySlug, String commitSha) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ScmController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ScmController.java
@@ -1,12 +1,11 @@
 /*
- * Copyright 2018 Schibsted ASA.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- *
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,19 +14,15 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.igor.travis.client;
+package com.netflix.spinnaker.igor.scm;
 
-import com.netflix.spinnaker.igor.travis.service.TravisService;
-import java.util.Map;
+import java.util.List;
 
-public class TravisMasters {
-  private Map<String, TravisService> map;
+/** Abstracts underlying implementation details of each SCM system under a common interface. */
+public interface ScmController {
+  String DEFAULT_GIT_REF = "refs/heads/master";
 
-  public Map<String, TravisService> getMap() {
-    return map;
-  }
+  List<String> listDirectory(String projectKey, String repositorySlug, String path, String ref);
 
-  public void setMap(Map<String, TravisService> map) {
-    this.map = map;
-  }
+  String getTextFileContents(String projectKey, String repositorySlug, String path, String ref);
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -90,17 +90,30 @@ class InfoControllerSpec extends Specification {
         .build()
     }
 
+    @Deprecated
     void 'is able to get a list of jenkins buildMasters'() {
         given:
-        createMocks(['master2': null, 'build.buildServices.blah': null, 'master1': null])
+        createMocks(['controller2': null, 'build.buildServices.blah': null, 'controller1': null])
 
         when:
         MockHttpServletResponse response = mockMvc.perform(get('/masters/')
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
-        response.contentAsString == '["build.buildServices.blah","master1","master2"]'
+        response.contentAsString == '["build.buildServices.blah","controller1","controller2"]'
     }
+
+  void 'is able to get a list of jenkins buildControllers'() {
+    given:
+    createMocks(['controller2': null, 'build.buildServices.blah': null, 'controller1': null])
+
+    when:
+    MockHttpServletResponse response = mockMvc.perform(get('/controllers/')
+      .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+    then:
+    response.contentAsString == '["build.buildServices.blah","controller1","controller2"]'
+  }
 
     void 'is able to get a list of google cloud build accounts'() {
       given:
@@ -133,8 +146,8 @@ class InfoControllerSpec extends Specification {
 
     void 'buildServices returns correctly if gcb is not defined'() {
       given:
-      JenkinsService jenkinsService1 = new JenkinsService('master2', null, false, Permissions.EMPTY, circuitBreakerRegistry)
-      createMocks(['master2': jenkinsService1])
+      JenkinsService jenkinsService1 = new JenkinsService('controller2', null, false, Permissions.EMPTY, circuitBreakerRegistry)
+      createMocks(['controller2': jenkinsService1])
 
       when:
       MockHttpServletResponse response = mockMvc.perform(get('/buildServices')
@@ -143,7 +156,7 @@ class InfoControllerSpec extends Specification {
       then:
       def actualAccounts = new JsonSlurper().parseText(response.contentAsString);
       actualAccounts.size == 1
-      actualAccounts[0].name == 'master2'
+      actualAccounts[0].name == 'controller2'
 
     }
 
@@ -235,13 +248,13 @@ class InfoControllerSpec extends Specification {
         )
     }
 
-    void 'is able to get jobs for a jenkins master'() {
+    void 'is able to get jobs for a jenkins controller'() {
         given:
         JenkinsService jenkinsService = Stub(JenkinsService)
-        createMocks(['master1': jenkinsService])
+        createMocks(['controller1': jenkinsService])
 
         when:
-        MockHttpServletResponse response = mockMvc.perform(get('/jobs/master1/')
+        MockHttpServletResponse response = mockMvc.perform(get('/jobs/controller1/')
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
@@ -253,13 +266,13 @@ class InfoControllerSpec extends Specification {
         response.contentAsString == '["job1","job2","job3"]'
     }
 
-    void 'is able to get jobs for a jenkins master with the folders plugin'() {
+    void 'is able to get jobs for a jenkins controller with the folders plugin'() {
         given:
         JenkinsService jenkinsService = Stub(JenkinsService)
-        createMocks(['master1': jenkinsService])
+        createMocks(['controller1': jenkinsService])
 
         when:
-        MockHttpServletResponse response = mockMvc.perform(get('/jobs/master1/')
+        MockHttpServletResponse response = mockMvc.perform(get('/jobs/controller1/')
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
@@ -274,30 +287,30 @@ class InfoControllerSpec extends Specification {
         response.contentAsString == '["folder/job/job1","folder/job/job2","job3"]'
     }
 
-    void 'is able to get jobs for a travis master'() {
+    void 'is able to get jobs for a travis controller'() {
         given:
         TravisService travisService = Stub(TravisService)
-        createMocks(['travis-master1': travisService])
+        createMocks(['travis-controller1': travisService])
 
         when:
-        MockHttpServletResponse response = mockMvc.perform(get('/jobs/travis-master1')
+        MockHttpServletResponse response = mockMvc.perform(get('/jobs/travis-controller1')
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
         travisService.getBuildServiceProvider() >> BuildServiceProvider.TRAVIS
-        1 * cache.getJobNames('travis-master1') >> ["some-job"]
+        1 * cache.getJobNames('travis-controller1') >> ["some-job"]
         response.contentAsString == '["some-job"]'
 
     }
 
-    void 'is able to get jobs for a wercker master'() {
+    void 'is able to get jobs for a wercker controller'() {
         given:
         def werckerJob = 'myOrg/myApp/myTarget'
         WerckerService werckerService = Stub(WerckerService)
-        createMocks(['wercker-master': werckerService])
+        createMocks(['wercker-controller': werckerService])
 
         when:
-        MockHttpServletResponse response = mockMvc.perform(get('/jobs/wercker-master')
+        MockHttpServletResponse response = mockMvc.perform(get('/jobs/wercker-controller')
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
@@ -325,10 +338,10 @@ class InfoControllerSpec extends Specification {
     void 'is able to get a job config at url #url'() {
         given:
         setResponse(getJobConfig())
-        createMocks(['master1': service])
+        createMocks(['controller1': service])
 
         when:
-        MockHttpServletResponse response = mockMvc.perform(get('/jobs/master1/MY-JOB')
+        MockHttpServletResponse response = mockMvc.perform(get('/jobs/controller1/MY-JOB')
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:
@@ -340,16 +353,16 @@ class InfoControllerSpec extends Specification {
         output.firstBuild == null
 
         where:
-        url << ['/jobs/master1/MY-JOB', '/jobs/master1/folder/job/MY-JOB']
+        url << ['/jobs/controller1/MY-JOB', '/jobs/controller1/folder/job/MY-JOB']
     }
 
     void 'is able to get a job config where a parameter includes choices'() {
         given:
         setResponse(getJobConfigWithChoices())
-        createMocks(['master1': service])
+        createMocks(['controller1': service])
 
         when:
-        MockHttpServletResponse response = mockMvc.perform(get('/jobs/master1/MY-JOB')
+        MockHttpServletResponse response = mockMvc.perform(get('/jobs/controller1/MY-JOB')
             .accept(MediaType.APPLICATION_JSON)).andReturn().response
 
         then:

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitorSpec.groovy
@@ -39,14 +39,14 @@ class GitlabCiBuildMonitorSpec extends Specification {
     EchoService echoService = Mock(EchoService)
     GitlabCiBuildMonitor buildMonitor
 
-    String MASTER = "MASTER"
+    String CONTROLLER = "CONTROLLER"
     int CACHED_JOB_TTL_SECONDS = 172800
     int CACHED_JOB_TTL_DAYS = 2
 
     void setup() {
         def properties = new GitlabCiProperties(cachedJobTTLDays: CACHED_JOB_TTL_DAYS)
         def buildServices = new BuildServices()
-        buildServices.addServices([MASTER: service])
+        buildServices.addServices([CONTROLLER: service])
         buildMonitor = new GitlabCiBuildMonitor(
             new IgorConfigurationProperties(),
             new NoopRegistry(),
@@ -70,15 +70,15 @@ class GitlabCiBuildMonitorSpec extends Specification {
 
         service.getProjects() >> [project]
         service.getPipelines(project, _) >> [pipeline]
-        buildCache.getJobNames(MASTER) >> jobsInCache
-        buildCache.getLastBuild(MASTER, _, false) >> lastBuildNr
+        buildCache.getJobNames(CONTROLLER) >> jobsInCache
+        buildCache.getLastBuild(CONTROLLER, _, false) >> lastBuildNr
 
         when:
-        buildMonitor.pollSingle(new PollContext(MASTER))
+        buildMonitor.pollSingle(new PollContext(CONTROLLER))
 
         then:
-        1 * buildCache.setLastBuild(MASTER, "user1/project1", 101, false, CACHED_JOB_TTL_SECONDS)
-        1 * buildCache.setLastBuild(MASTER, "user1/project1/master", 101, false, CACHED_JOB_TTL_SECONDS)
+        1 * buildCache.setLastBuild(CONTROLLER, "user1/project1", 101, false, CACHED_JOB_TTL_SECONDS)
+        1 * buildCache.setLastBuild(CONTROLLER, "user1/project1/master", 101, false, CACHED_JOB_TTL_SECONDS)
 
         and:
         1 * echoService.postEvent({
@@ -104,15 +104,15 @@ class GitlabCiBuildMonitorSpec extends Specification {
 
         service.getProjects() >> [project]
         service.getPipelines(project, _) >> [pipeline]
-        buildCache.getJobNames(MASTER) >> jobsInCache
-        buildCache.getLastBuild(MASTER, _, false) >> lastBuildNr
+        buildCache.getJobNames(CONTROLLER) >> jobsInCache
+        buildCache.getLastBuild(CONTROLLER, _, false) >> lastBuildNr
 
         when:
-        buildMonitor.pollSingle(new PollContext(MASTER).fastForward())
+        buildMonitor.pollSingle(new PollContext(CONTROLLER).fastForward())
 
         then:
-        1 * buildCache.setLastBuild(MASTER, "user1/project1", 101, false, CACHED_JOB_TTL_SECONDS)
-        1 * buildCache.setLastBuild(MASTER, "user1/project1/master", 101, false, CACHED_JOB_TTL_SECONDS)
+        1 * buildCache.setLastBuild(CONTROLLER, "user1/project1", 101, false, CACHED_JOB_TTL_SECONDS)
+        1 * buildCache.setLastBuild(CONTROLLER, "user1/project1/master", 101, false, CACHED_JOB_TTL_SECONDS)
 
         and:
         0 * echoService.postEvent(_)
@@ -130,10 +130,10 @@ class GitlabCiBuildMonitorSpec extends Specification {
 
         service.getProjects() >> [project]
         service.getPipelines(project, _) >> [pipeline]
-        buildCache.getJobNames(MASTER) >> []
+        buildCache.getJobNames(CONTROLLER) >> []
 
         when:
-        buildMonitor.pollSingle(new PollContext(MASTER))
+        buildMonitor.pollSingle(new PollContext(CONTROLLER))
 
         then:
         0 * buildCache.setLastBuild(_, _, _, _, _)
@@ -149,11 +149,11 @@ class GitlabCiBuildMonitorSpec extends Specification {
 
         service.getProjects() >> [project]
         service.getPipelines(project, _) >> [pipeline]
-        buildCache.getJobNames(MASTER) >> ["user1/project1/master"]
-        buildCache.getLastBuild(MASTER, "user1/project1/master", false) >> 102
+        buildCache.getJobNames(CONTROLLER) >> ["user1/project1/master"]
+        buildCache.getLastBuild(CONTROLLER, "user1/project1/master", false) >> 102
 
         when:
-        buildMonitor.pollSingle(new PollContext(MASTER))
+        buildMonitor.pollSingle(new PollContext(CONTROLLER))
 
         then:
         0 * buildCache.setLastBuild(_, _, _, _, _)

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsCacheSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsCacheSpec.groovy
@@ -34,7 +34,7 @@ class JenkinsCacheSpec extends Specification {
     @Subject
     JenkinsCache cache = new JenkinsCache(redisClientDelegate, new IgorConfigurationProperties())
 
-    def master = 'master'
+    def controller = 'controller'
     def test = 'test'
 
     void cleanup() {
@@ -46,30 +46,30 @@ class JenkinsCacheSpec extends Specification {
 
     void 'new build numbers get overridden'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, true)
+        cache.setLastBuild(controller, 'job1', 78, true)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildLabel == 78
+        cache.getLastBuild(controller, 'job1').lastBuildLabel == 78
 
         when:
-        cache.setLastBuild(master, 'job1', 80, false)
+        cache.setLastBuild(controller, 'job1', 80, false)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildLabel == 80
+        cache.getLastBuild(controller, 'job1').lastBuildLabel == 80
     }
 
     void 'statuses get overridden'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, true)
+        cache.setLastBuild(controller, 'job1', 78, true)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildBuilding == true
+        cache.getLastBuild(controller, 'job1').lastBuildBuilding == true
 
         when:
-        cache.setLastBuild(master, 'job1', 78, false)
+        cache.setLastBuild(controller, 'job1', 78, false)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildBuilding == false
+        cache.getLastBuild(controller, 'job1').lastBuildBuilding == false
 
     }
 
@@ -78,41 +78,41 @@ class JenkinsCacheSpec extends Specification {
         cache.getLastBuild('notthere', 'job1') == [:]
     }
 
-    void 'can set builds for multiple masters'() {
+    void 'can set builds for multiple controllers'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, true)
+        cache.setLastBuild(controller, 'job1', 78, true)
         cache.setLastBuild('example2', 'job1', 88, true)
 
         then:
-        cache.getLastBuild(master, 'job1').lastBuildLabel == 78
+        cache.getLastBuild(controller, 'job1').lastBuildLabel == 78
         cache.getLastBuild('example2', 'job1').lastBuildLabel == 88
     }
 
-    void 'correctly retrieves all jobsNames for a master'() {
+    void 'correctly retrieves all jobsNames for a controller'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, true)
-        cache.setLastBuild(master, 'job2', 11, false)
-        cache.setLastBuild(master, 'blurb', 1, false)
+        cache.setLastBuild(controller, 'job1', 78, true)
+        cache.setLastBuild(controller, 'job2', 11, false)
+        cache.setLastBuild(controller, 'blurb', 1, false)
 
         then:
-        cache.getJobNames(master) == ['blurb', 'job1', 'job2']
+        cache.getJobNames(controller) == ['blurb', 'job1', 'job2']
     }
 
     void 'can remove details for a build'() {
         when:
-        cache.setLastBuild(master, 'job1', 78, true)
-        cache.remove(master, 'job1')
+        cache.setLastBuild(controller, 'job1', 78, true)
+        cache.remove(controller, 'job1')
 
         then:
-        cache.getLastBuild(master, 'job1') == [:]
+        cache.getLastBuild(controller, 'job1') == [:]
     }
 
     @Unroll
     void 'retrieves all matching jobs for typeahead #query'() {
         when:
-        cache.setLastBuild(master, 'job1', 1, true)
+        cache.setLastBuild(controller, 'job1', 1, true)
         cache.setLastBuild(test, 'job1', 1, false)
-        cache.setLastBuild(master, 'job2', 1, false)
+        cache.setLastBuild(controller, 'job2', 1, false)
         cache.setLastBuild(test, 'job3', 1, false)
 
         then:
@@ -120,10 +120,10 @@ class JenkinsCacheSpec extends Specification {
 
         where:
         query  || expected
-        'job'  || ['master:job1', 'master:job2', 'test:job1', 'test:job3']
-        'job1' || ['master:job1', 'test:job1']
-        'ob1'  || ['master:job1', 'test:job1']
-        'B2'   || ['master:job2']
+        'job'  || ['controller:job1', 'controller:job2', 'test:job1', 'test:job3']
+        'job1' || ['controller:job1', 'test:job1']
+        'ob1'  || ['controller:job1', 'test:job1']
+        'B2'   || ['controller:job2']
         '3'    || ['test:job3']
         'nope' || []
     }
@@ -135,16 +135,16 @@ class JenkinsCacheSpec extends Specification {
         JenkinsCache secondInstance = new JenkinsCache(redisClientDelegate, cfg)
 
         when:
-        secondInstance.setLastBuild(master, 'job1', 1, false)
+        secondInstance.setLastBuild(controller, 'job1', 1, false)
 
         then:
-        secondInstance.getJobNames(master) == ['job1']
-        cache.getJobNames(master) == []
+        secondInstance.getJobNames(controller) == ['job1']
+        cache.getJobNames(controller) == []
 
         when:
-        cache.remove(master, 'job1')
+        cache.remove(controller, 'job1')
 
         then:
-        secondInstance.getJobNames(master) == ['job1']
+        secondInstance.getJobNames(controller) == ['job1']
     }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmServiceSpec.groovy
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.netflix.spinnaker.igor.config.ManagedDeliveryConfigProperties
 import com.netflix.spinnaker.igor.scm.stash.client.StashClient
-import com.netflix.spinnaker.igor.scm.stash.client.StashMaster
+import com.netflix.spinnaker.igor.scm.stash.client.StashController
 import com.netflix.spinnaker.igor.scm.stash.client.model.DirectoryChild
 import com.netflix.spinnaker.igor.scm.stash.client.model.DirectoryChildren
 import com.netflix.spinnaker.igor.scm.stash.client.model.DirectoryListingResponse
@@ -29,7 +29,7 @@ import com.netflix.spinnaker.igor.scm.stash.client.model.TextLinesResponse
 import spock.lang.Specification
 import spock.lang.Subject
 
-import static com.netflix.spinnaker.igor.scm.stash.client.StashMaster.DEFAULT_PAGED_RESPONSE_LIMIT
+import static com.netflix.spinnaker.igor.scm.stash.client.StashController.DEFAULT_PAGED_RESPONSE_LIMIT
 
 class ManagedDeliveryScmServiceSpec extends Specification {
   @Subject
@@ -44,7 +44,7 @@ class ManagedDeliveryScmServiceSpec extends Specification {
   void setup() {
       service = new ManagedDeliveryScmService(
         Optional.of(new ManagedDeliveryConfigProperties(manifestBasePath: ".spinnaker")),
-        Optional.of(new StashMaster(stashClient: client, baseUrl : STASH_ADDRESS)),
+        Optional.of(new StashController(stashClient: client, baseUrl : STASH_ADDRESS)),
         Optional.empty(),
         Optional.empty(),
         Optional.empty()

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ScmInfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ScmInfoControllerSpec.groovy
@@ -17,11 +17,11 @@
 package com.netflix.spinnaker.igor.scm
 
 import com.netflix.spinnaker.igor.scm.github.client.GitHubClient
-import com.netflix.spinnaker.igor.scm.github.client.GitHubMaster
+import com.netflix.spinnaker.igor.scm.github.client.GitHubController
 import com.netflix.spinnaker.igor.scm.stash.client.StashClient
-import com.netflix.spinnaker.igor.scm.stash.client.StashMaster
+import com.netflix.spinnaker.igor.scm.stash.client.StashController
 import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketClient
-import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketMaster
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketController
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -38,18 +38,29 @@ class ScmInfoControllerSpec extends Specification {
     BitBucketClient bitBucketClient = Mock(BitBucketClient)
 
     void setup() {
-        controller = new ScmInfoController(gitHubMaster: new GitHubMaster(gitHubClient: gitHubClient, baseUrl: "https://github.com"),
-                                           stashMaster: new StashMaster(stashClient: stashClient, baseUrl: "http://stash.com"),
-                                           bitBucketMaster: new BitBucketMaster(bitBucketClient: bitBucketClient, baseUrl: "https://api.bitbucket.org"))
+        controller = new ScmInfoController(gitHubController: new GitHubController(gitHubClient: gitHubClient, baseUrl: "https://github.com"),
+          stashController: new StashController(stashClient: stashClient, baseUrl: "http://stash.com"),
+          bitBucketController: new BitBucketController(bitBucketClient: bitBucketClient, baseUrl: "https://api.bitbucket.org"))
     }
 
+    @Deprecated(forRemoval = true)
     void 'list masters'() {
         when:
-        Map listMastersResponse = controller.listMasters()
+        Map listControllersResponse = controller.listMasters()
 
         then:
-        listMastersResponse.stash == "http://stash.com"
-        listMastersResponse.gitHub == "https://github.com"
-        listMastersResponse.bitBucket == "https://api.bitbucket.org"
+        listControllersResponse.stash == "http://stash.com"
+        listControllersResponse.gitHub == "https://github.com"
+        listControllersResponse.bitBucket == "https://api.bitbucket.org"
+    }
+
+    void 'list controllers'() {
+        when:
+        Map listControllersResponse = controller.listControllers()
+
+        then:
+        listControllersResponse.stash == "http://stash.com"
+        listControllersResponse.gitHub == "https://github.com"
+        listControllersResponse.bitBucket == "https://api.bitbucket.org"
     }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitControllerSpec.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.igor.scm.bitbucket
 import com.netflix.spinnaker.igor.config.BitBucketProperties
 import com.netflix.spinnaker.igor.scm.AbstractCommitController
 import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketClient
-import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketMaster
+import com.netflix.spinnaker.igor.scm.bitbucket.client.BitBucketController
 import com.netflix.spinnaker.igor.scm.bitbucket.client.model.Author
 import com.netflix.spinnaker.igor.scm.bitbucket.client.model.Commit
 import com.netflix.spinnaker.igor.scm.bitbucket.client.model.CompareCommitsResponse
@@ -44,7 +44,7 @@ class CommitControllerSpec extends Specification {
   def BITBUCKET_ADDRESS = "https://api.bitbucket.org"
 
   void setup() {
-    controller = new CommitController(executor: Executors.newSingleThreadExecutor(), bitBucketMaster: new BitBucketMaster(bitBucketClient: client, baseUrl : BITBUCKET_ADDRESS), bitBucketProperties: new BitBucketProperties(commitDisplayLength: 7))
+    controller = new CommitController(executor: Executors.newSingleThreadExecutor(), bitBucketController: new BitBucketController(bitBucketClient: client, baseUrl : BITBUCKET_ADDRESS), bitBucketProperties: new BitBucketProperties(commitDisplayLength: 7))
   }
 
   void 'missing query params'() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/github/CommitControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/github/CommitControllerSpec.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.igor.scm.github
 import com.netflix.spinnaker.igor.config.GitHubProperties
 import com.netflix.spinnaker.igor.scm.AbstractCommitController
 import com.netflix.spinnaker.igor.scm.github.client.GitHubClient
-import com.netflix.spinnaker.igor.scm.github.client.GitHubMaster
+import com.netflix.spinnaker.igor.scm.github.client.GitHubController
 import com.netflix.spinnaker.igor.scm.github.client.model.Author
 import com.netflix.spinnaker.igor.scm.github.client.model.Commit
 import com.netflix.spinnaker.igor.scm.github.client.model.CommitInfo
@@ -45,7 +45,7 @@ class CommitControllerSpec extends Specification {
     def GITHUB_ADDRESS = "https://github.com"
 
     void setup() {
-        controller = new CommitController(executor: Executors.newSingleThreadExecutor(), master: new GitHubMaster(gitHubClient: client, baseUrl : GITHUB_ADDRESS), gitHubProperties: new GitHubProperties(commitDisplayLength: 8))
+        controller = new CommitController(executor: Executors.newSingleThreadExecutor(), controller: new GitHubController(gitHubClient: client, baseUrl : GITHUB_ADDRESS), gitHubProperties: new GitHubProperties(commitDisplayLength: 8))
     }
 
     void 'missing query params'() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/github/client/GitHubControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/github/client/GitHubControllerSpec.groovy
@@ -21,14 +21,14 @@ import com.netflix.spinnaker.igor.scm.github.client.model.GetRepositoryContentRe
 import spock.lang.Specification
 import spock.lang.Subject
 
-class GitHubMasterSpec extends Specification {
+class GitHubControllerSpec extends Specification {
   @Subject
-  GitHubMaster gitHubMaster
+  GitHubController gitHubController
 
   GitHubClient gitHubClient = Mock(GitHubClient)
 
   void setup() {
-    gitHubMaster = new GitHubMaster(gitHubClient: gitHubClient, baseUrl: "")
+    gitHubController = new GitHubController(gitHubClient: gitHubClient, baseUrl: "")
   }
 
   void 'list directory'() {
@@ -36,7 +36,7 @@ class GitHubMasterSpec extends Specification {
     1 * gitHubClient.listDirectory(project, repo, dir, ref) >> gitHubClientResponse
 
     when:
-    List<String> response = gitHubMaster.listDirectory(project, repo, dir, ref)
+    List<String> response = gitHubController.listDirectory(project, repo, dir, ref)
 
     then:
     response == expectedResponse
@@ -60,7 +60,7 @@ class GitHubMasterSpec extends Specification {
     1 * gitHubClient.getFileContent(project, repo, dir, ref) >> gitHubClientResponse
 
     when:
-    String response = gitHubMaster.getTextFileContents(project, repo, dir, ref)
+    String response = gitHubController.getTextFileContents(project, repo, dir, ref)
 
     then:
     response == expectedResponse

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/gitlab/CommitControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/gitlab/CommitControllerSpec.groovy
@@ -19,16 +19,13 @@ package com.netflix.spinnaker.igor.scm.gitlab
 import com.netflix.spinnaker.igor.config.GitLabProperties
 import com.netflix.spinnaker.igor.scm.AbstractCommitController
 import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabClient
-import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabMaster
+import com.netflix.spinnaker.igor.scm.gitlab.client.GitLabController
 import com.netflix.spinnaker.igor.scm.gitlab.client.model.Commit
 import com.netflix.spinnaker.igor.scm.gitlab.client.model.CompareCommitsResponse
 import retrofit.RetrofitError
 import retrofit.client.Response
 import spock.lang.Specification
 import spock.lang.Subject
-
-import java.time.Instant
-import java.util.concurrent.Executors
 
 /**
  * Tests for GitLab CommitController
@@ -46,7 +43,7 @@ class CommitControllerSpec extends Specification {
         def props = new GitLabProperties()
         props.baseUrl = GITLAB_ADDRESS
         props.commitDisplayLength = 8
-        controller = new CommitController(new GitLabMaster(client, GITLAB_ADDRESS), props)
+        controller = new CommitController(new GitLabController(client, GITLAB_ADDRESS), props)
     }
 
     void 'missing query params'() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/CommitControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/CommitControllerSpec.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.igor.scm.stash
 
 import com.netflix.spinnaker.igor.scm.AbstractCommitController
 import com.netflix.spinnaker.igor.scm.stash.client.StashClient
-import com.netflix.spinnaker.igor.scm.stash.client.StashMaster
+import com.netflix.spinnaker.igor.scm.stash.client.StashController
 import com.netflix.spinnaker.igor.scm.stash.client.model.Author
 import com.netflix.spinnaker.igor.scm.stash.client.model.Commit
 import com.netflix.spinnaker.igor.scm.stash.client.model.CompareCommitsResponse
@@ -42,7 +42,7 @@ class CommitControllerSpec extends Specification {
     def STASH_ADDRESS = "https://stash.com"
 
     void setup() {
-        controller = new CommitController(executor: Executors.newSingleThreadExecutor(), stashMaster: new StashMaster(stashClient: client, baseUrl : STASH_ADDRESS))
+        controller = new CommitController(executor: Executors.newSingleThreadExecutor(), stashController: new StashController(stashClient: client, baseUrl : STASH_ADDRESS))
 
     }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/client/StashClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/client/StashClientSpec.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.igor.scm.stash.client
 
 import com.netflix.spinnaker.igor.config.StashConfig
-import com.netflix.spinnaker.igor.scm.ScmMaster
+import com.netflix.spinnaker.igor.scm.ScmController
 import com.netflix.spinnaker.igor.scm.stash.client.model.CompareCommitsResponse
 import com.netflix.spinnaker.igor.scm.stash.client.model.DirectoryListingResponse
 import com.netflix.spinnaker.igor.scm.stash.client.model.TextLinesResponse
@@ -108,7 +108,7 @@ class StashClientSpec extends Specification {
     setResponse('application/json', listDirectoryResponse)
 
     when:
-    DirectoryListingResponse dirListResponse = client.listDirectory('foo', 'repo', '.spinnaker', ScmMaster.DEFAULT_GIT_REF)
+    DirectoryListingResponse dirListResponse = client.listDirectory('foo', 'repo', '.spinnaker', ScmController.DEFAULT_GIT_REF)
 
     then:
     dirListResponse.children.size == 2
@@ -133,7 +133,7 @@ class StashClientSpec extends Specification {
     setResponse('application/json', contents)
 
     when:
-    TextLinesResponse response = client.getTextFileContents('foo', 'repo', 'bananas.txt', ScmMaster.DEFAULT_GIT_REF, 1, start)
+    TextLinesResponse response = client.getTextFileContents('foo', 'repo', 'bananas.txt', ScmController.DEFAULT_GIT_REF, 1, start)
 
     then:
     response.size == size

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitorSpec.groovy
@@ -35,19 +35,19 @@ class WerckerBuildMonitorSpec extends Specification {
     WerckerService mockService = Mock(WerckerService)
     WerckerService werckerService
     String werckerDev = 'https://dev.wercker.com/'
-    String master = 'WerckerTestMaster'
+    String controller = 'WerckerTestController'
 
     void setup() {
         client = Mock(WerckerClient)
         werckerService = new WerckerService(
-                new WerckerHost(name: master, address: werckerDev), cache, client, Permissions.EMPTY)
+                new WerckerHost(name: controller, address: werckerDev), cache, client, Permissions.EMPTY)
     }
 
-    def MASTER = 'MASTER'
+    def CONTROLLER = 'CONTROLLER'
 
     BuildServices mockBuildServices() {
         BuildServices buildServices = new BuildServices()
-        buildServices.addServices([MASTER: mockService])
+        buildServices.addServices([CONTROLLER: mockService])
         return buildServices
     }
 
@@ -67,7 +67,7 @@ class WerckerBuildMonitorSpec extends Specification {
         mockService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
 
         when:
-        monitor.pollSingle(new PollContext(MASTER))
+        monitor.pollSingle(new PollContext(CONTROLLER))
 
         then: 'initial poll'
         0 * echoService.postEvent(_)
@@ -89,7 +89,7 @@ class WerckerBuildMonitorSpec extends Specification {
         mockService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
 
         when:
-        monitor.pollSingle(new PollContext(MASTER))
+        monitor.pollSingle(new PollContext(CONTROLLER))
 
         then: 'initial poll'
         1 * echoService.postEvent(_)
@@ -103,7 +103,7 @@ class WerckerBuildMonitorSpec extends Specification {
         mockService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
 
         when:
-        monitor.pollSingle(new PollContext(MASTER))
+        monitor.pollSingle(new PollContext(CONTROLLER))
 
         then: 'initial poll'
         0 * echoService.postEvent(_)
@@ -119,30 +119,30 @@ class WerckerBuildMonitorSpec extends Specification {
         cache.getLastPollCycleTimestamp(_, _) >> (now - 1000)
         1 * mockService.getRunsSince(_) >> [pipeline: runs1]
         cache.getBuildNumber(*_) >> 1
-        monitor.pollSingle(new PollContext(MASTER))
+        monitor.pollSingle(new PollContext(CONTROLLER))
 
         then:
-        1 * cache.setEventPosted('MASTER', 'pipeline', 'init')
+        1 * cache.setEventPosted('CONTROLLER', 'pipeline', 'init')
         1 * echoService.postEvent(_)
     }
 
     void 'get runs of multiple pipelines'() {
         setup:
         BuildServices buildServices = new BuildServices()
-        buildServices.addServices([MASTER: werckerService])
+        buildServices.addServices([CONTROLLER: werckerService])
         monitor = monitor(buildServices)
         cache.getBuildNumber(*_) >> 1
         client.getRunsSince(_, _, _, _, _) >> []
         mockService.getBuildServiceProvider() >> BuildServiceProvider.WERCKER
 
         when:
-        monitor.pollSingle(new PollContext(MASTER))
+        monitor.pollSingle(new PollContext(CONTROLLER))
 
         then: 'initial poll'
         0 * echoService.postEvent(_)
 
         when:
-        monitor.pollSingle(new PollContext(MASTER))
+        monitor.pollSingle(new PollContext(CONTROLLER))
 
         then:
         0 * echoService.postEvent(_)
@@ -172,14 +172,14 @@ class WerckerBuildMonitorSpec extends Specification {
         client.getRunsSince(_,_,_,_,_) >> runs1
         cache.getLastPollCycleTimestamp(_, _) >> (now - 1000)
         cache.getBuildNumber(*_) >> 1
-        monitor.pollSingle(new PollContext(MASTER))
+        monitor.pollSingle(new PollContext(CONTROLLER))
 
         then:
-        1 * cache.setEventPosted('MASTER', 'myOrg/app0/p00', 'run0')
-        1 * cache.setEventPosted('MASTER', 'myOrg/app1/p10', 'run1')
-        1 * cache.setEventPosted('MASTER', 'myOrg/app1/p11', 'run3')
-        1 * cache.setEventPosted('MASTER', 'myOrg/app2/p20', 'run4')
-        0 * cache.setEventPosted('MASTER', 'myOrg/app3/p30', 'run5')
+        1 * cache.setEventPosted('CONTROLLER', 'myOrg/app0/p00', 'run0')
+        1 * cache.setEventPosted('CONTROLLER', 'myOrg/app1/p10', 'run1')
+        1 * cache.setEventPosted('CONTROLLER', 'myOrg/app1/p11', 'run3')
+        1 * cache.setEventPosted('CONTROLLER', 'myOrg/app2/p20', 'run4')
+        0 * cache.setEventPosted('CONTROLLER', 'myOrg/app3/p30', 'run5')
         4 * echoService.postEvent(_)
     }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerCacheSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerCacheSpec.groovy
@@ -26,8 +26,7 @@ class WerckerCacheSpec extends Specification {
     @Subject
     WerckerCache cache = new WerckerCache(redisClientDelegate, new IgorConfigurationProperties())
 
-    def master = 'testWerckerMaster'
-    def test = 'test'
+    def controller = 'testWerckerController'
     def pipeline = 'myOrg/myApp/myTestPipeline'
 
     void cleanup() {
@@ -38,15 +37,15 @@ class WerckerCacheSpec extends Specification {
     void 'lastPollCycleTimestamp get overridden'() {
         long now1 = System.currentTimeMillis();
         when:
-        cache.setLastPollCycleTimestamp(master, 'myOrg/myApp/myPipeline', now1)
+        cache.setLastPollCycleTimestamp(controller, 'myOrg/myApp/myPipeline', now1)
         then:
-        cache.getLastPollCycleTimestamp(master, 'myOrg/myApp/myPipeline') == now1
+        cache.getLastPollCycleTimestamp(controller, 'myOrg/myApp/myPipeline') == now1
 
         long now2 = System.currentTimeMillis();
         when:
-        cache.setLastPollCycleTimestamp(master, 'myOrg/myApp/myPipeline', now2)
+        cache.setLastPollCycleTimestamp(controller, 'myOrg/myApp/myPipeline', now2)
         then:
-        cache.getLastPollCycleTimestamp(master, 'myOrg/myApp/myPipeline') == now2
+        cache.getLastPollCycleTimestamp(controller, 'myOrg/myApp/myPipeline') == now2
     }
 
     void 'generates buildNumbers ordered by startedAt'() {
@@ -56,17 +55,17 @@ class WerckerCacheSpec extends Specification {
             new Run(id:"a",    createdAt: new Date(now-11)),
             new Run(id:"init"),
         ]
-        cache.updateBuildNumbers(master, pipeline, runs1)
+        cache.updateBuildNumbers(controller, pipeline, runs1)
 
         List<Run> runs2 = [
             new Run(id:"now", startedAt: new Date(now)),
             new Run(id:"d",   createdAt: new Date(now-1)),
             new Run(id:"c",   startedAt: new Date(now-2)),
         ]
-        cache.updateBuildNumbers(master, pipeline, runs2)
+        cache.updateBuildNumbers(controller, pipeline, runs2)
 
         expect:
-        cache.getBuildNumber(master, pipeline, runId) == buildNumber
+        cache.getBuildNumber(controller, pipeline, runId) == buildNumber
 
         where:
         runId  | buildNumber
@@ -85,17 +84,17 @@ class WerckerCacheSpec extends Specification {
             new Run(id:"x",    startedAt: new Date(now-11)),
             new Run(id:"zero", createdAt: new Date(now-12)),
         ]
-        cache.updateBuildNumbers(master, pipeline, runs1)
+        cache.updateBuildNumbers(controller, pipeline, runs1)
 
         List<Run> runs2 = [
             new Run(id:"latest", createdAt: new Date(now)),
             new Run(id:"4",      startedAt: new Date(now-1)),
             new Run(id:"3",      createdAt: new Date(now-2)),
         ]
-        cache.updateBuildNumbers(master, pipeline, runs2)
+        cache.updateBuildNumbers(controller, pipeline, runs2)
 
         expect:
-        cache.getBuildNumber(master, pipeline, runId) == buildNumber
+        cache.getBuildNumber(controller, pipeline, runId) == buildNumber
 
         where:
         runId    | buildNumber

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerClientSpec.groovy
@@ -100,7 +100,7 @@ class WerckerClientSpec extends Specification {
                 .setHeader('Content-Type', 'application/json; charset=utf-8')
                 )
         server.start()
-        def host = new WerckerHost(name: 'werckerMaster', address: server.url('/').toString())
+        def host = new WerckerHost(name: 'werckerCONTROLLER', address: server.url('/').toString())
         client = new WerckerConfig().werckerClient(host, 30000, new OkHttpClientProvider([new InsecureOkHttpClientBuilderProvider(new OkHttpClient())]), RestAdapter.LogLevel.BASIC)
     }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerServiceSpec.groovy
@@ -26,12 +26,12 @@ class WerckerServiceSpec extends Specification {
     @Shared
     WerckerService service
     String werckerDev = 'https://dev.wercker.com/'
-    String master = 'WerckerTestMaster'
+    String controller = 'WerckerTestController'
 
     void setup() {
         client = Mock(WerckerClient)
         service = new WerckerService(
-                new WerckerHost(name: master, address: werckerDev), cache, client, Permissions.EMPTY)
+                new WerckerHost(name: controller, address: werckerDev), cache, client, Permissions.EMPTY)
     }
 
     void 'get pipelines as jobs'() {
@@ -130,7 +130,7 @@ class WerckerServiceSpec extends Specification {
         def runId = "testGenericBuild_werckerRunId"
         int buildNumber = 6
         setup:
-        cache.getRunID(master, job, buildNumber) >> runId
+        cache.getRunID(controller, job, buildNumber) >> runId
         client.getRunById(_, runId) >> new Run(id: runId)
 
         expect:
@@ -156,7 +156,7 @@ class WerckerServiceSpec extends Specification {
         ]
         client.triggerBuild(_, _) >> ['id': runId]
         client.getRunById(_, runId) >> new Run(id: runId)
-        cache.updateBuildNumbers(master, pipeline, _) >> ['test_triggerBuild_runId': buildNumber]
+        cache.updateBuildNumbers(controller, pipeline, _) >> ['test_triggerBuild_runId': buildNumber]
 
         expect:
         service.triggerBuildWithParameters(pipeline, [:]) == buildNumber

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitorTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitorTest.java
@@ -59,7 +59,7 @@ class ConcourseBuildMonitorTest {
     host.setPassword("fake");
 
     ConcourseProperties props = new ConcourseProperties();
-    props.setMasters(Collections.singletonList(host));
+    props.setControllers(Collections.singletonList(host));
 
     BuildServices buildServices = new BuildServices();
     buildServices.addServices(


### PR DESCRIPTION
This change renames master to controller. The reasoning behind this
change is that none of the services seems to be using that terminology
anymore.

Changing the terminology in Igor to something that at least some of
the services uses makes it easier to understand what's being referenced.

All externally accessible APIs with the old terminology are marked as
deprecated and will use the new functions until the deprecated functions
are finally removed. This to remain backward compatible.
