### PR TITLE
fix(travis): Properly return API triggered builds

### DIFF
--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisService.java
@@ -266,7 +266,7 @@ public class TravisService implements BuildOperations, BuildProperties {
                 getAccessToken(),
                 repoSlug,
                 branch,
-                "push",
+                "push,api",
                 buildResultLimit,
                 addLogCompleteIfApplicable());
         break;

--- a/igor-monitor-travis/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
+++ b/igor-monitor-travis/src/test/groovy/com/netflix/spinnaker/igor/travis/service/TravisServiceSpec.groovy
@@ -351,10 +351,10 @@ class TravisServiceSpec extends Specification {
         service.accessToken = accessToken
 
         when:
-        def genericBuilds = service.getBuilds("my/slug")
+        def genericBuilds = service.getBuilds("my/slug/master")
 
         then:
-        1 * client.v3builds("token someToken", "my/slug", TRAVIS_BUILD_RESULT_LIMIT,
+        1 * client.v3builds("token someToken", "my/slug", "master", "push,api", TRAVIS_BUILD_RESULT_LIMIT,
             legacyLogFetching ? null : "build.log_complete") >> new V3Builds([builds: [build]])
         (isLogCompleteFlag ? 0 : 1) * travisCache.getJobLog("travis-ci", 2) >> (isLogCached ? "log" : null)
         (!isLogCompleteFlag && !isLogCached ? 1 : 0) * client.jobLog("token someToken", 2) >> v3log


### PR DESCRIPTION
When populating the build dropdown for manual executions, manually triggered builds are missing for Travis Enterprise version 3.0.54 and newer. Before these builds had the same `event_type=push` as other builds, but now they have `event_type=api`. Adding `api` to the filtering fixes the issue.