### PR TITLE
fix(gitlabci): Fixed JSON parsing exceptions for unknown GitlabCI pipeline statuses

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/PipelineStatus.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/model/PipelineStatus.java
@@ -15,11 +15,22 @@
  */
 package com.netflix.spinnaker.igor.gitlabci.client.model;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public enum PipelineStatus {
   running,
   pending,
   success,
   failed,
   canceled,
-  skipped
+  skipped,
+  created,
+  @JsonProperty("waiting_for_resource")
+  waitingForResource,
+  preparing,
+  manual,
+  scheduled,
+  @JsonEnumDefaultValue
+  unknown
 }


### PR DESCRIPTION
Fixes spinnaker/spinnaker#6754

Added all Gitlab API's documented pipeline statuses, and also added a special one `unknown` which will be the default for any others that are added in the future to avoid breaking the GitlabCiClient.