### PR TITLE
feat(travis): Add redis TTL for queue keys

### DIFF
--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
@@ -36,6 +36,7 @@ public class TravisCache {
   private static final String QUEUE_TYPE = ID + ":queue";
   private static final String LOG_TYPE = ID + ":log";
   private static final int LOG_EXPIRE_SECONDS = 600;
+  private static final int QUEUE_EXPIRE_SECONDS = 3600;
 
   private final RedisClientDelegate redisClientDelegate;
   private final IgorConfigurationProperties igorConfigurationProperties;
@@ -71,6 +72,7 @@ public class TravisCache {
         c -> {
           c.hset(key, "requestId", Integer.toString(requestId));
           c.hset(key, "repositoryId", Integer.toString(repositoryId));
+          c.expire(key, QUEUE_EXPIRE_SECONDS);
         });
     return requestId;
   }


### PR DESCRIPTION
I noticed not all cached keys will be deleted by Igor, leading to a slow, but steady buildup of keys. Resolving by expiring them after 60 minutes. No need to make this user configurable.