### PR TITLE
chore(dependencies): remove org.springframework.boot:spring-boot-properties-migrator

### DIFF
--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -22,7 +22,6 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok"
     implementation "io.spinnaker.kork:kork-retrofit"
 
-    runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation "org.springframework.boot:spring-boot-starter-web"
 


### PR DESCRIPTION
since it's meant for migration only

See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#configuration-properties for background.
