### PR TITLE
chore(dependency): add testImplementation of groovy-json dependency while upgrading to groovy 3.x

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -92,6 +92,7 @@ dependencies {
     testImplementation "com.squareup.okhttp:mockwebserver"
     testImplementation "io.spinnaker.kork:kork-jedis-test"
     testImplementation "org.codehaus.groovy:groovy-datetime"
+    testImplementation "org.codehaus.groovy:groovy-json"
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.assertj:assertj-core"
 


### PR DESCRIPTION
While upgrading groovy from 2.5.15 to 3.0.10, encountered following error during igor-web:test :
```
> Task :igor-web:compileTestGroovy
startup failed:
/igor/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy: 32: unable to resolve class groovy.json.JsonSlurper
 @ line 32, column 1.
   import groovy.json.JsonSlurper
   ^
1 error
> Task :igor-web:compileTestGroovy FAILED
```
To resolve this issue added testImplementation of org.codehaus.groovy:groovy-json in igor-web.gradle.