### PR TITLE
fix(travis): Enable legacy log fetching

### DIFF
--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
@@ -62,7 +62,12 @@ public class V3Log {
     }
     int numberOfParts = logParts.size() - 1;
     V3LogPart lastLogPart = logParts.get(numberOfParts);
-    return numberOfParts == lastLogPart.number && lastLogPart.isFinal();
+    String logContent = getContent();
+    return numberOfParts == lastLogPart.number
+        && lastLogPart.isFinal()
+        && (logContent != null
+            && (logContent.contains("Done. Your build exited with ")
+                || logContent.contains("travis_terminate")));
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisConfig.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisConfig.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.igor.service.ArtifactDecorator;
 import com.netflix.spinnaker.igor.service.BuildServices;
 import com.netflix.spinnaker.igor.travis.TravisCache;
 import com.netflix.spinnaker.igor.travis.client.TravisClient;
+import com.netflix.spinnaker.igor.travis.client.model.v3.Root;
 import com.netflix.spinnaker.igor.travis.service.TravisService;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import com.squareup.okhttp.OkHttpClient;
@@ -82,22 +83,23 @@ public class TravisConfig {
                               igorConfigurationProperties.getClient().getTimeout(),
                               objectMapper);
 
-                      // Disabling the use of the log_complete attribute for now. We suspect it can
-                      // cause some trouble.
                       boolean useLegacyLogFetching = true;
-                      //                      try {
-                      //                        Root root = client.getRoot();
-                      //                        useLegacyLogFetching =
-                      // !root.hasLogCompleteAttribute();
-                      //                        if (useLegacyLogFetching) {
-                      //                          log.info(
-                      //                              "It seems Travis Enterprise is older than
-                      // version 2.2.9. Will use legacy log fetching.");
-                      //                        }
-                      //                      } catch (Exception e) {
-                      //                        log.warn("Could not query Travis API to check API
-                      // compability", e);
-                      //                      }
+                      if (host.isUseLogComplete()) {
+                        try {
+                          Root root = client.getRoot();
+                          useLegacyLogFetching = !root.hasLogCompleteAttribute();
+                          if (useLegacyLogFetching) {
+                            log.info(
+                                "It seems Travis Enterprise is older than version 2.2.9. Will use legacy log fetching.");
+                          }
+                        } catch (Exception e) {
+                          log.warn(
+                              "Could not query Travis API to check API compatibility for log_complete. "
+                                  + "Will use legacy log fetching.",
+                              e);
+                        }
+                      }
+
                       return new TravisService(
                           travisName,
                           host.getBaseUrl(),

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisConfig.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisConfig.java
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.igor.service.ArtifactDecorator;
 import com.netflix.spinnaker.igor.service.BuildServices;
 import com.netflix.spinnaker.igor.travis.TravisCache;
 import com.netflix.spinnaker.igor.travis.client.TravisClient;
-import com.netflix.spinnaker.igor.travis.client.model.v3.Root;
 import com.netflix.spinnaker.igor.travis.service.TravisService;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import com.squareup.okhttp.OkHttpClient;
@@ -83,17 +82,22 @@ public class TravisConfig {
                               igorConfigurationProperties.getClient().getTimeout(),
                               objectMapper);
 
-                      boolean useLegacyLogFetching = false;
-                      try {
-                        Root root = client.getRoot();
-                        useLegacyLogFetching = !root.hasLogCompleteAttribute();
-                        if (useLegacyLogFetching) {
-                          log.info(
-                              "It seems Travis Enterprise is older than version 2.2.9. Will use legacy log fetching.");
-                        }
-                      } catch (Exception e) {
-                        log.warn("Could not query Travis API to check API compability", e);
-                      }
+                      // Disabling the use of the log_complete attribute for now. We suspect it can
+                      // cause some trouble.
+                      boolean useLegacyLogFetching = true;
+                      //                      try {
+                      //                        Root root = client.getRoot();
+                      //                        useLegacyLogFetching =
+                      // !root.hasLogCompleteAttribute();
+                      //                        if (useLegacyLogFetching) {
+                      //                          log.info(
+                      //                              "It seems Travis Enterprise is older than
+                      // version 2.2.9. Will use legacy log fetching.");
+                      //                        }
+                      //                      } catch (Exception e) {
+                      //                        log.warn("Could not query Travis API to check API
+                      // compability", e);
+                      //                      }
                       return new TravisService(
                           travisName,
                           host.getBaseUrl(),

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisProperties.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/config/TravisProperties.java
@@ -74,6 +74,14 @@ public class TravisProperties implements BuildServerProperties<TravisProperties.
 
     private Integer itemUpperThreshold;
     private Permissions.Builder permissions = new Permissions.Builder();
+    /**
+     * The Travis Builds and Jobs API supports an attribute called <code>log_complete</code> that is
+     * supposed to tell us if the log is ready to be downloaded. Igor has been using this attribute
+     * to cut down on the number of potentially expensive API calls needed towards Travis during
+     * polling. However, relying on <code>log_complete</code> has been unreliable for some Travis
+     * users, so we're disabling it by default.
+     */
+    private boolean useLogComplete = false;
 
     @Deprecated
     public void setNumberOfRepositories(int numberOfRepositories) {

--- a/igor-monitor-travis/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
+++ b/igor-monitor-travis/src/test/groovy/com/netflix/spinnaker/igor/travis/client/TravisClientSpec.groovy
@@ -121,7 +121,7 @@ class TravisClientSpec extends Specification {
                 "delete_log": false
             },
             "id": 1337,
-            "content": "ERROR: An error occured while trying to parse your .travis.yml file.\\n\\nPlease make sure that the file is valid YAML.\\n\\nhttp://lint.travis-ci.org can check your .travis.yml.\\n\\nThe error was \\"undefined method `merge' for false:FalseClass\\".",
+            "content": "ERROR: An error occured while trying to parse your .travis.yml file.\\n\\nPlease make sure that the file is valid YAML.\\n\\nhttp://lint.travis-ci.org can check your .travis.yml.\\n\\nThe error was \\"undefined method `merge' for false:FalseClass\\".\\n\\nDone. Your build exited with 1.",
             "log_parts": [
                 {
                     "content": "ERROR: An error occured while trying to parse your .travis.yml file.\\n\\nPlease make sure that the file is valid YAML.\\n\\n",
@@ -129,7 +129,7 @@ class TravisClientSpec extends Specification {
                     "number": 0
                 },
                 {
-                    "content": "http://lint.travis-ci.org can check your .travis.yml.\\n\\nThe error was \\"undefined method `merge' for false:FalseClass\\".",
+                    "content": "http://lint.travis-ci.org can check your .travis.yml.\\n\\nThe error was \\"undefined method `merge' for false:FalseClass\\".\\n\\nDone. Your build exited with 1.",
                     "final": true,
                     "number": 1
                 }


### PR DESCRIPTION
We've had lots of trouble with the `log_complete` feature Travis added a while back on our request. It was supposed to solve our issues with figuring out when logs are _actually_ available (which can be up to several minutes after the build is complete) - but basically it can't be trusted. We've seen cases where it turns to `true` even before the _build_ was completed (how can the logs be done then? 😆), and also in the opposite case, it can return `false` for a long time even though the logs _are_ in fact complete. So it's better to just fall back to the old way of checking log completion (**with some improvements***). We've been running this internally in Schibsted for several months, and have not seen any issues with log fetching during that time - a huge improvement from earlier!

\* The log complete check will now check that the log output contains one of two phrases that all Travis builds should always contain - either `Done. Your build exited with ` or `travis_terminate`.