### PR TITLE
fix(java17): remove long-deprecated import that doesn't work with JRE17

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/Main.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/Main.groovy
@@ -23,7 +23,6 @@ import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAuto
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
-import sun.net.InetAddressCachePolicy
 
 import java.security.Security
 
@@ -47,7 +46,6 @@ class Main extends SpringBootServletInitializer {
      * We often operate in an environment where we expect resolution of DNS names for remote dependencies to change
      * frequently, so it's best to tell the JVM to avoid caching DNS results internally.
      */
-    InetAddressCachePolicy.cachePolicy = InetAddressCachePolicy.NEVER
     Security.setProperty('networkaddress.cache.ttl', '0')
   }
 


### PR DESCRIPTION
`sun.net.*` is no longer accessible [as of JDK16](https://openjdk.org/jeps/396). Thankfully `    Security.setProperty('networkaddress.cache.ttl', '0')` seems to achieve the same goal as the removed code, so I'm not sure why they were both there in the first place.

Closes https://github.com/spinnaker/spinnaker/issues/6879.