### PR TITLE
fix(travis): Avoid a potential NPE when retrieving latest builds

### DIFF
--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
@@ -339,6 +339,7 @@ public class TravisService implements BuildOperations, BuildProperties {
                 TravisBuildState.failed,
                 TravisBuildState.canceled)
             .stream()
+            .filter(job -> job.getBuild() != null)
             .collect(
                 Collectors.groupingBy(V3Job::getBuild, LinkedHashMap::new, Collectors.toList()));
 


### PR DESCRIPTION
After upgrading from Travis Enterprise 2 to 3, we ran into an issue where the build was `null` for some jobs. I believe this  is a bug in Travis, but I'm adding a check here to just avoid a NullPointerException that blocks the Travis provider from fetching builds if this issue should ever occur again.