### PR TITLE
feat(jenkins): Stop Jenkins job when job name has slashes in the job name

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -126,7 +126,7 @@ class BuildController {
   @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'READ')")
   Object getQueueLocation(@PathVariable String master, @PathVariable int item) {
     def buildService = getBuildService(master)
-    return buildService.queuedBuild(master, item);
+    return buildService.queuedBuild(master, item)
   }
 
   @RequestMapping(value = '/builds/all/{master:.+}/**')
@@ -145,7 +145,24 @@ class BuildController {
     @PathVariable String jobName,
     @PathVariable String queuedBuild,
     @PathVariable Integer buildNumber) {
+    stopJob(master, buildNumber, jobName, queuedBuild)
+    "true"
+  }
 
+  @RequestMapping(value = "/masters/{master}/jobs/stop/{queuedBuild}/{buildNumber}", method = RequestMethod.PUT)
+  @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'WRITE')")
+  String stopWithQueryParam(
+    @PathVariable String master,
+    @RequestParam String jobName,
+    @PathVariable String queuedBuild,
+    @PathVariable Integer buildNumber) {
+
+    stopJob(master, buildNumber, jobName, queuedBuild)
+    "true"
+  }
+
+
+  void stopJob(String master, int buildNumber, String jobName, String queuedBuild) {
     def buildService = getBuildService(master)
     if (buildService instanceof JenkinsService) {
       // Jobs that haven't been started yet won't have a buildNumber
@@ -169,7 +186,6 @@ class BuildController {
       }
     }
 
-    "true"
   }
 
   @RequestMapping(value = "/masters/{name}/jobs/**/update/{buildNumber}", method = RequestMethod.PATCH)
@@ -289,7 +305,7 @@ class BuildController {
       key = key + ":" + parameterDefinition.key + "=" + parameterDefinition.value
     }
 
-    return key;
+    return key
   }
 
   @RequestMapping(value = '/builds/properties/{buildNumber}/{fileName}/{master:.+}/**')

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -77,6 +77,7 @@ class BuildControllerSpec extends Specification {
   def BUILD_ID = 654321
   def QUEUED_JOB_NUMBER = 123456
   def JOB_NAME = "job/name/can/have/slashes"
+  def SIMPLE_JOB_NAME = "simpleJobName"
   def PENDING_JOB_NAME = "pendingjob"
   def FILE_NAME = "test.yml"
 
@@ -107,7 +108,7 @@ class BuildControllerSpec extends Specification {
     server = new MockWebServer()
     pendingOperationService = Mock(PendingOperationsCache)
     pendingOperationService.getAndSetOperationStatus(_, _, _) >> {
-        return new PendingOperationsCache.OperationState()
+      return new PendingOperationsCache.OperationState()
     }
 
     mockMvc = MockMvcBuilders
@@ -410,7 +411,7 @@ class BuildControllerSpec extends Specification {
     MockHttpServletResponse response = mockMvc.perform(
       patch("/masters/${JENKINS_SERVICE}/jobs/${jobName}/update/${BUILD_NUMBER}")
         .contentType(MediaType.APPLICATION_JSON)
-      .content("""
+        .content("""
 {
   "description": "this is my new description"
 }
@@ -428,4 +429,34 @@ class BuildControllerSpec extends Specification {
       "simpleJobName"
     ]
   }
+
+  void "stop a jenkins job with simple name"() {
+
+    when:
+    MockHttpServletResponse response = mockMvc.perform(
+      put("/masters/{master}/jobs/{jobNamePath}/stop/{queue_build}/{build_number}", JENKINS_SERVICE, SIMPLE_JOB_NAME, QUEUED_JOB_NUMBER, BUILD_NUMBER)
+    ).andReturn().response
+
+    then:
+    1 * jenkinsService.stopRunningBuild(SIMPLE_JOB_NAME, BUILD_NUMBER)
+    response.status == 200
+    response.contentAsString == 'true'
+
+  }
+
+  void "stop a jenkins job with name containing slashes"() {
+
+    when:
+    MockHttpServletResponse response = mockMvc.perform(
+      put("/masters/{master}/jobs/stop/{queue_build}/{build_number}", JENKINS_SERVICE, QUEUED_JOB_NUMBER, BUILD_NUMBER)
+      .param('jobName', JOB_NAME)
+    ).andReturn().response
+
+    then:
+    1 * jenkinsService.stopRunningBuild(JOB_NAME, BUILD_NUMBER)
+    response.status == 200
+    response.contentAsString == 'true'
+
+  }
+
 }


### PR DESCRIPTION
When defining a Jenkins job inside folders, the name contains slashes. Because of that, instead of matching the request to the IGOR STOP endpoint (`/masters/{name}/jobs/{jobName}/stop/{queuedBuild}/{buildNumber}`), Spring is matching the request to the BUILD one (`/masters/{name}/jobs/**`) because it accepts anything after the last slash.

I have tried to avoid adding a new endpoint by modifying the existing one to accept anything between `jobs` and `stop` (e.g. `/masters/{name}/jobs/**/stop/{queuedBuild}/{buildNumber}`)and parse the job name manually, but it is still matching the other endpoint. 

Related Orca PR: https://github.com/spinnaker/orca/pull/4294
