### PR TITLE
fix(jenkins): replacing retrofit error 

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation "org.codehaus.groovy:groovy"
 
     implementation "com.fasterxml.jackson.core:jackson-annotations"
+    implementation 'com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.1'
     implementation "com.fasterxml.jackson.core:jackson-core"
     implementation "com.fasterxml.jackson.core:jackson-databind"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitor.groovy
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.igor.polling.PollingDelta
 import com.netflix.spinnaker.igor.service.BuildServices
 import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.time.TimeCategory
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,7 +43,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.stereotype.Service
-import retrofit.RetrofitError
 import java.util.stream.Collectors
 
 import static net.logstash.logback.argument.StructuredArguments.kv
@@ -157,9 +157,8 @@ class JenkinsBuildMonitor extends CommonPollingMonitor<JobDelta, JobPollingDelta
 
         } catch (e) {
             log.error("Error processing builds for [{}:{}]", kv("master", master), kv("job", job.name), e)
-            if (e.cause instanceof RetrofitError) {
-                def re = (RetrofitError) e.cause
-                log.error("Error communicating with jenkins for [{}:{}]: {}", kv("master", master), kv("job", job.name), kv("url", re.url), re)
+            if (e instanceof SpinnakerServerException) {
+                log.error("Error communicating with jenkins for [{}:{}]: {}", kv("master", master), kv("job", job.name), kv("url", e.url), e)
             }
         }
     }


### PR DESCRIPTION
igor relies on the SpinnakerRetrofitHandler and it looks like this one
got missed, which would cause the `getBuilds` method to fail if an
exception occurred rather than happily carrying on.