### PR TITLE
fix(java17): resolve remaining access to private fields, run tests on JRE 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: |
+            17
+            11
           distribution: 'zulu'
           cache: 'gradle'
       - name: Prepare build variables

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: |
+            17
+            11
           distribution: 'zulu'
           cache: 'gradle'
       - name: Prepare build variables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: |
+            17
+            11
           distribution: 'zulu'
           cache: 'gradle'
       - name: Assemble release info

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,17 @@ subprojects {
       useJUnitPlatform()
     }
 
+    tasks.withType(JavaCompile).configureEach {
+      javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(11)
+      }
+    }
+    tasks.withType(Test).configureEach {
+      javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(17)
+      }
+    }
+
     tasks.withType(JavaExec) {
       if (System.getProperty('DEBUG', 'false') == 'true') {
         jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8188'

--- a/igor-monitor-travis/src/test/groovy/com/netflix/spinnaker/igor/travis/client/logparser/ArtifactParserTest.groovy
+++ b/igor-monitor-travis/src/test/groovy/com/netflix/spinnaker/igor/travis/client/logparser/ArtifactParserTest.groovy
@@ -44,7 +44,7 @@ class ArtifactParserTest extends Specification {
         then:
         artifacts.first().fileName == "some-package-1.2.3-4.noarch.rpm"
         artifacts.last().fileName == "another-package-4.3.2.deb"
-        artifacts.size == 2
+        artifacts.size() == 2
     }
 
     def "make sure we only have one unique entry for each artifact"() {
@@ -59,7 +59,7 @@ class ArtifactParserTest extends Specification {
 
         then:
         artifacts.first().fileName == "some-package-1.2.3-4.noarch.rpm"
-        artifacts.size == 1
+        artifacts.size() == 1
     }
 
     def "get multiple artifactory deb from log using default regexes"() {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerBuildMonitor.groovy
@@ -147,14 +147,14 @@ class WerckerBuildMonitor extends CommonPollingMonitor<PipelineDelta, PipelinePo
 
             Long cursor = cache.getLastPollCycleTimestamp(master, pipeline)
             //The last build/run
-            Long lastBuildStamp = lastStartedAt.startedAt.fastTime
+            Long lastBuildStamp = lastStartedAt.startedAt.getTime()
             Date upperBound     = lastStartedAt.startedAt
             if (cursor == lastBuildStamp) {
                 log.debug("[${master}:${pipeline}] is up to date. skipping")
                 return
             }
             cache.updateBuildNumbers(master, pipeline, allRuns)
-            List<Run> allBuilds = allRuns.findAll { it?.startedAt?.fastTime > cursor }
+            List<Run> allBuilds = allRuns.findAll { it?.startedAt?.getTime() > cursor }
             if (!cursor && !igorProperties.spinnaker.build.handleFirstBuilds) {
                 cache.setLastPollCycleTimestamp(master, pipeline, lastBuildStamp)
                 return
@@ -203,7 +203,7 @@ class WerckerBuildMonitor extends CommonPollingMonitor<PipelineDelta, PipelinePo
                 building: (run.finishedAt == null),
                 result: res,
                 number: cache.getBuildNumber(master, pipeline, run.id),
-                timestamp: run.startedAt.fastTime as String,
+                timestamp: run.startedAt.getTime() as String,
                 id: run.id,
                 url: run.url
                 )

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/InfoControllerSpec.groovy
@@ -126,7 +126,7 @@ class InfoControllerSpec extends Specification {
 
       then:
       def actualAccounts = new JsonSlurper().parseText(response.contentAsString);
-      actualAccounts.size == 1
+      actualAccounts.size() == 1
       actualAccounts[0].permissions == [:]
 
     }
@@ -142,7 +142,7 @@ class InfoControllerSpec extends Specification {
 
       then:
       def actualAccounts = new JsonSlurper().parseText(response.contentAsString);
-      actualAccounts.size == 1
+      actualAccounts.size() == 1
       actualAccounts[0].name == 'master2'
 
     }

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/concourse/service/ConcourseServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/concourse/service/ConcourseServiceSpec.groovy
@@ -130,7 +130,7 @@ class ConcourseServiceSpec extends Specification {
         List<Build> builds = service.getBuilds('myteam/mypipeline/myjob', 1421717251402)
 
         then:
-        builds.size == 3
+        builds.size() == 3
         builds[0].id == '49-id'
         builds[1].id == '48.1-id'
         builds[2].id == '47-id'

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/bitbucket/CommitControllerSpec.groovy
@@ -98,7 +98,7 @@ class CommitControllerSpec extends Specification {
     List commitsResponse = controller.compareCommits(projectKey, repositorySlug, controllerParams)
 
     then:
-    commitsResponse.size == 2
+    commitsResponse.size() == 2
 
     with(commitsResponse[0]) {
       displayId == "1234512"

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/github/CommitControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/github/CommitControllerSpec.groovy
@@ -91,7 +91,7 @@ class CommitControllerSpec extends Specification {
         List commitsResponse = controller.compareCommits(projectKey, repositorySlug, ['to': toCommit, 'from': fromCommit])
 
         then:
-        commitsResponse.size == 2
+        commitsResponse.size() == 2
 
         with(commitsResponse[0]) {
             displayId == "12345123"

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/gitlab/CommitControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/gitlab/CommitControllerSpec.groovy
@@ -94,7 +94,7 @@ class CommitControllerSpec extends Specification {
         List commitsResponse = controller.compareCommits(projectKey, repositorySlug, ['to': toCommit, 'from': fromCommit])
 
         then:
-        commitsResponse.size == 2
+        commitsResponse.size() == 2
 
         with(commitsResponse[0]) {
             displayId == "12345123"

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/CommitControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/scm/stash/CommitControllerSpec.groovy
@@ -87,7 +87,7 @@ class CommitControllerSpec extends Specification {
         List commitsResponse = controller.compareCommits(projectKey, repositorySlug, ['to': toCommit, 'from': fromCommit])
 
         then:
-        commitsResponse.size == 2
+        commitsResponse.size() == 2
         commitsResponse[0].displayId == "12345"
         commitsResponse[0].id == "1234512345123451234512345"
         commitsResponse[0].authorDisplayName == "Joe Coder"

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerServiceSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerServiceSpec.groovy
@@ -45,7 +45,7 @@ class WerckerServiceSpec extends Specification {
         ]
 
         expect:
-        service.jobs.size == 3
+        service.jobs.size() == 3
         service.jobs.contains('x/foo/myApp2/myPipeX')
     }
 


### PR DESCRIPTION
`fastTime` and `size` are no longer accessible fields. Replace with `getTime()` and `size()` respectively. IntelliJ shows no remaining access related issues (not to say there aren't more hiding).

Additionally, run tests using JRE 17 to catch this stuff earlier.

Note: this does **not** resolve the issue reported relating to `Instant.seconds` - further PR to come in Kork for that one.