### PR TITLE
feat(java17): compile with JDK17 targeting Java 11 bytecode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: |
-            17
             11
+            17
           distribution: 'zulu'
           cache: 'gradle'
       - name: Prepare build variables
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}
-        run: ./gradlew build --stacktrace ${{ steps.build_variables.outputs.REPO }}-web:installDist
+        run: ./gradlew -PenableCrossCompilerPlugin=true build --stacktrace ${{ steps.build_variables.outputs.REPO }}-web:installDist
       - name: Login to GAR
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: |
-            17
             11
+            17
           distribution: 'zulu'
           cache: 'gradle'
       - name: Prepare build variables
@@ -32,7 +32,7 @@ jobs:
       - name: Build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}
-        run: ./gradlew build ${{ steps.build_variables.outputs.REPO }}-web:installDist
+        run: ./gradlew -PenableCrossCompilerPlugin=true build ${{ steps.build_variables.outputs.REPO }}-web:installDist
       - name: Build slim container image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: |
-            17
             11
+            17
           distribution: 'zulu'
           cache: 'gradle'
       - name: Assemble release info
@@ -52,14 +52,14 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPgpSigningKey: ${{ secrets.NEXUS_PGP_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_nexusPgpSigningPassword: ${{ secrets.NEXUS_PGP_SIGNING_PASSWORD }}
         run: |
-          ./gradlew --info build ${{ steps.build_variables.outputs.REPO }}-web:installDist publishToNexus closeAndReleaseNexusStagingRepository
+          ./gradlew --info -PenableCrossCompilerPlugin=true build ${{ steps.build_variables.outputs.REPO }}-web:installDist publishToNexus closeAndReleaseNexusStagingRepository
       - name: Publish apt packages to Google Artifact Registry
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}
           ORG_GRADLE_PROJECT_artifactRegistryPublishEnabled: true
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
-          ./gradlew --info publish
+          ./gradlew --info -PenableCrossCompilerPlugin=true publish
       - name: Login to Google Cloud
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -5,4 +5,4 @@ RUN apt-get update && apt-get install -y \
 LABEL maintainer="sig-platform@spinnaker.io"
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS -Xmx4g
-CMD ./gradlew --no-daemon igor-web:installDist -x test
+CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true igor-web:installDist -x test

--- a/build.gradle
+++ b/build.gradle
@@ -73,17 +73,6 @@ subprojects {
       useJUnitPlatform()
     }
 
-    tasks.withType(JavaCompile).configureEach {
-      javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(11)
-      }
-    }
-    tasks.withType(Test).configureEach {
-      javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(17)
-      }
-    }
-
     tasks.withType(JavaExec) {
       if (System.getProperty('DEBUG', 'false') == 'true') {
         jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8188'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ fiatVersion=1.42.0
 korkVersion=7.205.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.31.0
-targetJava11=true
+targetJava17=false
 
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.


### PR DESCRIPTION
## DO NOT MERGE PRE-1.33

- Swap the `setup-java` versions around so that 17 comes first on the PATH.
- Update build commands to enable cross compilation plugin.

Build should pass once https://github.com/spinnaker/spinnaker-gradle-project/pull/203 and https://github.com/spinnaker/spinnaker-gradle-project/pull/204 are both merged.

Confirmed it's working with `targetJava17=false`:

```
javap -v igor-web/build/classes/groovy/main/com/netflix/spinnaker/igor/Main | grep major
Warning: File ./igor-web/build/classes/groovy/main/com/netflix/spinnaker/igor/Main.class does not contain class igor-web/build/classes/groovy/main/com/netflix/spinnaker/igor/Main
  major version: 55
```

and `true`:

```
javap -v igor-web/build/classes/groovy/main/com/netflix/spinnaker/igor/Main | grep major
Warning: File ./igor-web/build/classes/groovy/main/com/netflix/spinnaker/igor/Main.class does not contain class igor-web/build/classes/groovy/main/com/netflix/spinnaker/igor/Main
  major version: 61
```