### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY igor-web/build/install/igor /opt/igor
 RUN mkdir -p /opt/igor/plugins && chown -R spinnaker:nogroup /opt/igor/plugins


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#9 102.5 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
#9 102.6 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#9 102.9 Segmentation fault (core dumped)
#9 103.0 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#9 103.3 Segmentation fault (core dumped)
#9 103.3 dpkg: error processing package libc-bin (--configure):
#9 103.3  installed libc-bin package post-installation script subprocess returned error exit status 139
```
from https://github.com/spinnaker/igor/actions/runs/13294119104/job/37121773617?pr=1309

suggestion from https://stackoverflow.com/a/78107622

similar to https://github.com/spinnaker/orca/pull/4834