### PR TITLE
fix(java17): add Jackson converter to RestAdapters to avoid Gson

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/EchoConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/EchoConfig.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.igor.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
@@ -28,6 +29,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import retrofit.Endpoints
 import retrofit.RestAdapter
+import retrofit.converter.JacksonConverter
 
 /**
  * history service configuration
@@ -36,9 +38,12 @@ import retrofit.RestAdapter
 @Configuration
 class EchoConfig {
     @Bean
-    EchoService echoService(OkHttpClientProvider okHttpClientProvider,
-                            IgorConfigurationProperties igorConfigurationProperties,
-                            RestAdapter.LogLevel retrofitLogLevel) {
+    EchoService echoService(
+      OkHttpClientProvider okHttpClientProvider,
+      IgorConfigurationProperties igorConfigurationProperties,
+      RestAdapter.LogLevel retrofitLogLevel,
+      ObjectMapper objectMapper
+    ) {
         String address = igorConfigurationProperties.services.echo.baseUrl ?: 'none'
 
         if (address == 'none') {
@@ -48,6 +53,7 @@ class EchoConfig {
         new RestAdapter.Builder()
             .setEndpoint(Endpoints.newFixedEndpoint(address))
             .setClient(new Ok3Client(okHttpClientProvider.getClient(new DefaultServiceEndpoint("echo", address))))
+            .setConverter(new JacksonConverter(objectMapper))
             .setLogLevel(retrofitLogLevel)
             .setLog(new Slf4jRetrofitLogger(EchoService))
             .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.spinnaker.igor.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jakewharton.retrofit.Ok3Client;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.DefaultServiceEndpoint;
@@ -40,6 +41,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
 import retrofit.Endpoints;
 import retrofit.RestAdapter;
+import retrofit.converter.JacksonConverter;
 
 @Configuration
 @ConditionalOnProperty("services.front50.base-url")
@@ -55,7 +57,8 @@ public class PluginMonitorConfig {
   public PluginReleaseService pluginReleaseService(
       OkHttpClientProvider clientProvider,
       IgorConfigurationProperties properties,
-      RestAdapter.LogLevel retrofitLogLevel) {
+      RestAdapter.LogLevel retrofitLogLevel,
+      ObjectMapper objectMapper) {
     String address = properties.getServices().getFront50().getBaseUrl();
 
     Front50Service front50Service =
@@ -66,6 +69,7 @@ public class PluginMonitorConfig {
                     clientProvider.getClient(new DefaultServiceEndpoint("front50", address))))
             .setLogLevel(retrofitLogLevel)
             .setLog(new Slf4jRetrofitLogger(Front50Service.class))
+            .setConverter(new JacksonConverter(objectMapper))
             .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
             .build()
             .create(Front50Service.class);

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerClientSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/wercker/WerckerClientSpec.groovy
@@ -9,6 +9,8 @@
  */
 package com.netflix.spinnaker.igor.wercker
 
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.config.okhttp3.InsecureOkHttpClientBuilderProvider
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.igor.config.*
@@ -29,8 +31,13 @@ class WerckerClientSpec extends Specification {
     @Shared
     MockWebServer server
 
+    @Shared
+    ObjectMapper objectMapper
+
     void setup() {
         server = new MockWebServer()
+        objectMapper = new ObjectMapper()
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
     }
 
     void cleanup() {
@@ -101,7 +108,7 @@ class WerckerClientSpec extends Specification {
                 )
         server.start()
         def host = new WerckerHost(name: 'werckerMaster', address: server.url('/').toString())
-        client = new WerckerConfig().werckerClient(host, 30000, new OkHttpClientProvider([new InsecureOkHttpClientBuilderProvider(new OkHttpClient())]), RestAdapter.LogLevel.BASIC)
+        client = new WerckerConfig().werckerClient(host, 30000, new OkHttpClientProvider([new InsecureOkHttpClientBuilderProvider(new OkHttpClient())]), RestAdapter.LogLevel.BASIC, objectMapper)
     }
 
     String read(String fileName) {


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/6881

If no converter is set for a RestAdapter it defaults to Gson, which uses reflection to set fields. JRE 17 says no bueno to that on classes like `Instant` that are now making fields inaccessible.