### PR TITLE
refactor(retrofit1): make sure Retrofit2EncodeCorrectionInterceptor is not included in the retrofit1 clients

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DockerRegistryConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/DockerRegistryConfig.groovy
@@ -58,7 +58,7 @@ class DockerRegistryConfig {
 
         new RestAdapter.Builder()
                 .setEndpoint(Endpoints.newFixedEndpoint(address))
-                .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("clouddriver", address))))
+                .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("clouddriver", address), true)))
                 .setLogLevel(retrofitLogLevel)
                 .setConverter(new JacksonConverter(objectMapper))
                 .setLog(new Slf4jRetrofitLogger(ClouddriverService))

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/EchoConfig.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/EchoConfig.groovy
@@ -52,7 +52,7 @@ class EchoConfig {
 
         new RestAdapter.Builder()
             .setEndpoint(Endpoints.newFixedEndpoint(address))
-            .setClient(new Ok3Client(okHttpClientProvider.getClient(new DefaultServiceEndpoint("echo", address))))
+            .setClient(new Ok3Client(okHttpClientProvider.getClient(new DefaultServiceEndpoint("echo", address), true)))
             .setConverter(new JacksonConverter(objectMapper))
             .setLogLevel(retrofitLogLevel)
             .setLog(new Slf4jRetrofitLogger(EchoService))

--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/PluginMonitorConfig.java
@@ -66,7 +66,7 @@ public class PluginMonitorConfig {
             .setEndpoint(Endpoints.newFixedEndpoint(address))
             .setClient(
                 new Ok3Client(
-                    clientProvider.getClient(new DefaultServiceEndpoint("front50", address))))
+                    clientProvider.getClient(new DefaultServiceEndpoint("front50", address), true)))
             .setLogLevel(retrofitLogLevel)
             .setLog(new Slf4jRetrofitLogger(Front50Service.class))
             .setConverter(new JacksonConverter(objectMapper))

--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/KeelConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/KeelConfig.java
@@ -50,7 +50,7 @@ public class KeelConfig {
         .setClient(
             new Ok3Client(
                 clientProvider.getClient(
-                    new DefaultServiceEndpoint("keel", keelEndpoint.getUrl()))))
+                    new DefaultServiceEndpoint("keel", keelEndpoint.getUrl()), true)))
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(KeelService.class))
         .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())


### PR DESCRIPTION
Along with https://github.com/spinnaker/kork/pull/1233, this PR fixes any issues arising due to the addition of Retrofit2EncodeCorrectionInterceptor to the OkHttpClient used for retrofit1 client. 