### PR TITLE
fix(docker): reverting default containers to java 11

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,6 +1,6 @@
 FROM alpine:3.16
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apk --no-cache add --update bash openjdk17-jre
+RUN apk --no-cache add --update bash openjdk11-jre
 RUN addgroup -S -g 10111 spinnaker
 RUN adduser -S -G spinnaker -u 10111 spinnaker
 COPY igor-web/build/install/igor /opt/igor

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install openjdk-17-jre-headless wget
+RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY igor-web/build/install/igor /opt/igor
 RUN mkdir -p /opt/igor/plugins && chown -R spinnaker:nogroup /opt/igor/plugins


### PR DESCRIPTION
Partially reverting https://github.com/spinnaker/igor/pull/1143

I tried to upgrade to Java 17 but it will need more time, and containers for Java 11 will not work

Fixes spinnaker/spinnaker#6879