### PR TITLE
chore(dependency): add explicit dependency of jaxb-api while upgrading spring boot 2.6.x

### DIFF
--- a/igor-monitor-travis/igor-monitor-travis.gradle
+++ b/igor-monitor-travis/igor-monitor-travis.gradle
@@ -32,6 +32,7 @@ dependencies {
   implementation "com.squareup.retrofit:retrofit"
   implementation "io.reactivex:rxjava" // TODO(jervi): get rid of this dependency
   implementation "javax.validation:validation-api"
+  implementation "javax.xml.bind:jaxb-api"
 
   testImplementation "com.squareup.okhttp:mockwebserver"
 }


### PR DESCRIPTION
While upgrading spring boot 2.6.15, encounter below errors in igor-monitor-travis module during build:
```
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.java:26: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.java:38: error: cannot find symbol
@XmlRootElement(name = "builds")
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Branch.java:22: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Branch.java:30: error: cannot find symbol
@XmlRootElement(name = "branch")
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Commit.java:26: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Commit.java:34: error: cannot find symbol
@XmlRootElement(name = "commit")
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Repository.java:21: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Repository.java:26: error: cannot find symbol
@XmlRootElement(name = "repository")
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/AccessToken.java:22: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/AccessToken.java:27: error: cannot find symbol
@XmlRootElement
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Builds.java:23: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Builds.java:24: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Builds.java:29: error: cannot find symbol
@XmlRootElement
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Build.java:27: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Build.java:33: error: cannot find symbol
@XmlRootElement(name = "builds")
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Builds.java:24: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Builds.java:25: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Builds.java:31: error: cannot find symbol
@XmlRootElement
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Job.java:23: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Job.java:29: error: cannot find symbol
@XmlRootElement(name = "job")
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Commit.java:24: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Commit.java:30: error: cannot find symbol
@XmlRootElement(name = "commits")
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/EmptyObject.java:20: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/EmptyObject.java:22: error: cannot find symbol
@XmlRootElement
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Jobs.java:24: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Jobs.java:25: error: package javax.xml.bind.annotation does not exist
import javax.xml.bind.annotation.XmlRootElement;
                                ^
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Jobs.java:31: error: cannot find symbol
@XmlRootElement
 ^
  symbol: class XmlRootElement
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Builds.java:35: error: cannot find symbol
  @XmlElement(name = "builds", required = false)
   ^
  symbol:   class XmlElement
  location: class V3Builds
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Builds.java:33: error: cannot find symbol
  @XmlElement(name = "builds", required = false)
   ^
  symbol:   class XmlElement
  location: class Builds
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Builds.java:37: error: cannot find symbol
  @XmlElement(name = "jobs", required = false)
   ^
  symbol:   class XmlElement
  location: class Builds
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/Builds.java:41: error: cannot find symbol
  @XmlElement(name = "commits", required = false)
   ^
  symbol:   class XmlElement
  location: class Builds
/igor/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Jobs.java:35: error: cannot find symbol
  @XmlElement(name = "jobs", required = false)
   ^
  symbol:   class XmlElement
  location: class V3Jobs
32 errors
startup failed:
Compilation failed; see the compiler error output for details.

1 error

> Task :igor-monitor-travis:compileGroovy FAILED
```

To fix these issues, adding explicit dependency of jaxb-api in igor-monitor-travis.gradle. Since jaxb-api is a transitive dependency of [spring boot](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.15/spring-boot-dependencies-2.6.15.pom) both 2.5.x and 2.6.x, pinning the dependency is not required.