### PR TITLE
refactor(dependency): replace groovy coordinates during upgrade of groovy 4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
       implementation "net.logstash.logback:logstash-logback-encoder"
 
       // TODO(rz): Why does Spock need groovy as implementation and not testImplementation to find tests?
-      implementation "org.codehaus.groovy:groovy"
+      implementation "org.apache.groovy:groovy"
       testImplementation "org.springframework.boot:spring-boot-starter-test"
       testImplementation "org.spockframework:spock-core"
       testImplementation "org.spockframework:spock-spring"

--- a/igor-monitor-artifactory/igor-monitor-artifactory.gradle
+++ b/igor-monitor-artifactory/igor-monitor-artifactory.gradle
@@ -23,7 +23,10 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
 
-  implementation "org.jfrog.artifactory.client:artifactory-java-client-services:2.9.2"
+  implementation("org.jfrog.artifactory.client:artifactory-java-client-services:2.9.2") {
+    exclude group: "org.codehaus.groovy", module: "*"
+  }
+  implementation "org.apache.groovy:groovy"
 
   // TODO(rz): Get rid of this dependency!
   implementation "io.spinnaker.kork:kork-jedis"

--- a/igor-web/igor-web.gradle
+++ b/igor-web/igor-web.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest-core"
     testRuntimeOnly "cglib:cglib-nodep"
     testRuntimeOnly "org.objenesis:objenesis"
-    implementation "org.codehaus.groovy:groovy"
+    implementation "org.apache.groovy:groovy"
 
     implementation "com.fasterxml.jackson.core:jackson-annotations"
     implementation "com.fasterxml.jackson.core:jackson-core"
@@ -81,8 +81,8 @@ dependencies {
 
     testImplementation "com.squareup.okhttp:mockwebserver"
     testImplementation "io.spinnaker.kork:kork-jedis-test"
-    testImplementation "org.codehaus.groovy:groovy-datetime"
-    testImplementation "org.codehaus.groovy:groovy-json"
+    testImplementation "org.apache.groovy:groovy-datetime"
+    testImplementation "org.apache.groovy:groovy-json"
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.assertj:assertj-core"
 


### PR DESCRIPTION
Replacing the groovy coordinates from `org.codehaus.groovy` to `org.apache.groovy` supported by groovy 4.x and above versions. Excluding the transitive groovy dependency from `org.jfrog.artifactory.client:artifactory-java-client-services:2.9.2`, and explictly adding the new coordinates of groovy to igor-monitor-artifactory module.