### PR TITLE
fix(monitor): rename parameter to let spring know what bean inject

### DIFF
--- a/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
+++ b/igor-monitor-artifactory/src/main/java/com/netflix/spinnaker/igor/artifactory/ArtifactoryBuildMonitor.java
@@ -76,14 +76,14 @@ public class ArtifactoryBuildMonitor
       Optional<EchoService> echoService,
       ArtifactoryCache cache,
       ArtifactoryProperties artifactoryProperties,
-      TaskScheduler scheduler) {
+      TaskScheduler taskScheduler) {
     super(
         properties,
         registry,
         dynamicConfigService,
         discoveryStatusListener,
         lockService,
-        scheduler);
+        taskScheduler);
     this.cache = cache;
     this.artifactoryProperties = artifactoryProperties;
     this.echoService = echoService;

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/PluginsBuildMonitor.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/PluginsBuildMonitor.java
@@ -55,14 +55,14 @@ public class PluginsBuildMonitor
       PluginReleaseService pluginInfoService,
       PluginCache cache,
       Optional<EchoService> echoService,
-      TaskScheduler scheduler) {
+      TaskScheduler taskScheduler) {
     super(
         igorProperties,
         registry,
         dynamicConfigService,
         discoveryStatusListener,
         lockService,
-        scheduler);
+        taskScheduler);
     this.pluginInfoService = pluginInfoService;
     this.cache = cache;
     this.echoService = echoService;

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -81,14 +81,14 @@ public class TravisBuildMonitor
       TravisProperties travisProperties,
       Optional<EchoService> echoService,
       Optional<LockService> lockService,
-      TaskScheduler scheduler) {
+      TaskScheduler taskScheduler) {
     super(
         properties,
         registry,
         dynamicConfigService,
         discoveryStatusListener,
         lockService,
-        scheduler);
+        taskScheduler);
     this.buildCache = buildCache;
     this.buildServices = buildServices;
     this.travisProperties = travisProperties;

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
@@ -81,7 +81,7 @@ public class PluginMonitorConfig {
       PluginReleaseService pluginReleaseService,
       PluginCache pluginCache,
       Optional<EchoService> echoService,
-      TaskScheduler scheduler) {
+      TaskScheduler taskScheduler) {
     return new PluginsBuildMonitor(
         properties,
         registry,
@@ -91,6 +91,6 @@ public class PluginMonitorConfig {
         pluginReleaseService,
         pluginCache,
         echoService,
-        scheduler);
+        taskScheduler);
   }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/docker/DockerMonitor.groovy
@@ -66,8 +66,8 @@ class DockerMonitor extends CommonPollingMonitor<ImageDelta, DockerPollingDelta>
                   Optional<EchoService> echoService,
                   Optional<KeelService> keelService,
                   DockerRegistryProperties dockerRegistryProperties,
-                  TaskScheduler scheduler) {
-        super(properties, registry, dynamicConfigService, discoveryStatusListener, lockService, scheduler)
+                  TaskScheduler taskScheduler) {
+        super(properties, registry, dynamicConfigService, discoveryStatusListener, lockService, taskScheduler)
         this.cache = cache
         this.dockerRegistryAccounts = dockerRegistryAccounts
         this.echoService = echoService

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
@@ -77,14 +77,14 @@ public class GitlabCiBuildMonitor
       BuildServices buildServices,
       GitlabCiProperties gitlabCiProperties,
       Optional<EchoService> echoService,
-      TaskScheduler scheduler) {
+      TaskScheduler taskScheduler) {
     super(
         properties,
         registry,
         dynamicConfigService,
         discoveryStatusListener,
         lockService,
-        scheduler);
+        taskScheduler);
     this.buildCache = buildCache;
     this.buildServices = buildServices;
     this.gitlabCiProperties = gitlabCiProperties;

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -71,8 +71,8 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
                         @Value('${jenkins.polling.enabled:true}') boolean pollingEnabled,
                         Optional<EchoService> echoService,
                         JenkinsProperties jenkinsProperties,
-                        TaskScheduler scheduler) {
-        super(properties, registry, dynamicConfigService, discoveryStatusListener, lockService, scheduler)
+                        TaskScheduler taskScheduler) {
+        super(properties, registry, dynamicConfigService, discoveryStatusListener, lockService, taskScheduler)
         this.cache = cache
         this.buildServices = buildServices
         this.pollingEnabled = pollingEnabled

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
@@ -73,8 +73,8 @@ class WerckerBuildMonitor extends CommonPollingMonitor<PipelineDelta, PipelinePo
       @Value('${wercker.polling.enabled:true}') boolean pollingEnabled,
       Optional<EchoService> echoService,
       WerckerProperties werckerProperties,
-      TaskScheduler scheduler) {
-        super(properties, registry, dynamicConfigService, discoveryStatusListener, lockService, scheduler)
+      TaskScheduler taskScheduler) {
+        super(properties, registry, dynamicConfigService, discoveryStatusListener, lockService, taskScheduler)
         this.cache = cache
         this.buildServices = buildServices
         this.pollingEnabled = pollingEnabled

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseBuildMonitor.java
@@ -70,14 +70,14 @@ public class ConcourseBuildMonitor
       BuildServices buildServices,
       ConcourseCache cache,
       ConcourseProperties concourseProperties,
-      TaskScheduler scheduler) {
+      TaskScheduler taskScheduler) {
     super(
         properties,
         registry,
         dynamicConfigService,
         discoveryStatusListener,
         lockService,
-        scheduler);
+        taskScheduler);
     this.buildServices = buildServices;
     this.cache = cache;
     this.concourseProperties = concourseProperties;

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/helm/HelmMonitor.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/helm/HelmMonitor.java
@@ -59,14 +59,14 @@ public class HelmMonitor
       HelmCache cache,
       HelmAccounts helmAccounts,
       Optional<EchoService> echoService,
-      TaskScheduler scheduler) {
+      TaskScheduler taskScheduler) {
     super(
         properties,
         registry,
         dynamicConfigService,
         discoveryStatusListener,
         lockService,
-        scheduler);
+        taskScheduler);
     this.cache = cache;
     this.helmAccounts = helmAccounts;
     this.echoService = echoService;


### PR DESCRIPTION
When there is more than one SpringAutoConfiguration class in the Spring context that defines a `TaskScheduler` bean, Igor fails on startup because Spring doesn't know which bean to use.

Example error message:

`***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 10 of constructor in com.netflix.spinnaker.igor.jenkins.JenkinsBuildMonitor required a single bean, but 2 were found:
	- taskScheduler: defined by method 'taskScheduler' in class path resource [org/springframework/boot/autoconfigure/task/TaskSchedulingAutoConfiguration.class]
	- vaultThreadPoolTaskScheduler: defined in null`
	
To avoid this problem we can give spring a clue on what bean has priority by include the beanName as the parameter name. In this way, we ensure that the bean injected in all Monitor classes would be the `TaskScheduler` from `TaskSchedulingAutoConfiguration`


