### PR TITLE
refactor(web): Clean up redundant spring property in gradle file

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -1,12 +1,4 @@
-ext {
-  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/".toString())
-}
-
 apply plugin: 'io.spinnaker.package'
-
-run {
-  systemProperty('spring.config.additional-location', project.springConfigLocation)
-}
 
 mainClassName = 'com.netflix.spinnaker.igor.Main'
 


### PR DESCRIPTION
The property spring.config.additional-location is redundant in igor-web.gradle file. This property is set by class com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder in com.netflix.spinnaker.igor.Main. So removing it from gradle file.
