### PR TITLE
chore(dependencies): bump spinnakerGradleVersion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 fiatVersion=1.28.0
 korkVersion=7.115.2
 org.gradle.parallel=true
-spinnakerGradleVersion=8.15.0
+spinnakerGradleVersion=8.23.0
 targetJava11=true
 
 # To enable a composite reference to a project, set the


### PR DESCRIPTION
to pick up google artifact registry publishing fixes

Doing this manually rather than backporting ~7 PRs
