### PR TITLE
feat(scm): add ability to retrieve raw delivery config

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmController.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmController.java
@@ -75,11 +75,12 @@ public class ManagedDeliveryScmController {
       @RequestParam final String repository,
       @RequestParam final String manifest,
       @RequestParam(required = false) final String directory,
-      @RequestParam(required = false) final String ref) {
+      @RequestParam(required = false) final String ref,
+      @RequestParam(required = false, defaultValue = "false") final boolean raw) {
     try {
       return new ResponseEntity<>(
           mdScmService.getDeliveryConfigManifest(
-              scmType, project, repository, directory, manifest, ref),
+              scmType, project, repository, directory, manifest, ref, raw),
           HttpStatus.OK);
     } catch (Exception e) {
       HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmService.java
@@ -111,7 +111,8 @@ public class ManagedDeliveryScmService {
       final String repository,
       final String directory,
       final String manifest,
-      final String ref) {
+      final String ref,
+      final boolean raw) {
 
     if (scmType == null || project == null || repository == null) {
       throw new IllegalArgumentException("scmType, project and repository are required arguments");
@@ -132,6 +133,10 @@ public class ManagedDeliveryScmService {
         "Retrieving delivery config manifest from " + project + ":" + repository + "/" + path);
     String manifestContents =
         getScmMaster(scmType).getTextFileContents(project, repository, path, ref);
+
+    if (raw) {
+      return Map.of("manifest", manifestContents);
+    }
 
     try {
       if (manifest.endsWith(".json")) {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmService.java
@@ -104,6 +104,14 @@ public class ManagedDeliveryScmService {
    *
    * <p>This API supports both YAML and JSON for the format of the manifest in source control, but
    * always returns the parsed contents as a Map.
+   *
+   * @param scmType the type of SCM system to use (e.g. "github", "gitlab", etc.)
+   * @param project the name of the project in the SCM system
+   * @param repository the name of the repository in the SCM system
+   * @param directory the directory within the repository to look for the manifest
+   * @param manifest the name of the manifest file to retrieve
+   * @param ref the git reference to use (branch, tag, commit hash, etc.)
+   * @param raw if true, returns the raw contents of the manifest as a string
    */
   public Map<String, Object> getDeliveryConfigManifest(
       final String scmType,

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmControllerSpec.groovy
@@ -58,10 +58,10 @@ class ManagedDeliveryScmControllerSpec extends Specification {
 
   void 'get delivery config manifest returns contents from service'() {
     given:
-    1 * service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref) >> expectedResponse
+    1 * service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref, raw) >> expectedResponse
 
     when:
-    ResponseEntity<Map<String, Object>> response = controller.getDeliveryConfigManifest(scmType, project, repo, manifest, dir, ref)
+    ResponseEntity<Map<String, Object>> response = controller.getDeliveryConfigManifest(scmType, project, repo, manifest, dir, ref, raw)
 
     then:
     response == new ResponseEntity(expectedResponse, HttpStatus.OK)
@@ -73,6 +73,7 @@ class ManagedDeliveryScmControllerSpec extends Specification {
     manifest = 'manifest.yml'
     dir = 'dir'
     ref = 'refs/heads/master'
+    raw = false
     expectedResponse = [
       apiVersion: "foo",
       kind: "Foo",
@@ -83,12 +84,12 @@ class ManagedDeliveryScmControllerSpec extends Specification {
 
   void 'IllegalArgumentException from service causes a 400'() {
     given:
-    1 * service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref) >> {
+    1 * service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref, raw) >> {
       throw new IllegalArgumentException("oops!")
     }
 
     when:
-    ResponseEntity<Map<String, Object>> response = controller.getDeliveryConfigManifest(scmType, project, repo, manifest, dir, ref)
+    ResponseEntity<Map<String, Object>> response = controller.getDeliveryConfigManifest(scmType, project, repo, manifest, dir, ref, raw)
 
     then:
     response == new ResponseEntity<>(expectedResponse, HttpStatus.BAD_REQUEST)
@@ -100,12 +101,13 @@ class ManagedDeliveryScmControllerSpec extends Specification {
     manifest = 'somefile'
     dir = 'dir'
     ref = 'refs/heads/master'
+    raw = false
     expectedResponse = [error: "oops!"]
   }
 
   void '404 error from service is propagated'() {
     given:
-    1 * service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref) >> {
+    1 * service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref, raw) >> {
       throw new SpinnakerHttpException(new RetrofitError("oops!", "http://nada",
         new Response("http://nada", 404, "", [], new TypedString('{"detail": "oops!"}')),
         new JacksonConverter(),
@@ -116,7 +118,7 @@ class ManagedDeliveryScmControllerSpec extends Specification {
     }
 
     when:
-    ResponseEntity<Map<String, Object>> response = controller.getDeliveryConfigManifest(scmType, project, repo, manifest, dir, ref)
+    ResponseEntity<Map<String, Object>> response = controller.getDeliveryConfigManifest(scmType, project, repo, manifest, dir, ref, raw)
 
     then:
     response == new ResponseEntity<>(expectedResponse, HttpStatus.NOT_FOUND)
@@ -128,17 +130,18 @@ class ManagedDeliveryScmControllerSpec extends Specification {
     manifest = 'somefile'
     dir = 'dir'
     ref = 'refs/heads/master'
+    raw = false
     expectedResponse = [error: [detail: "oops!"]]
   }
 
   void 'other exceptions from service cause a 500'() {
     given:
-    1 * service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref) >> {
+    1 * service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref, raw) >> {
       throw new RuntimeException("another oops!")
     }
 
     when:
-    ResponseEntity<Map<String, Object>> response = controller.getDeliveryConfigManifest(scmType, project, repo, manifest, dir, ref)
+    ResponseEntity<Map<String, Object>> response = controller.getDeliveryConfigManifest(scmType, project, repo, manifest, dir, ref, raw)
 
     then:
     response == new ResponseEntity<>(expectedResponse, HttpStatus.INTERNAL_SERVER_ERROR)
@@ -150,6 +153,7 @@ class ManagedDeliveryScmControllerSpec extends Specification {
     manifest = 'somefile'
     dir = 'dir'
     ref = 'refs/heads/master'
+    raw = false
     expectedResponse = [error: "another oops!"]
   }
 }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/ManagedDeliveryScmServiceSpec.groovy
@@ -80,7 +80,7 @@ class ManagedDeliveryScmServiceSpec extends Specification {
     1 * client.getTextFileContents(project, repo, ".spinnaker/dir/manifest.yml", ref, DEFAULT_PAGED_RESPONSE_LIMIT, 0) >> expectedResponse
 
     when:
-    Map<String, Object> response = service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref)
+    Map<String, Object> response = service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref, raw)
 
     then:
     response == yamlMapper.readValue(expectedResponse.toTextContents(), Map.class)
@@ -92,6 +92,7 @@ class ManagedDeliveryScmServiceSpec extends Specification {
     manifest = 'manifest.yml'
     dir = 'dir'
     ref = 'refs/heads/master'
+    raw = false
     expectedResponse = new TextLinesResponse(
       lines: [
         [ text: "apiVersion: foo"],
@@ -109,7 +110,7 @@ class ManagedDeliveryScmServiceSpec extends Specification {
     1 * client.getTextFileContents(project, repo, ".spinnaker/dir/manifest.json", ref, DEFAULT_PAGED_RESPONSE_LIMIT, 0) >> expectedResponse
 
     when:
-    Map<String, Object> response = service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref)
+    Map<String, Object> response = service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref, raw)
 
     then:
     response == jsonMapper.readValue(expectedResponse.toTextContents(), Map.class)
@@ -121,6 +122,34 @@ class ManagedDeliveryScmServiceSpec extends Specification {
     manifest = 'manifest.json'
     dir = 'dir'
     ref = 'refs/heads/master'
+    raw = false
+    expectedResponse = new TextLinesResponse(
+      lines: [
+        [ text: '{ "apiVersion": "foo", "kind": "Foo", "metadata": {}, "spec": {} }']
+      ],
+      size: 1,
+      isLastPage: true
+    )
+  }
+
+  void 'get raw delivery config manifest'() {
+    given:
+    1 * client.getTextFileContents(project, repo, ".spinnaker/dir/manifest.json", ref, DEFAULT_PAGED_RESPONSE_LIMIT, 0) >> expectedResponse
+
+    when:
+    Map<String, Object> response = service.getDeliveryConfigManifest(scmType, project, repo, dir, manifest, ref, raw)
+
+    then:
+    jsonMapper.readValue((String) response["manifest"], Map.class) == jsonMapper.readValue(expectedResponse.toTextContents(), Map.class)
+
+    where:
+    scmType = 'stash'
+    project = 'proj'
+    repo = 'repo'
+    manifest = 'manifest.json'
+    dir = 'dir'
+    ref = 'refs/heads/master'
+    raw = true
     expectedResponse = new TextLinesResponse(
       lines: [
         [ text: '{ "apiVersion": "foo", "kind": "Foo", "metadata": {}, "spec": {} }']


### PR DESCRIPTION
Allow retrieval of raw delivery configuration manifests which is
required by Keel.

https://github.com/spinnaker/keel/blob/master/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/ScmService.kt#L44