### PR TITLE
chore(dependency): add explicit dependency of jackson-module-jaxb-annotations while upgrading spring boot 2.6.x

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+    implementation "com.fasterxml.jackson.module:jackson-module-jaxb-annotations"
 
     implementation "com.squareup.retrofit:retrofit"
     implementation "com.squareup.retrofit:converter-jackson"


### PR DESCRIPTION
While upgrading spring boot 2.6.15, encounter below errors in igor-web module during build:
```
> Task :igor-web:compileGroovy

startup failed:
/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsConfig.groovy: 22: unable to resolve class com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule
 @ line 22, column 1.
   import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule
   ^

1 error

> Task :igor-web:compileGroovy FAILED
```

To fix this issue, adding explicit dependency of jackson-module-jaxb-annotations in igor-web.gradle. Since jackson-module-jaxb-annotations is a transitive dependency of [spring boot](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.15/spring-boot-dependencies-2.6.15.pom) both 2.5.x and 2.6.x, pinning the dependency is not required.
