### PR TITLE
fix(travis): Redis TTL is given in seconds, not minutes

### DIFF
--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/build/BuildCache.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/build/BuildCache.java
@@ -94,10 +94,10 @@ public class BuildCache {
         });
   }
 
-  public void setTTL(String key, int ttl) {
+  public void setTTL(String key, int ttlSeconds) {
     redisClientDelegate.withCommandsClient(
         c -> {
-          c.expire(key, ttl);
+          c.expire(key, ttlSeconds);
         });
   }
 
@@ -157,13 +157,13 @@ public class BuildCache {
     return builds;
   }
 
-  public void setTracking(String master, String job, int buildId, int ttl) {
+  public void setTracking(String master, String job, int buildId, int ttlSeconds) {
     String key = makeTrackKey(master, job, buildId);
     redisClientDelegate.withCommandsClient(
         c -> {
           c.set(key, "marked as running");
         });
-    setTTL(key, ttl);
+    setTTL(key, ttlSeconds);
   }
 
   public void deleteTracking(String master, String job, int buildId) {

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -68,7 +68,7 @@ public class TravisBuildMonitor
   private final TravisProperties travisProperties;
   private final Optional<EchoService> echoService;
 
-  public static final int TRACKING_TTL = (int) TimeUnit.HOURS.toMinutes(5);
+  public static final int TRACKING_TTL = (int) TimeUnit.HOURS.toSeconds(5);
 
   @Autowired
   public TravisBuildMonitor(

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -68,7 +68,7 @@ public class TravisBuildMonitor
   private final TravisProperties travisProperties;
   private final Optional<EchoService> echoService;
 
-  public static final int TRACKING_TTL = (int) TimeUnit.HOURS.toSeconds(5);
+  static final int TRACKING_TTL_SECS = (int) TimeUnit.HOURS.toSeconds(5);
 
   @Autowired
   public TravisBuildMonitor(
@@ -206,7 +206,7 @@ public class TravisBuildMonitor
       case created:
       case started:
         buildCache.setTracking(
-            master, build.getRepository().getSlug(), build.getId(), TRACKING_TTL);
+            master, build.getRepository().getSlug(), build.getId(), TRACKING_TTL_SECS);
         break;
       case passed:
         if (!travisService.isLogReady(build)) {

--- a/igor-monitor-travis/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
+++ b/igor-monitor-travis/src/test/groovy/com/netflix/spinnaker/igor/travis/TravisBuildMonitorSpec.groovy
@@ -227,7 +227,7 @@ class TravisBuildMonitorSpec extends Specification {
 
         then:
         2 * travisService.getLatestBuilds() >>> [ [ build ], [] ]
-        1 * buildCache.setTracking(MASTER, build.getRepository().getSlug(), 1337, TravisBuildMonitor.TRACKING_TTL)
+        1 * buildCache.setTracking(MASTER, build.getRepository().getSlug(), 1337, TravisBuildMonitor.TRACKING_TTL_SECS)
         2 * buildCache.getTrackedBuilds(MASTER) >> [ [ buildId: "1337" ] ]
         1 * travisService.getV3Build(1337) >> build
         2 * travisService.getGenericBuild(_, _) >> { V3Build b, boolean fetchLogs ->


### PR DESCRIPTION
This fixes a rare bug where some builds will "be lost" and not trigger any pipelines. Because we effectively set the TTL to 5 minutes instead of 5 hours, Spinnaker would quickly stop tracking builds. Usually this is no problem because they will be present in the builds returned from the Travis API, but if the `numberOfJobs` property is set too low or during periods with a lot of simultaneous builds, this could cause builds (especially long running ones) to be lost.