### PR TITLE
chore(dependencies): remove dependency on groovy-all where straightforward

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
       implementation "net.logstash.logback:logstash-logback-encoder"
 
       // TODO(rz): Why does Spock need groovy as implementation and not testImplementation to find tests?
-      implementation "org.codehaus.groovy:groovy-all"
+      implementation "org.codehaus.groovy:groovy"
       testImplementation "org.springframework.boot:spring-boot-starter-test"
       testImplementation "org.spockframework:spock-core"
       testImplementation "org.spockframework:spock-spring"

--- a/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/RedisPluginCache.java
+++ b/igor-monitor-plugins/src/main/java/com/netflix/spinnaker/igor/plugins/RedisPluginCache.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
-import jline.internal.Nullable;
+import javax.annotation.Nullable;
 
 public class RedisPluginCache implements PluginCache {
 

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -38,7 +38,7 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest-core"
     testRuntimeOnly "cglib:cglib-nodep"
     testRuntimeOnly "org.objenesis:objenesis"
-    implementation "org.codehaus.groovy:groovy-all"
+    implementation "org.codehaus.groovy:groovy"
 
     implementation "com.fasterxml.jackson.core:jackson-annotations"
     implementation "com.fasterxml.jackson.core:jackson-core"
@@ -86,6 +86,7 @@ dependencies {
 
     testImplementation "com.squareup.okhttp:mockwebserver"
     testImplementation "io.spinnaker.kork:kork-jedis-test"
+    testImplementation "org.codehaus.groovy:groovy-all"
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.assertj:assertj-core"
 


### PR DESCRIPTION
with a specific goal to get `org.testng:testng:7.4.0` out of shipping code, since it's vulnerable to CVE-2022-4065.
