### PR TITLE
chore(web): remove deprecated endpoints.health.sensitive configuratio…

### DIFF
--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -14,8 +14,6 @@ spinnaker:
     # https://github.com/spinnaker/igor/blob/master/igor-core/src/main/java/com/netflix/spinnaker/igor/IgorConfigurationProperties.java#L92
     itemUpperThreshold: 1000
 
-endpoints.health.sensitive: false
-
 spring.jackson.serialization.write_dates_as_timestamps: false
 
 server.port: 8088


### PR DESCRIPTION
…n property

With this property, Spring boot 2.2.13 warns on startup like:
```
{"@timestamp":"2022-05-12T22:16:02.124+00:00","@version":1,"message":"\nThe use of configuration keys that are no longer supported was found in the environment:\n\nProperty source 'applicationConfig: [classpath:/igor.yml]':\n\tKey: endpoints.health.sensitive\n\t\tReason: Endpoint sensitive flag is no longer customizable as Spring Boot no longer provides a customizable security auto-configuration .\n\n\nPlease refer to the migration guide or reference guide for potential alternatives.\n","logger_name":"org.springframework.boot.context.properties.migrator.PropertiesMigrationListener","thread_name":"main","level":"ERROR","level_value":40000}
```
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Configuration-Changelog shows that endpoints.health.sensitive was removed in spring boot 2.0.0

Similar to https://github.com/spinnaker/fiat/pull/877