### PR TITLE
fix(jenkins): Enable properties and artifacts with job name as query parameter

### DIFF
--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -238,6 +238,21 @@ class BuildControllerSpec extends Specification {
       .andReturn().response
   }
 
+  void 'get properties of a build with job Name in query parameters' () {
+    given:
+    1 * jenkinsService.getGenericBuild(JOB_NAME, BUILD_NUMBER) >> genericBuild
+    1 * jenkinsService.getBuildProperties(JOB_NAME, genericBuild, FILE_NAME) >> ['foo': 'bar']
+
+    when:
+    MockHttpServletResponse response = mockMvc.perform(
+      get("/builds/properties/${BUILD_NUMBER}/${FILE_NAME}/${JENKINS_SERVICE}")
+        .param("job", JOB_NAME)
+        .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+    then:
+    response.contentAsString == "{\"foo\":\"bar\"}"
+  }
+
   void 'get properties of a travis build'() {
     given:
     1 * travisService.getGenericBuild(JOB_NAME, BUILD_NUMBER) >> genericBuild


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/6928

The implementation of: 
```
        feature:
          igor:
            jobNameAsQueryParameter: true
```
did not include the support  for Jenkins artifacts and property files leading to failures on Manual triggers and rerun's of a Spinnaker pipeline retrieving BuildInfo from the sub-folder Jenkins job.
