### PR TITLE
refactor(web/test): replace deprecated mockito api verifyZeroInteractions() with verifyNoMoreInteractions() during upgrade to spring boot 2.6.x

### DIFF
--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.igor.nexus;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.netflix.spinnaker.igor.config.NexusProperties;
 import com.netflix.spinnaker.igor.history.EchoService;
@@ -116,7 +116,7 @@ class NexusEventPosterTest {
 
     nexusEventPoster.postEvent(payload);
 
-    verifyZeroInteractions(echoService);
+    verifyNoMoreInteractions(echoService);
   }
 
   @Test
@@ -126,7 +126,7 @@ class NexusEventPosterTest {
 
     nexusEventPoster.postEvent(payload);
 
-    verifyZeroInteractions(echoService);
+    verifyNoMoreInteractions(echoService);
   }
 
   @Test
@@ -136,7 +136,7 @@ class NexusEventPosterTest {
 
     nexusEventPoster.postEvent(payload);
 
-    verifyZeroInteractions(echoService);
+    verifyNoMoreInteractions(echoService);
   }
 
   @Test


### PR DESCRIPTION
While upgrading spring boot 2.6.15, encounter below errors in igor-web module during test compilation:
```
> Task :igor-web:compileTestJava FAILED
/igor/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java:21: error: cannot find symbol
import static org.mockito.Mockito.verifyZeroInteractions;
^
  symbol:   static verifyZeroInteractions
  location: class Mockito
/igor/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java:119: error: cannot find symbol
    verifyZeroInteractions(echoService);
    ^
  symbol:   method verifyZeroInteractions(EchoService)
  location: class NexusEventPosterTest
/igor/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java:129: error: cannot find symbol
    verifyZeroInteractions(echoService);
    ^
  symbol:   method verifyZeroInteractions(EchoService)
  location: class NexusEventPosterTest
/igor/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java:139: error: cannot find symbol
    verifyZeroInteractions(echoService);
    ^
  symbol:   method verifyZeroInteractions(EchoService)
  location: class NexusEventPosterTest
4 errors
```
Spring boot [2.6.15](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.15/spring-boot-dependencies-2.6.15.pom) brings mockito 4.0.0 as transitive dependency. The `verifyZeroInteractions()` was deprecated in 3.x as mentioned here: https://github.com/mockito/mockito-kotlin/issues/383 And now it is removed from mockito 4.0.0.
To fix these issues, replacing `verifyZeroInteractions()` with `verifyNoMoreInteractions()`

