### PR TITLE
fix(jenkins): Use Long values rather than Ints for buildNumbers and Queue numbers

### DIFF
--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/build/BuildCache.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/build/BuildCache.java
@@ -71,14 +71,14 @@ public class BuildCache {
     return results;
   }
 
-  public int getLastBuild(String master, String job, boolean running) {
+  public long getLastBuild(String master, String job, boolean running) {
     String key = makeKey(master, job, running);
     return redisClientDelegate.withCommandsClient(
         c -> {
           if (!c.exists(key)) {
-            return -1;
+            return -1l;
           }
-          return Integer.parseInt(c.get(key));
+          return Long.parseLong(c.get(key));
         });
   }
 
@@ -101,7 +101,7 @@ public class BuildCache {
         });
   }
 
-  public void setLastBuild(String master, String job, int lastBuild, boolean building, int ttl) {
+  public void setLastBuild(String master, String job, long lastBuild, boolean building, int ttl) {
     if (!building) {
       setBuild(makeKey(master, job), lastBuild, false, master, job, ttl);
     }
@@ -138,7 +138,7 @@ public class BuildCache {
     }
 
     Map<String, Object> converted = new HashMap<>();
-    converted.put("lastBuildLabel", Integer.parseInt(result.get("lastBuildLabel")));
+    converted.put("lastBuildLabel", Long.parseLong(result.get("lastBuildLabel")));
     converted.put("lastBuildBuilding", Boolean.valueOf(result.get("lastBuildBuilding")));
 
     return converted;
@@ -157,7 +157,7 @@ public class BuildCache {
     return builds;
   }
 
-  public void setTracking(String master, String job, int buildId, int ttlSeconds) {
+  public void setTracking(String master, String job, long buildId, int ttlSeconds) {
     String key = makeTrackKey(master, job, buildId);
     redisClientDelegate.withCommandsClient(
         c -> {
@@ -166,7 +166,7 @@ public class BuildCache {
     setTTL(key, ttlSeconds);
   }
 
-  public void deleteTracking(String master, String job, int buildId) {
+  public void deleteTracking(String master, String job, long buildId) {
     String key = makeTrackKey(master, job, buildId);
     redisClientDelegate.withCommandsClient(
         c -> {
@@ -182,19 +182,19 @@ public class BuildCache {
   }
 
   private void setBuild(
-      String key, int lastBuild, boolean building, String master, String job, int ttl) {
+      String key, long lastBuild, boolean building, String master, String job, int ttl) {
     redisClientDelegate.withCommandsClient(
         c -> {
-          c.hset(key, "lastBuildLabel", Integer.toString(lastBuild));
+          c.hset(key, "lastBuildLabel", Long.toString(lastBuild));
           c.hset(key, "lastBuildBuilding", Boolean.toString(building));
         });
     setTTL(key, ttl);
   }
 
-  private void storeLastBuild(String key, int lastBuild, int ttl) {
+  private void storeLastBuild(String key, long lastBuild, int ttl) {
     redisClientDelegate.withCommandsClient(
         c -> {
-          c.set(key, Integer.toString(lastBuild));
+          c.set(key, Long.toString(lastBuild));
         });
     setTTL(key, ttl);
   }
@@ -208,7 +208,7 @@ public class BuildCache {
     return baseKey() + ":" + buildState + ":" + master + ":" + job.toUpperCase() + ":" + job;
   }
 
-  protected String makeTrackKey(String master, String job, int buildId) {
+  protected String makeTrackKey(String master, String job, long buildId) {
     return baseKey() + ":track:" + master + ":" + job.toUpperCase() + ":" + job + ":" + buildId;
   }
 

--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/build/model/GenericBuild.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/build/model/GenericBuild.java
@@ -35,7 +35,7 @@ public class GenericBuild {
   private boolean building;
   private String fullDisplayName;
   private String name;
-  private int number;
+  private long number;
   private Integer duration;
   /** String representation of time in nanoseconds since Unix epoch */
   private String timestamp;

--- a/igor-core/src/main/java/com/netflix/spinnaker/igor/service/BuildOperations.java
+++ b/igor-core/src/main/java/com/netflix/spinnaker/igor/service/BuildOperations.java
@@ -45,7 +45,7 @@ public interface BuildOperations extends BuildService {
    * @param buildNumber The build number
    * @return A Spinnaker representation of a build
    */
-  GenericBuild getGenericBuild(String job, int buildNumber);
+  GenericBuild getGenericBuild(String job, long buildNumber);
 
   /**
    * Trigger a build of a given job on the build service host
@@ -54,7 +54,7 @@ public interface BuildOperations extends BuildService {
    * @param queryParameters A key-value map of parameters to be injected into the build
    * @return An id identifying the build; preferably the build number of the build
    */
-  int triggerBuildWithParameters(String job, Map<String, String> queryParameters);
+  long triggerBuildWithParameters(String job, Map<String, String> queryParameters);
 
   /**
    * Returns all/relevant builds for the given job.
@@ -71,13 +71,13 @@ public interface BuildOperations extends BuildService {
    * @param buildNumber The build number
    * @param updatedBuild The updated details for the build
    */
-  default void updateBuild(String jobName, Integer buildNumber, UpdatedBuild updatedBuild) {
+  default void updateBuild(String jobName, Long buildNumber, UpdatedBuild updatedBuild) {
     // not supported by default
   }
 
   JobConfiguration getJobConfig(String jobName);
 
-  default Object queuedBuild(String master, int item) {
+  default Object queuedBuild(String master, long item) {
     throw new UnsupportedOperationException(
         String.format("Queued builds are not supported for build service %s", master));
   }

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisBuildMonitor.java
@@ -131,7 +131,7 @@ public class TravisBuildMonitor
     delta.getItems().forEach(item -> processBuild(sendEvents, master, travisService, item));
 
     // Find id of processed builds
-    Set<Integer> processedBuilds =
+    Set<Long> processedBuilds =
         delta.getItems().stream()
             .map(BuildDelta::getBuild)
             .map(V3Build::getId)
@@ -140,7 +140,7 @@ public class TravisBuildMonitor
     // Check for tracked builds that have fallen out of the tracking window (can happen for long
     // running Travis jobs)
     buildCache.getTrackedBuilds(master).stream()
-        .mapToInt(build -> Integer.parseInt(build.get("buildId")))
+        .mapToLong(build -> Long.parseLong(build.get("buildId")))
         .filter(id -> !processedBuilds.contains(id))
         .mapToObj(travisService::getV3Build)
         .filter(
@@ -178,7 +178,7 @@ public class TravisBuildMonitor
 
   private Stream<? extends BuildDelta> createBuildDelta(
       String master, TravisService travisService, V3Build v3Build) {
-    int lastBuild =
+    long lastBuild =
         buildCache.getLastBuild(master, v3Build.branchedRepoSlug(), v3Build.getState().isRunning());
     return Stream.of(v3Build)
         .filter(build -> !build.spinnakerTriggered())
@@ -311,7 +311,7 @@ public class TravisBuildMonitor
     private final V3Build build;
     private final GenericBuild genericBuild;
     private final String travisBaseUrl;
-    private final int currentBuildNum;
-    private final int previousBuildNum;
+    private final long currentBuildNum;
+    private final long previousBuildNum;
   }
 }

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/TravisCache.java
@@ -48,7 +48,7 @@ public class TravisCache {
     this.igorConfigurationProperties = igorConfigurationProperties;
   }
 
-  public Map<String, Integer> getQueuedJob(String master, int queueNumber) {
+  public Map<String, Long> getQueuedJob(String master, long queueNumber) {
     Map<String, String> result =
         redisClientDelegate.withCommandsClient(
             c -> {
@@ -59,32 +59,32 @@ public class TravisCache {
       return Collections.emptyMap();
     }
 
-    Map<String, Integer> converted = new HashMap<>();
-    converted.put("requestId", Integer.parseInt(result.get("requestId")));
-    converted.put("repositoryId", Integer.parseInt(result.get("repositoryId")));
+    Map<String, Long> converted = new HashMap<>();
+    converted.put("requestId", Long.parseLong(result.get("requestId")));
+    converted.put("repositoryId", Long.parseLong(result.get("repositoryId")));
 
     return converted;
   }
 
-  public int setQueuedJob(String master, int repositoryId, int requestId) {
+  public long setQueuedJob(String master, long repositoryId, long requestId) {
     String key = makeKey(QUEUE_TYPE, master, requestId);
     redisClientDelegate.withCommandsClient(
         c -> {
-          c.hset(key, "requestId", Integer.toString(requestId));
-          c.hset(key, "repositoryId", Integer.toString(repositoryId));
+          c.hset(key, "requestId", Long.toString(requestId));
+          c.hset(key, "repositoryId", Long.toString(repositoryId));
           c.expire(key, QUEUE_EXPIRE_SECONDS);
         });
     return requestId;
   }
 
-  public void removeQuededJob(String master, int queueId) {
+  public void removeQuededJob(String master, long queueId) {
     redisClientDelegate.withCommandsClient(
         c -> {
           c.del(makeKey(QUEUE_TYPE, master, queueId));
         });
   }
 
-  public void setJobLog(String master, int jobId, String log) {
+  public void setJobLog(String master, long jobId, String log) {
     String key = makeKey(LOG_TYPE, master, jobId);
     redisClientDelegate.withCommandsClient(
         c -> {
@@ -92,7 +92,7 @@ public class TravisCache {
         });
   }
 
-  public String getJobLog(String master, int jobId) {
+  public String getJobLog(String master, long jobId) {
     String key = makeKey(LOG_TYPE, master, jobId);
     return redisClientDelegate.withCommandsClient(
         c -> {
@@ -100,7 +100,7 @@ public class TravisCache {
         });
   }
 
-  private String makeKey(String type, String master, int id) {
+  private String makeKey(String type, String master, long id) {
     return baseKey() + ":" + type + ":" + master + ":" + id;
   }
 

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/TravisClient.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/TravisClient.java
@@ -57,7 +57,7 @@ public interface TravisClient {
   public abstract Builds builds(
       @Header("Authorization") String accessToken,
       @Query("slug") String repoSlug,
-      @Query("number") int buildNumber);
+      @Query("number") long buildNumber);
 
   @POST("/repo/{repoSlug}/requests")
   @Headers("Travis-API-Version: 3")
@@ -79,14 +79,14 @@ public interface TravisClient {
   @Headers("Travis-API-Version: 3")
   public abstract V3Build v3build(
       @Header("Authorization") String accessToken,
-      @Path("build_id") int buildId,
+      @Path("build_id") long buildId,
       @Query("include") String include);
 
   @GET("/repo/{repository_id}/builds")
   @Headers("Travis-API-Version: 3")
   public abstract V3Builds builds(
       @Header("Authorization") String accessToken,
-      @Path("repository_id") int repositoryId,
+      @Path("repository_id") long repositoryId,
       @Query("limit") int limit,
       @Query("include") String include);
 
@@ -130,8 +130,8 @@ public interface TravisClient {
   @Headers("Travis-API-Version: 3")
   public abstract Request request(
       @Header("Authorization") String accessToken,
-      @Path("repository_id") int repositoryId,
-      @Path("request_id") int requestId);
+      @Path("repository_id") long repositoryId,
+      @Path("request_id") long requestId);
 
   @GET("/jobs")
   @Headers("Travis-API-Version: 3")

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/Request.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/Request.java
@@ -29,5 +29,5 @@ public class Request {
 
   private List<V3Build> builds;
 
-  private int id;
+  private long id;
 }

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Build.java
@@ -41,7 +41,7 @@ public class V3Build {
   private V3Branch branch;
 
   @JsonProperty("commit_id")
-  private int commitId;
+  private long commitId;
 
   private V3Commit commit;
 
@@ -50,14 +50,14 @@ public class V3Build {
   @JsonProperty("event_type")
   private String eventType;
 
-  @EqualsAndHashCode.Include private int id;
+  @EqualsAndHashCode.Include private long id;
 
   private V3Repository repository;
 
   @JsonProperty("repository_id")
-  private int repositoryId;
+  private long repositoryId;
 
-  private int number;
+  private long number;
 
   @EqualsAndHashCode.Include private TravisBuildState state;
 

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Log.java
@@ -76,7 +76,7 @@ public class V3Log {
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class V3LogPart {
     private String content;
-    private Integer number;
+    private Long number;
     private boolean isFinal;
 
     public String getContent() {
@@ -87,11 +87,11 @@ public class V3Log {
       this.content = content;
     }
 
-    public Integer getNumber() {
+    public Long getNumber() {
       return number;
     }
 
-    public void setNumber(Integer number) {
+    public void setNumber(Long number) {
       this.number = number;
     }
 

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Repository.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/client/model/v3/V3Repository.java
@@ -26,7 +26,7 @@ import lombok.Data;
 @XmlRootElement(name = "repository")
 public class V3Repository {
 
-  private int id;
+  private long id;
 
   private String name;
 

--- a/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisBuildConverter.java
+++ b/igor-monitor-travis/src/main/java/com/netflix/spinnaker/igor/travis/service/TravisBuildConverter.java
@@ -53,7 +53,7 @@ public class TravisBuildConverter {
     return genericBuild;
   }
 
-  public static String url(String repoSlug, String baseUrl, int id) {
+  public static String url(String repoSlug, String baseUrl, long id) {
     return baseUrl + "/" + repoSlug + "/builds/" + id;
   }
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -76,7 +76,7 @@ class BuildController {
   }
 
   @Nullable
-  private GenericBuild jobStatus(BuildOperations buildService, String master, String job, Integer buildNumber) {
+  private GenericBuild jobStatus(BuildOperations buildService, String master, String job, Long buildNumber) {
     GenericBuild build = buildService.getGenericBuild(job, buildNumber)
     if (!build)
       return null

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -100,7 +100,7 @@ class BuildController {
   @RequestMapping(value = '/builds/status/{buildNumber}/{master:.+}/**')
   @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'READ')")
   GenericBuild getJobStatus(@PathVariable String master, @PathVariable
-    Integer buildNumber, HttpServletRequest request) {
+    Long buildNumber, HttpServletRequest request) {
     def job = ((String) request.getAttribute(
       HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).split('/').drop(5).join('/')
     def buildService = getBuildService(master)
@@ -111,7 +111,7 @@ class BuildController {
   @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'READ')")
   GenericBuild getJobStatus(
     @PathVariable String master,
-    @PathVariable Integer buildNumber,
+    @PathVariable Long buildNumber,
     @RequestParam("job") String job) {
     def buildService = getBuildService(master)
     return jobStatus(buildService, master, job, buildNumber)
@@ -120,7 +120,7 @@ class BuildController {
   @RequestMapping(value = '/builds/artifacts/{buildNumber}/{master:.+}/**')
   @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'READ')")
   List<Artifact> getBuildResults(@PathVariable String master, @PathVariable
-    Integer buildNumber, @Query("propertyFile") String propertyFile, HttpServletRequest request) {
+    Long buildNumber, @Query("propertyFile") String propertyFile, HttpServletRequest request) {
     def job = ((String) request.getAttribute(
       HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).split('/').drop(5).join('/')
     def buildService = getBuildService(master)
@@ -136,7 +136,7 @@ class BuildController {
   @RequestMapping(value = '/builds/artifacts/{buildNumber}/{master}')
   @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'READ')")
   List<Artifact> getBuildResults(@PathVariable String master, @PathVariable
-    Integer buildNumber, @RequestParam("job") String job ,@Query("propertyFile") String propertyFile) {
+    Long buildNumber, @RequestParam("job") String job ,@Query("propertyFile") String propertyFile) {
     def buildService = getBuildService(master)
     GenericBuild build = jobStatus(buildService, master, job, buildNumber)
     if (build && buildService instanceof BuildProperties && artifactExtractor != null) {
@@ -148,7 +148,7 @@ class BuildController {
 
   @RequestMapping(value = '/builds/queue/{master}/{item}')
   @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'READ')")
-  Object getQueueLocation(@PathVariable String master, @PathVariable int item) {
+  Object getQueueLocation(@PathVariable String master, @PathVariable long item) {
     def buildService = getBuildService(master)
     return buildService.queuedBuild(master, item)
   }
@@ -168,7 +168,7 @@ class BuildController {
     @PathVariable("name") String master,
     @PathVariable String jobName,
     @PathVariable String queuedBuild,
-    @PathVariable Integer buildNumber) {
+    @PathVariable Long buildNumber) {
     stopJob(master, buildNumber, jobName, queuedBuild)
     "true"
   }
@@ -179,14 +179,14 @@ class BuildController {
     @PathVariable String master,
     @RequestParam String jobName,
     @PathVariable String queuedBuild,
-    @PathVariable Integer buildNumber) {
+    @PathVariable Long buildNumber) {
 
     stopJob(master, buildNumber, jobName, queuedBuild)
     "true"
   }
 
 
-  void stopJob(String master, int buildNumber, String jobName, String queuedBuild) {
+  void stopJob(String master, long buildNumber, String jobName, String queuedBuild) {
     def buildService = getBuildService(master)
     if (buildService instanceof JenkinsService) {
       // Jobs that haven't been started yet won't have a buildNumber
@@ -216,7 +216,7 @@ class BuildController {
   @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'WRITE')")
   void update(
     @PathVariable("name") String master,
-    @PathVariable("buildNumber") Integer buildNumber,
+    @PathVariable("buildNumber") Long buildNumber,
     @RequestBody UpdatedBuild updatedBuild,
     HttpServletRequest request
   ) {
@@ -336,7 +336,7 @@ class BuildController {
   @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'READ')")
   Map<String, Object> getProperties(
     @PathVariable String master,
-    @PathVariable Integer buildNumber, @PathVariable
+    @PathVariable Long buildNumber, @PathVariable
       String fileName, HttpServletRequest request) {
     def job = ((String) request.getAttribute(
       HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).split('/').drop(6).join('/')
@@ -354,7 +354,7 @@ class BuildController {
   @PreAuthorize("hasPermission(#master, 'BUILD_SERVICE', 'READ')")
   Map<String, Object> getProperties(
     @PathVariable String master,
-    @PathVariable Integer buildNumber, @PathVariable
+    @PathVariable Long buildNumber, @PathVariable
       String fileName, @RequestParam("job") String job) {
     def buildService = getBuildService(master)
     if (buildService instanceof BuildProperties) {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/exceptions/ArtifactNotFoundException.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/exceptions/ArtifactNotFoundException.java
@@ -23,8 +23,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(NOT_FOUND)
 public class ArtifactNotFoundException extends NotFoundException {
-  public ArtifactNotFoundException(
-      String master, String job, Integer buildNumber, String fileName) {
+  public ArtifactNotFoundException(String master, String job, Long buildNumber, String fileName) {
     super(
         String.format(
             "Could not find build artifact matching requested filename '%s' on '%s/%s' build %s",

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/GitlabCiBuildMonitor.java
@@ -130,7 +130,7 @@ public class GitlabCiBuildMonitor
                   continue;
                 }
                 String pipelineIdCacheKey = String.valueOf(project.getId());
-                int cachedBuildId = buildCache.getLastBuild(master, pipelineIdCacheKey, false);
+                long cachedBuildId = buildCache.getLastBuild(master, pipelineIdCacheKey, false);
                 // GitLab CI pipelineIds increment; Determine if it is new using the ID
                 if (pipeline.getId() > cachedBuildId) {
                   updatedBuilds.incrementAndGet();

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.java
@@ -45,12 +45,12 @@ public interface GitlabCiClient {
   Pipeline getPipeline(@Path("projectId") String projectId, @Path("pipelineId") long pipelineId);
 
   @GET("/api/v4/projects/{projectId}/pipelines/{pipelineId}/jobs")
-  List<Job> getJobs(@Path("projectId") String projectId, @Path("pipelineId") int pipelineId);
+  List<Job> getJobs(@Path("projectId") String projectId, @Path("pipelineId") long pipelineId);
 
   @GET("/api/v4/projects/{projectId}/jobs/{jobId}/trace")
-  Response getJobLog(@Path("projectId") String projectId, @Path("jobId") int jobId);
+  Response getJobLog(@Path("projectId") String projectId, @Path("jobId") long jobId);
 
   // GitLabCI pipelines can spawn other child pipelines, which are linked by bridges
   @GET("/api/v4/projects/{projectId}/pipelines/{pipelineId}/bridges")
-  List<Bridge> getBridges(@Path("projectId") String projectId, @Path("pipelineId") int pipelineId);
+  List<Bridge> getBridges(@Path("projectId") String projectId, @Path("pipelineId") long pipelineId);
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.java
@@ -78,7 +78,7 @@ public class GitlabCiService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  public GenericBuild getGenericBuild(String projectId, int pipelineId) {
+  public GenericBuild getGenericBuild(String projectId, long pipelineId) {
     Project project = client.getProject(projectId);
     if (project == null) {
       log.error("Could not find Gitlab CI Project with projectId={}", projectId);
@@ -103,7 +103,7 @@ public class GitlabCiService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  public int triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
+  public long triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
     throw new UnsupportedOperationException();
   }
 
@@ -131,7 +131,7 @@ public class GitlabCiService implements BuildOperations, BuildProperties {
   }
 
   // Gets a pipeline's jobs along with any child pipeline jobs (bridges)
-  private List<Job> getJobsWithBridges(String projectId, Integer pipelineId) {
+  private List<Job> getJobsWithBridges(String projectId, Long pipelineId) {
     List<Job> jobs = this.client.getJobs(projectId, pipelineId);
     List<Bridge> bridges = this.client.getBridges(projectId, pipelineId);
     bridges.parallelStream()
@@ -150,7 +150,7 @@ public class GitlabCiService implements BuildOperations, BuildProperties {
     return jobs;
   }
 
-  private Map<String, Object> getPropertyFileFromLog(String projectId, Integer pipelineId) {
+  private Map<String, Object> getPropertyFileFromLog(String projectId, Long pipelineId) {
     Map<String, Object> properties = new HashMap<>();
     return retrySupport.retry(
         () -> {

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -48,14 +48,14 @@ interface JenkinsClient {
     BuildDependencies getDependencies(@EncodedPath('jobName') String jobName)
 
     @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(totalCount)]&tree=actions[failCount,skipCount,totalCount,urlName],duration,number,timestamp,result,building,url,fullDisplayName,artifacts[displayPath,fileName,relativePath]')
-    Build getBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
+    Build getBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Long buildNumber)
 
     // The location of the SCM details in the build xml changed in version 4.0.0 of the jenkins-git plugin; see the
     // header comment in com.netflix.spinnaker.igor.jenkins.client.model.ScmDetails for more information.
     // The exclude and tree parameters to this call must continue to support both formats to remain compatible with
     // all versions of the plugin.
     @GET('/job/{jobName}/{buildNumber}/api/xml?exclude=/*/action[not(build|lastBuiltRevision)]&tree=actions[remoteUrls,lastBuiltRevision[branch[name,SHA1]],build[revision[branch[name,SHA1]]]]')
-    ScmDetails getGitDetails(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber)
+    ScmDetails getGitDetails(@EncodedPath('jobName') String jobName, @Path('buildNumber') Long buildNumber)
 
     @GET('/job/{jobName}/lastCompletedBuild/api/xml')
     Build getLatestBuild(@EncodedPath('jobName') String jobName)
@@ -67,7 +67,7 @@ interface JenkinsClient {
     Response getBuildOutput(@EncodedPath('jobName') String jobName, @Path('buildNumber') String buildNumber)
 
     @GET('/queue/item/{itemNumber}/api/xml')
-    QueuedJob getQueuedItem(@Path('itemNumber') Integer item)
+    QueuedJob getQueuedItem(@Path('itemNumber') Long item)
 
     @POST('/job/{jobName}/build')
     Response build(@EncodedPath('jobName') String jobName, @Body String emptyRequest, @Header("Jenkins-Crumb") String crumb)
@@ -77,10 +77,10 @@ interface JenkinsClient {
 
     @FormUrlEncoded
     @POST('/job/{jobName}/{buildNumber}/submitDescription')
-    Response submitDescription(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber, @Field("description") String description, @Header("Jenkins-Crumb") String crumb)
+    Response submitDescription(@EncodedPath('jobName') String jobName, @Path('buildNumber') Long buildNumber, @Field("description") String description, @Header("Jenkins-Crumb") String crumb)
 
     @POST('/job/{jobName}/{buildNumber}/stop')
-    Response stopRunningBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Integer buildNumber,  @Body String EmptyRequest, @Header("Jenkins-Crumb") String crumb)
+    Response stopRunningBuild(@EncodedPath('jobName') String jobName, @Path('buildNumber') Long buildNumber,  @Body String EmptyRequest, @Header("Jenkins-Crumb") String crumb)
 
     @POST('/queue/cancelItem')
     Response stopQueuedBuild(@Query('id') String queuedBuild, @Body String emptyRequest, @Header("Jenkins-Crumb") String crumb)
@@ -92,7 +92,7 @@ interface JenkinsClient {
     @GET('/job/{jobName}/{buildNumber}/artifact/{fileName}')
     Response getPropertyFile(
         @EncodedPath('jobName') String jobName,
-        @Path('buildNumber') Integer buildNumber, @Path(value = 'fileName', encode = false) String fileName)
+        @Path('buildNumber') Long buildNumber, @Path(value = 'fileName', encode = false) String fileName)
 
     @GET('/crumbIssuer/api/xml')
     Crumb getCrumb()

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/QueuedJob.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/model/QueuedJob.groovy
@@ -26,7 +26,7 @@ class QueuedJob {
     QueuedExecutable executable
 
     @XmlElement(name = 'number')
-    Integer getNumber() {
+    Long getNumber() {
         return executable?.number
     }
 }
@@ -34,5 +34,5 @@ class QueuedJob {
 
 class QueuedExecutable {
     @XmlElement
-    Integer number
+    Long number
 }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
@@ -170,18 +170,18 @@ public class JenkinsService implements BuildOperations, BuildProperties {
     return circuitBreaker.executeSupplier(() -> jenkinsClient.getDependencies(encode(jobName)));
   }
 
-  public Build getBuild(String jobName, Integer buildNumber) {
+  public Build getBuild(String jobName, Long buildNumber) {
     return circuitBreaker.executeSupplier(
         () -> jenkinsClient.getBuild(encode(jobName), buildNumber));
   }
 
   @Override
-  public GenericBuild getGenericBuild(String jobName, int buildNumber) {
+  public GenericBuild getGenericBuild(String jobName, long buildNumber) {
     return getBuild(jobName, buildNumber).genericBuild(jobName);
   }
 
   @Override
-  public int triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
+  public long triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
     Response response = buildWithParameters(job, queryParameters);
     if (response.getStatus() != 201) {
       throw new BuildJobError("Received a non-201 status when submitting job '" + job + "'");
@@ -200,7 +200,7 @@ public class JenkinsService implements BuildOperations, BuildProperties {
                         "Could not find Location header for job '" + job + "'"));
 
     int lastSlash = queuedLocation.lastIndexOf('/');
-    return Integer.parseInt(queuedLocation.substring(lastSlash + 1));
+    return Long.parseLong(queuedLocation.substring(lastSlash + 1));
   }
 
   @Override
@@ -208,7 +208,7 @@ public class JenkinsService implements BuildOperations, BuildProperties {
     return permissions;
   }
 
-  private ScmDetails getGitDetails(String jobName, Integer buildNumber) {
+  private ScmDetails getGitDetails(String jobName, Long buildNumber) {
     return retrySupport.retry(
         () -> {
           try {
@@ -230,7 +230,7 @@ public class JenkinsService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  public QueuedJob queuedBuild(String master, int item) {
+  public QueuedJob queuedBuild(String master, long item) {
     try {
       return circuitBreaker.executeSupplier(() -> jenkinsClient.getQueuedItem(item));
     } catch (SpinnakerHttpException e) {
@@ -253,7 +253,7 @@ public class JenkinsService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  public void updateBuild(String jobName, Integer buildNumber, UpdatedBuild updatedBuild) {
+  public void updateBuild(String jobName, Long buildNumber, UpdatedBuild updatedBuild) {
     if (updatedBuild.getDescription() != null) {
       circuitBreaker.executeRunnable(
           () ->
@@ -298,7 +298,7 @@ public class JenkinsService implements BuildOperations, BuildProperties {
     return map;
   }
 
-  private String getArtifactPathFromBuild(String job, int buildNumber, String fileName) {
+  private String getArtifactPathFromBuild(String job, long buildNumber, String fileName) {
     return retrySupport.retry(
         () ->
             this.getBuild(job, buildNumber).getArtifacts().stream()
@@ -319,7 +319,7 @@ public class JenkinsService implements BuildOperations, BuildProperties {
         false);
   }
 
-  private Response getPropertyFile(String jobName, Integer buildNumber, String fileName) {
+  private Response getPropertyFile(String jobName, Long buildNumber, String fileName) {
     return retrySupport.retry(
         () -> {
           try {
@@ -342,7 +342,7 @@ public class JenkinsService implements BuildOperations, BuildProperties {
         false);
   }
 
-  public Response stopRunningBuild(String jobName, Integer buildNumber) {
+  public Response stopRunningBuild(String jobName, Long buildNumber) {
     return circuitBreaker.executeSupplier(
         () -> jenkinsClient.stopRunningBuild(encode(jobName), buildNumber, "", getCrumb()));
   }

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerCache.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerCache.java
@@ -84,7 +84,7 @@ public class WerckerCache {
         });
   }
 
-  public String getRunID(String master, String pipeline, final int buildNumber) {
+  public String getRunID(String master, String pipeline, final long buildNumber) {
     String key = makeKey(master, pipeline) + ":runs";
     final Map<String, String> existing =
         redisClientDelegate.withCommandsClient(
@@ -94,7 +94,7 @@ public class WerckerCache {
               }
               return c.hgetAll(key);
             });
-    String build = Integer.toString(buildNumber);
+    String build = Long.toString(buildNumber);
     for (Entry<String, String> entry : existing.entrySet()) {
       if (entry.getValue().equals(build)) {
         return entry.getKey();
@@ -112,7 +112,7 @@ public class WerckerCache {
    * @param runs
    * @return a map containing the generated build numbers for each run created, keyed by run id
    */
-  public Map<String, Integer> updateBuildNumbers(
+  public Map<String, Long> updateBuildNumbers(
       String master, String appAndPipelineName, List<Run> runs) {
     String key = makeKey(master, appAndPipelineName) + ":runs";
     final Map<String, String> existing =
@@ -130,22 +130,22 @@ public class WerckerCache {
               .filter(run -> !existing.containsKey(run.getId()))
               .collect(Collectors.toList());
     }
-    Map<String, Integer> runIdToBuildNumber = new HashMap<>();
+    Map<String, Long> runIdToBuildNumber = new HashMap<>();
     int startNumber = (existing == null || existing.size() == 0) ? 0 : existing.size();
     newRuns.sort(startedAtComparator);
     for (int i = 0; i < newRuns.size(); i++) {
       int buildNum = startNumber + i;
-      setBuildNumber(master, appAndPipelineName, newRuns.get(i).getId(), buildNum);
-      runIdToBuildNumber.put(newRuns.get(i).getId(), buildNum);
+      setBuildNumber(master, appAndPipelineName, newRuns.get(i).getId(), (long) buildNum);
+      runIdToBuildNumber.put(newRuns.get(i).getId(), (long) buildNum);
     }
     return runIdToBuildNumber;
   }
 
-  public void setBuildNumber(String master, String pipeline, String runID, int number) {
+  public void setBuildNumber(String master, String pipeline, String runID, long number) {
     String key = makeKey(master, pipeline) + ":runs";
     redisClientDelegate.withCommandsClient(
         c -> {
-          c.hset(key, runID, Integer.toString(number));
+          c.hset(key, runID, Long.toString(number));
         });
   }
 

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerService.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/wercker/WerckerService.groovy
@@ -86,7 +86,7 @@ class WerckerService implements BuildOperations {
     }
 
     @Override
-    GenericBuild getGenericBuild(final String job, final int buildNumber) {
+    GenericBuild getGenericBuild(final String job, final long buildNumber) {
         QualifiedPipelineName qPipeline = QualifiedPipelineName.of(job)
         String runId = cache.getRunID(groupKey, job, buildNumber)
         if (runId == null) {
@@ -128,7 +128,7 @@ class WerckerService implements BuildOperations {
         return Result.UNSTABLE
     }
 
-    Response stopRunningBuild (String appAndPipelineName, Integer buildNumber){
+    Response stopRunningBuild (String appAndPipelineName, Long buildNumber){
         String runId = cache.getRunID(groupKey, appAndPipelineName, buildNumber)
         if (runId == null) {
             log.warn("Could not cancel build number {} for job {} - no matching run ID!",
@@ -140,7 +140,7 @@ class WerckerService implements BuildOperations {
     }
 
     @Override
-    int triggerBuildWithParameters(final String appAndPipelineName, final Map<String, String> queryParameters) {
+    long triggerBuildWithParameters(final String appAndPipelineName, final Map<String, String> queryParameters) {
         QualifiedPipelineName qPipeline = QualifiedPipelineName.of(appAndPipelineName)
         String org = qPipeline.ownerName
         String appName = qPipeline.appName
@@ -163,7 +163,7 @@ class WerckerService implements BuildOperations {
 
                 //Create an entry in the WerckerCache for this new run. This will also generate
                 //an integer build number for the run
-                Map<String, Integer> runIdBuildNumbers = cache.updateBuildNumbers(
+                Map<String, Long> runIdBuildNumbers = cache.updateBuildNumbers(
                         master, appAndPipelineName, Collections.singletonList(run))
 
                 log.info("Triggered run {} at URL {} with build number {}",

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseCache.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/ConcourseCache.java
@@ -50,18 +50,18 @@ public class ConcourseCache {
   }
 
   public boolean getEventPosted(
-      ConcourseProperties.Host host, Job job, Long cursor, Integer buildNumber) {
+      ConcourseProperties.Host host, Job job, Long cursor, Long buildNumber) {
     String key = makeKey(host, job) + ":" + POLL_STAMP + ":" + cursor;
     return redisClientDelegate.withCommandsClient(
-        c -> c.hget(key, Integer.toString(buildNumber)) != null);
+        c -> c.hget(key, Long.toString(buildNumber)) != null);
   }
 
   public void setEventPosted(
-      ConcourseProperties.Host host, Job job, Long cursor, Integer buildNumber) {
+      ConcourseProperties.Host host, Job job, Long cursor, Long buildNumber) {
     String key = makeKey(host, job) + ":" + POLL_STAMP + ":" + cursor;
     redisClientDelegate.withCommandsClient(
         c -> {
-          c.hset(key, Integer.toString(buildNumber), "POSTED");
+          c.hset(key, Long.toString(buildNumber), "POSTED");
         });
   }
 

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/Build.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/client/model/Build.java
@@ -36,8 +36,8 @@ public class Build implements Comparable<Build> {
     return new BigDecimal(name);
   }
 
-  public int getNumber() {
-    return getDecimalNumber().intValue();
+  public long getNumber() {
+    return getDecimalNumber().longValue();
   }
 
   public boolean isSuccessful() {

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/concourse/service/ConcourseService.java
@@ -145,7 +145,7 @@ public class ConcourseService implements BuildOperations, BuildProperties {
 
   @Nullable
   @Override
-  public GenericBuild getGenericBuild(String jobPath, int buildNumber) {
+  public GenericBuild getGenericBuild(String jobPath, long buildNumber) {
     return getBuilds(jobPath, null).stream()
         .filter(build -> build.getNumber() == buildNumber)
         .sorted()
@@ -322,7 +322,7 @@ public class ConcourseService implements BuildOperations, BuildProperties {
   }
 
   @Override
-  public int triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
+  public long triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
     throw new UnsupportedOperationException("Triggering concourse builds not supported");
   }
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -73,7 +73,7 @@ class BuildControllerSpec extends Specification {
   def JENKINS_SERVICE = 'JENKINS_SERVICE'
   def TRAVIS_SERVICE = 'TRAVIS_SERVICE'
   def HTTP_201 = 201
-  def BUILD_NUMBER = 123
+  def BUILD_NUMBER = 123456789012
   def BUILD_ID = 654321
   def QUEUED_JOB_NUMBER = 123456
   def JOB_NAME = "job/name/can/have/slashes"

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerSpec.groovy
@@ -74,8 +74,8 @@ class BuildControllerSpec extends Specification {
   def TRAVIS_SERVICE = 'TRAVIS_SERVICE'
   def HTTP_201 = 201
   def BUILD_NUMBER = 123456789012
-  def BUILD_ID = 654321
-  def QUEUED_JOB_NUMBER = 123456
+  def BUILD_ID = 654321098765
+  def QUEUED_JOB_NUMBER = 123456789012
   def JOB_NAME = "job/name/can/have/slashes"
   def SIMPLE_JOB_NAME = "simpleJobName"
   def PENDING_JOB_NAME = "pendingjob"


### PR DESCRIPTION
This PR is to resolve [#7002](https://github.com/spinnaker/spinnaker/issues/7002).

Cloudbees has started using Long for HA enabled Queues. To resolve this, Starting from the getQueue code, I have change the expected type from Int to Long. I followed the trail through until all changes needed were made.
