### PR TITLE
fix(build): bump kork to 7.110.0 & change groupid for dependencies

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -3,6 +3,23 @@
   <component name="CompilerConfiguration">
     <annotationProcessing>
       <profile default="true" name="Default" enabled="true" />
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.12/48e4e5d60309ebd833bc528dcf77668eab3cd72c/lombok-1.18.12.jar" />
+        </processorPath>
+        <module name="igor.igor-core.main" />
+        <module name="igor.igor-monitor-plugins.main" />
+        <module name="igor.igor-monitor-travis.main" />
+        <module name="igor.igor-web.main" />
+        <module name="igor.igor-core.test" />
+        <module name="igor.igor-monitor-artifactory.main" />
+        <module name="igor.igor-monitor-plugins.test" />
+        <module name="igor.igor-monitor-travis.test" />
+        <module name="igor.igor-monitor-artifactory.test" />
+        <module name="igor.igor-web.test" />
+      </profile>
     </annotationProcessing>
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,11 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="delegatedBuild" value="true" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="useAutoImport" value="true" />
+        <option name="gradleHome" value="/usr/local/Cellar/gradle/6.3/libexec" />
+        <option name="gradleJvm" value="11" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/igor-bom" />
+            <option value="$PROJECT_DIR$/igor-core" />
+            <option value="$PROJECT_DIR$/igor-monitor-artifactory" />
+            <option value="$PROJECT_DIR$/igor-monitor-plugins" />
+            <option value="$PROJECT_DIR$/igor-monitor-travis" />
+            <option value="$PROJECT_DIR$/igor-web" />
+          </set>
+        </option>
       </GradleProjectSettings>
     </option>
   </component>

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 subprojects {
-  group = "com.netflix.spinnaker.igor"
+  group = "io.spinnaker.igor"
   apply plugin: 'io.spinnaker.project'
 
   if ([korkVersion, fiatVersion].find { it.endsWith('-SNAPSHOT') }) {
@@ -36,11 +36,11 @@ subprojects {
     sourceSets.main.groovy.srcDirs += ["src/main/java"]
 
     dependencies {
-      implementation platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+      implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
       compileOnly "org.projectlombok:lombok"
-      annotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+      annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor "org.projectlombok:lombok"
-      testAnnotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+      testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
 
       implementation "org.springframework.boot:spring-boot-starter-actuator"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-fiatVersion=1.26.0
-korkVersion=7.99.1
+fiatVersion=1.27.0
+korkVersion=7.110.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.10.1
 targetJava11=true

--- a/igor-bom/igor-bom.gradle
+++ b/igor-bom/igor-bom.gradle
@@ -22,11 +22,11 @@ javaPlatform {
 
 
 dependencies {
-  api(platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion"))
+  api(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
 
   constraints {
-    api("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
-    api("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+    api("io.spinnaker.fiat:fiat-api:$fiatVersion")
+    api("io.spinnaker.fiat:fiat-core:$fiatVersion")
 
     rootProject
       .subprojects

--- a/igor-core/igor-core.gradle
+++ b/igor-core/igor-core.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  implementation "com.netflix.spinnaker.kork:kork-artifacts"
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-jedis"
-  implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.kork:kork-artifacts"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-jedis"
+  implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
 
   // TODO(rz): Get rid of this dependency!
   implementation "com.squareup.retrofit:retrofit"

--- a/igor-monitor-artifactory/igor-monitor-artifactory.gradle
+++ b/igor-monitor-artifactory/igor-monitor-artifactory.gradle
@@ -17,16 +17,16 @@
 dependencies {
   implementation project(":igor-core")
 
-  implementation "com.netflix.spinnaker.kork:kork-artifacts"
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.kork:kork-artifacts"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-security"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
 
   implementation "org.jfrog.artifactory.client:artifactory-java-client-services:2.8.1"
 
   // TODO(rz): Get rid of this dependency!
-  implementation "com.netflix.spinnaker.kork:kork-jedis"
+  implementation "io.spinnaker.kork:kork-jedis"
 
   // TODO(rz): Get rid of this dependency!
   implementation "net.logstash.logback:logstash-logback-encoder"

--- a/igor-monitor-plugins/igor-monitor-plugins.gradle
+++ b/igor-monitor-plugins/igor-monitor-plugins.gradle
@@ -18,10 +18,10 @@
 dependencies {
   implementation project(":igor-core")
 
-  implementation "com.netflix.spinnaker.kork:kork-artifacts"
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-jedis"
-  implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.kork:kork-artifacts"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-jedis"
+  implementation "io.spinnaker.kork:kork-security"
 
   implementation "org.springframework.boot:spring-boot-starter-actuator"
 

--- a/igor-monitor-travis/igor-monitor-travis.gradle
+++ b/igor-monitor-travis/igor-monitor-travis.gradle
@@ -17,12 +17,12 @@
 dependencies {
   implementation project(":igor-core")
 
-  implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
-  implementation "com.netflix.spinnaker.kork:kork-artifacts"
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-jedis"
-  implementation "com.netflix.spinnaker.kork:kork-security"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.kork:kork-artifacts"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-jedis"
+  implementation "io.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.kork:kork-web"
 
   implementation "com.fasterxml.jackson.core:jackson-databind"
   implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -8,7 +8,7 @@ run {
   systemProperty('spring.config.additional-location', project.springConfigLocation)
 }
 
-mainClassName = 'com.netflix.spinnaker.igor.Main'
+mainClassName = 'io.spinnaker.igor.Main'
 
 test {
   useJUnitPlatform()
@@ -21,11 +21,11 @@ dependencies {
     implementation project(":igor-monitor-plugins")
     implementation project(":igor-monitor-travis")
 
-    implementation platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+    implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
     compileOnly "org.projectlombok:lombok"
-    annotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+    annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
     annotationProcessor "org.projectlombok:lombok"
-    testAnnotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+    testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
     testAnnotationProcessor "org.projectlombok:lombok"
 
     runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"
@@ -61,8 +61,8 @@ dependencies {
     implementation "com.squareup.okhttp:okhttp-apache"
     implementation "com.squareup.okhttp3:okhttp-sse"
     implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0"
-    implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
-    implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
+    implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
+    implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
     implementation "org.springframework.security:spring-security-core"
     implementation "org.springframework.security:spring-security-config"
     implementation "org.springframework.security:spring-security-web"
@@ -73,14 +73,14 @@ dependencies {
     implementation "com.google.apis:google-api-services-cloudbuild"
     implementation "com.google.apis:google-api-services-storage"
     implementation 'com.google.auth:google-auth-library-oauth2-http'
-    implementation "com.netflix.spinnaker.kork:kork-config"
-    implementation "com.netflix.spinnaker.kork:kork-cloud-config-server"
-    implementation "com.netflix.spinnaker.kork:kork-artifacts"
-    implementation "com.netflix.spinnaker.kork:kork-exceptions"
-    implementation "com.netflix.spinnaker.kork:kork-web"
-    implementation "com.netflix.spinnaker.kork:kork-jedis"
-    implementation "com.netflix.spinnaker.kork:kork-telemetry"
-    implementation "com.netflix.spinnaker.kork:kork-plugins"
+    implementation "io.spinnaker.kork:kork-config"
+    implementation "io.spinnaker.kork:kork-cloud-config-server"
+    implementation "io.spinnaker.kork:kork-artifacts"
+    implementation "io.spinnaker.kork:kork-exceptions"
+    implementation "io.spinnaker.kork:kork-web"
+    implementation "io.spinnaker.kork:kork-jedis"
+    implementation "io.spinnaker.kork:kork-telemetry"
+    implementation "io.spinnaker.kork:kork-plugins"
 
     implementation "io.github.resilience4j:resilience4j-retry"
 
@@ -89,10 +89,10 @@ dependencies {
     implementation "com.google.guava:guava"
     implementation "javax.inject:javax.inject:1"
 
-    runtimeOnly "com.netflix.spinnaker.kork:kork-runtime"
+    runtimeOnly "io.spinnaker.kork:kork-runtime"
 
     testImplementation "com.squareup.okhttp:mockwebserver"
-    testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
+    testImplementation "io.spinnaker.kork:kork-jedis-test"
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.assertj:assertj-core"
 


### PR DESCRIPTION
There is an issue in the Plugins Framework that was solved in this PR: spinnaker/kork#866

but this fix was released in kork 7.110.0

I bumped the version of kork to include the fix in VersionManager in the plugins framework but this involved changing the groupId of kork because now it's been published under "io.spinnaker" and this release branch is pretty old.

I had to bump the version of Fiat as well because it has issues when trying to download the kork version in fiat due to the groupId change.